### PR TITLE
ValueType is a ref type and as such cannot be set in an attribute

### DIFF
--- a/docs/pages/modeling/model-components/attributes/select-filter.rst
+++ b/docs/pages/modeling/model-components/attributes/select-filter.rst
@@ -64,6 +64,7 @@ Properties
         
         This allows for querying against properties that are one level away from the current object.
 
-    :csharp:`public ValueType StaticPropertyValue { get; set; }`
-        A constant value that the foreign property will be filtered against.
+    :csharp:`public string StaticPropertyValue { get; set; }`
+        A constant value that the foreign property will be filtered against. 
+        This string must be parsable into the foreign property's type to have any effect.
         If this is set, :csharp:`LocalPropertyName` will be ignored.

--- a/src/IntelliTect.Coalesce.Knockout/Helpers/Knockout.cs
+++ b/src/IntelliTect.Coalesce.Knockout/Helpers/Knockout.cs
@@ -418,18 +418,18 @@ namespace IntelliTect.Coalesce.Knockout.Helpers
 
             if (propertyModel.HasAttribute<SelectFilterAttribute>())
             {
-                var foreignPropName = propertyModel.GetAttributeValue<SelectFilterAttribute>(nameof(SelectFilterAttribute.ForeignPropertyName)).ToString();
-                var localValue = propertyModel.GetAttributeValue<SelectFilterAttribute>(nameof(SelectFilterAttribute.StaticPropertyValue));
+                var foreignPropName = propertyModel.GetAttributeValue<SelectFilterAttribute>(a => a.ForeignPropertyName);
+                var localValue = propertyModel.GetAttributeValue<SelectFilterAttribute>(a => a.StaticPropertyValue);
 
                 var foreignProp = propertyModel.Object.PropertyByName(foreignPropName);
                 if (localValue != null)
                 {
-                    filterString = $"?filter.{foreignProp.JsVariable}={localValue}";
+                    filterString = $"?filter.{foreignProp.JsVariable}={System.Net.WebUtility.UrlEncode(localValue)}";
                 }
                 else
                 {
-                    var localPropName = propertyModel.GetAttributeValue<SelectFilterAttribute>(nameof(SelectFilterAttribute.LocalPropertyName));
-                    var localPropObjName = propertyModel.GetAttributeValue<SelectFilterAttribute>(nameof(SelectFilterAttribute.LocalPropertyObjectName));
+                    var localPropName = propertyModel.GetAttributeValue<SelectFilterAttribute>(a => a.LocalPropertyName);
+                    var localPropObjName = propertyModel.GetAttributeValue<SelectFilterAttribute>(a => a.LocalPropertyObjectName);
 
 
                     if (localPropObjName != null)

--- a/src/IntelliTect.Coalesce/DataAnnotations/SelectFilterAttribute.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/SelectFilterAttribute.cs
@@ -33,6 +33,6 @@ namespace IntelliTect.Coalesce.DataAnnotations
         /// 
         /// If this is set, LocalPropertyName will be ignored.
         /// </summary>
-        public ValueType StaticPropertyValue { get; set; }
+        public string StaticPropertyValue { get; set; }
     }
 }


### PR DESCRIPTION
This is not a breaking change because no one could have possibly used StaticPropertyValue anyway.