### PR TITLE
Wire up HttpContext.RequestAborted to the SaveChanges cancellation token.

### DIFF
--- a/src/IntelliTect.Coalesce.Tests/Api/Behaviors/StandardBehaviorsTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Api/Behaviors/StandardBehaviorsTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using IntelliTect.Coalesce.Api;
+using IntelliTect.Coalesce.Tests.Fixtures;
+using IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext;
+using Xunit;
+
+namespace IntelliTect.Coalesce.Tests.Api.Behaviors
+{
+    public class StandardBehaviorsTests : TestDbContextTests<AccessibleTokenContext>
+    {
+        public StandardBehaviorsTests()
+        {
+            CaseBehavior = Behavior<Case>();
+        }
+
+        public StandardBehaviors<Case, AccessibleTokenContext> CaseBehavior { get; }
+
+        private StandardBehaviors<T, AccessibleTokenContext> Behavior<T>()
+            where T : class, new()
+        {
+            return new StandardBehaviors<T, AccessibleTokenContext>(CrudContext);
+        }
+
+        [Fact]
+        [Description("https://github.com/IntelliTect/Coalesce/issues/59")]
+        public async Task SaveChanges_Cancellable()
+        {
+            CrudContext = new CrudContext<AccessibleTokenContext>(Db, new ClaimsPrincipal(), new CancellationToken(true));
+
+            Db.Cancellation = ctx => Assert.True(ctx.IsCancellationRequested);
+
+            StandardBehaviors<Case, AccessibleTokenContext> sut = Behavior<Case>();
+
+            await sut.SaveAsync(new CaseDto(), new StandardDataSource<Case, AccessibleTokenContext>(CrudContext),
+                new DataSourceParameters());
+        }
+
+        [Fact]
+        [Description("https://github.com/IntelliTect/Coalesce/issues/59")]
+        public async Task Delete_Cancellable()
+        {
+
+            CrudContext = new CrudContext<AccessibleTokenContext>(Db, new ClaimsPrincipal(), new CancellationToken(true));
+
+            Db.Cancellation = ctx => Assert.True(ctx.IsCancellationRequested);
+
+            StandardBehaviors<Case, AccessibleTokenContext> sut = Behavior<Case>();
+
+            await sut.DeleteAsync<CaseDto>(42, new StandardDataSource<Case, AccessibleTokenContext>(CrudContext),
+                new DataSourceParameters());
+        }
+    }
+
+    public class AccessibleTokenContext : TestDbContext
+    {
+        public Action<CancellationToken> Cancellation { get; set; }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            Cancellation?.Invoke(cancellationToken);
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/IntelliTect.Coalesce.Tests/Fixtures/TestDbContextFixture.cs
+++ b/src/IntelliTect.Coalesce.Tests/Fixtures/TestDbContextFixture.cs
@@ -1,24 +1,27 @@
 ﻿using IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext;
 using IntelliTect.Coalesce.Tests.Util;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
 
 namespace IntelliTect.Coalesce.Tests.Fixtures
 {
-    public class TestDbContextTests
+    public class TestDbContextTests : TestDbContextTests<TestDbContext>
+    {
+
+    }
+
+    public class TestDbContextTests<TContext> where TContext :  DbContext, new()
     {
         public TestDbContextTests()
         {
-            Db = new TestDbContext();
-            CrudContext = new CrudContext<TestDbContext>(Db, new System.Security.Claims.ClaimsPrincipal())
+            Db = new TContext();
+            CrudContext = new CrudContext<TContext>(Db, new System.Security.Claims.ClaimsPrincipal(), CancellationToken.None)
             {
                 ReflectionRepository = ReflectionRepositoryFactory.Reflection
             };
         }
 
-        public TestDbContext Db { get; }
-        public CrudContext<TestDbContext> CrudContext { get; private set; }
+        public TContext Db { get; }
+        public CrudContext<TContext> CrudContext { get; set; }
     }
 }

--- a/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/CaseDto.cs
+++ b/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/CaseDto.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using IntelliTect.Coalesce.Models;
+
+namespace IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext
+{
+    public class CaseDto : GeneratedDto<Case>
+    {
+        public int? CaseKey { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public DateTimeOffset? OpenedAt { get; set; }
+        public int? AssignedToId { get; set; }
+        public int? ReportedById { get; set; }
+        public byte[] Attachment { get; set; }
+        public string Severity { get; set; }
+        public int? DevTeamAssignedId { get; set; }
+        public TimeSpan? Duration { get; set; }
+
+        /// <summary>
+        ///     Map from the domain object to the properties of the current DTO instance.
+        /// </summary>
+        public override void MapFrom(Case obj, IMappingContext context, IncludeTree tree = null)
+        {
+            if (obj == null) return;
+
+            // Fill the properties of the object.
+
+            CaseKey = obj.CaseKey;
+            Title = obj.Title;
+            Description = obj.Description;
+            OpenedAt = obj.OpenedAt;
+            AssignedToId = obj.AssignedToId;
+            ReportedById = obj.ReportedById;
+            Attachment = obj.Attachment;
+        }
+
+        /// <summary>
+        ///     Map from the current DTO instance to the domain object.
+        /// </summary>
+        public override void MapTo(Case entity, IMappingContext context)
+        {
+            if (OnUpdate(entity, context)) return;
+
+            entity.CaseKey = CaseKey ?? entity.CaseKey;
+            entity.Title = Title;
+            entity.Description = Description;
+            entity.OpenedAt = OpenedAt ?? entity.OpenedAt;
+            entity.AssignedToId = AssignedToId;
+            entity.ReportedById = ReportedById;
+            entity.Attachment = Attachment;
+        }
+    }
+}

--- a/src/IntelliTect.Coalesce/Api/Behaviors/StandardBehaviors.cs
+++ b/src/IntelliTect.Coalesce/Api/Behaviors/StandardBehaviors.cs
@@ -151,7 +151,7 @@ namespace IntelliTect.Coalesce
                 throw new InvalidOperationException("Recieved null from result of BeforeSave. Expected an ItemResult.");
             if (!beforeSave.WasSuccessful) return new ItemResult<TDto>(beforeSave);
 
-            await Db.SaveChangesAsync();
+            await Db.SaveChangesAsync(Context.CancellationToken);
 
             // Pull the object to get any changes.
             var newItemId = ClassViewModel.PrimaryKey.PropertyInfo.GetValue(item);
@@ -341,7 +341,7 @@ namespace IntelliTect.Coalesce
         public virtual Task ExecuteDeleteAsync(T item)
         {
             GetDbSet().Remove(item);
-            return Db.SaveChangesAsync();
+            return Db.SaveChangesAsync(Context.CancellationToken);
         }
 
         /// <summary>

--- a/src/IntelliTect.Coalesce/Api/CrudContext.cs
+++ b/src/IntelliTect.Coalesce/Api/CrudContext.cs
@@ -1,26 +1,22 @@
-﻿using IntelliTect.Coalesce.Models;
-using IntelliTect.Coalesce.TypeDefinition;
+﻿using IntelliTect.Coalesce.TypeDefinition;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Security.Claims;
-using System.Text;
+using System.Threading;
 
 namespace IntelliTect.Coalesce
 {
     public class CrudContext
     {
-        public CrudContext()
-        { }
 
-        public CrudContext(ClaimsPrincipal user)
+        public CrudContext(ClaimsPrincipal user, CancellationToken cancellationToken)
         {
             User = user ?? throw new ArgumentNullException(nameof(user));
+            CancellationToken = cancellationToken;
         }
 
-        public CrudContext(ClaimsPrincipal user, TimeZoneInfo timeZone)
-            : this(user)
+        public CrudContext(ClaimsPrincipal user, TimeZoneInfo timeZone, CancellationToken cancellationToken)
+            : this(user, cancellationToken)
         {
             TimeZone = timeZone ?? throw new ArgumentNullException(nameof(timeZone));
         }
@@ -28,7 +24,9 @@ namespace IntelliTect.Coalesce
         /// <summary>
         /// The user making the request for a CRUD action.
         /// </summary>
-        public ClaimsPrincipal User { get; set; } = null;
+        public ClaimsPrincipal User { get; }
+
+        public CancellationToken CancellationToken { get; }
 
         /// <summary>
         /// The timezone to be used when performing any actions on date inputs that lack time zone information.
@@ -44,14 +42,14 @@ namespace IntelliTect.Coalesce
     public class CrudContext<TContext> : CrudContext
         where TContext : DbContext
     {
-        public CrudContext(TContext dbContext, ClaimsPrincipal user)
-            : base(user)
+        public CrudContext(TContext dbContext, ClaimsPrincipal user, CancellationToken cancellationToken)
+            : base(user, cancellationToken)
         {
             DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public CrudContext(TContext dbContext, ClaimsPrincipal user, TimeZoneInfo timeZone)
-            : base(user, timeZone)
+        public CrudContext(TContext dbContext, ClaimsPrincipal user, TimeZoneInfo timeZone, CancellationToken cancellationToken)
+            : base(user, timeZone, cancellationToken)
         {
             DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }

--- a/src/IntelliTect.Coalesce/Application/CoalesceServiceBuilder.cs
+++ b/src/IntelliTect.Coalesce/Application/CoalesceServiceBuilder.cs
@@ -28,7 +28,8 @@ namespace IntelliTect.Coalesce
             Services.AddScoped(sp => new CrudContext<TContext>(
                 sp.GetRequiredService<TContext>(),
                 sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext.User,
-                sp.GetService<ITimeZoneResolver>()?.GetTimeZoneInfo() ?? TimeZoneInfo.Local
+                sp.GetService<ITimeZoneResolver>()?.GetTimeZoneInfo() ?? TimeZoneInfo.Local,
+                sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext.RequestAborted
             ));
 
             return this;


### PR DESCRIPTION
Wire up the HttpContext.RequestAborted to the EF context's SaveChanges().  Depending on the provider, YMMV (InMemoryDatabase totally ignores the CancellationToken).  Solves #59