### PR TITLE
Update SourceLink to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ src/Coalesce.Web/output.txt
 # Allow everything in our targets directory, which has a folder named "build" which would otherwise get ignored.
 !src/IntelliTect.Coalesce.CodeGeneration/Analysis/MsBuild/Targets/build/
 
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,3 @@ src/Coalesce.Web/output.txt
 # Allow everything in our targets directory, which has a folder named "build" which would otherwise get ignored.
 !src/IntelliTect.Coalesce.CodeGeneration/Analysis/MsBuild/Targets/build/
 
-.vscode

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,6 +30,7 @@
     <!-- SourceLink configuration - don't put the hash in the version number for releases.
     This version is what gets displayed to stdout when the CLI runs. -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsPackable) == 'true'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,6 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsPackable) == 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Also add .vscode files to gitignore
- Fixed build props to add PDBs (with source-linked symbols) to Nugets.
