### PR TITLE
#59 - Support CancellationToken in DataSources

### DIFF
--- a/src/IntelliTect.Coalesce/Api/Controllers/ApiActionFilter.cs
+++ b/src/IntelliTect.Coalesce/Api/Controllers/ApiActionFilter.cs
@@ -59,7 +59,8 @@ namespace IntelliTect.Coalesce.Api.Controllers
                     // The response we send back also doesn't matter because
                     // the client will never see it.
                     context.ExceptionHandled = true;
-                    context.Result = new StatusCodeResult(400);
+                    // 499 is a non-standard code "Client Closed Request" introduced by nginx .
+                    context.Result = new StatusCodeResult(499);
                     return;
                 }
 

--- a/src/IntelliTect.Coalesce/Api/CrudContext.cs
+++ b/src/IntelliTect.Coalesce/Api/CrudContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Security.Claims;
+using System.Threading;
 
 namespace IntelliTect.Coalesce
 {
@@ -19,10 +20,15 @@ namespace IntelliTect.Coalesce
             lazyUser = new Lazy<ClaimsPrincipal?>(userAccessor, true);
         }
 
-        public CrudContext(Func<ClaimsPrincipal?> userAccessor, TimeZoneInfo timeZone)
+        public CrudContext(
+            Func<ClaimsPrincipal?> userAccessor, 
+            TimeZoneInfo timeZone,
+            CancellationToken cancellationToken = default
+        )
             : this(userAccessor)
         {
             TimeZone = timeZone ?? throw new ArgumentNullException(nameof(timeZone));
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -39,6 +45,11 @@ namespace IntelliTect.Coalesce
         /// The ReflectionRepository that will be used to resolve a ClassViewModel for the type handled by the CRUD strategy.
         /// </summary>
         public ReflectionRepository ReflectionRepository { get; set; } = ReflectionRepository.Global;
+
+        /// <summary>
+        /// A <see cref="CancellationToken"/> that can be observed to see if the underlying request has been canceled.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
     }
 
     public class CrudContext<TContext> : CrudContext
@@ -50,8 +61,13 @@ namespace IntelliTect.Coalesce
             DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }
 
-        public CrudContext(TContext dbContext, Func<ClaimsPrincipal?> userAccessor, TimeZoneInfo timeZone)
-            : base(userAccessor, timeZone)
+        public CrudContext(
+            TContext dbContext, 
+            Func<ClaimsPrincipal?> userAccessor, 
+            TimeZoneInfo timeZone,
+            CancellationToken cancellationToken = default
+        )
+            : base(userAccessor, timeZone, cancellationToken)
         {
             DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         }

--- a/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
@@ -60,7 +60,7 @@ namespace IntelliTect.Coalesce
             var canUseAsync = CanEvalQueryAsynchronously(query);
             var projectedQuery = ApplyProjection(query, parameters);
             TDto mappedResult = canUseAsync 
-                ? await projectedQuery.FindItemAsync(id, Context.ReflectionRepository) 
+                ? await projectedQuery.FindItemAsync(id, Context.ReflectionRepository, GetEffectiveCancellationToken(parameters)) 
                 : projectedQuery.FindItem(id, Context.ReflectionRepository);
 
             if (mappedResult == null)
@@ -94,7 +94,7 @@ namespace IntelliTect.Coalesce
 
             var canUseAsync = CanEvalQueryAsynchronously(query);
             var projectedQuery = ApplyProjection(query, parameters);
-            IList<TDto> mappedList = canUseAsync ? await projectedQuery.ToListAsync() : projectedQuery.ToList();
+            IList<TDto> mappedList = canUseAsync ? await projectedQuery.ToListAsync(GetEffectiveCancellationToken(parameters)) : projectedQuery.ToList();
 
             mappedList = TrimListFields(mappedList, parameters);
 
@@ -103,17 +103,17 @@ namespace IntelliTect.Coalesce
 
         public sealed override IncludeTree GetIncludeTree(IQueryable<T> query, IDataSourceParameters parameters)
         {
-            throw new NotSupportedException($"StandardDtoDataSource does not utilize {nameof(IncludeTree)} - tree trimming is performed in {nameof(ApplyProjection)}");
+            throw new NotSupportedException($"ProjectedDtoDataSource does not utilize {nameof(IncludeTree)} - tree trimming is performed in {nameof(ApplyProjection)}");
         }
 
         public sealed override void TransformResults(IReadOnlyList<T> results, IDataSourceParameters parameters)
         {
-            throw new NotSupportedException($"StandardDtoDataSource does not utilize {nameof(TransformResults)} - transformations should be performed in {nameof(ApplyProjection)}");
+            throw new NotSupportedException($"ProjectedDtoDataSource does not utilize {nameof(TransformResults)} - transformations should be performed in {nameof(ApplyProjection)}");
         }
 
         public sealed override Task TransformResultsAsync(IReadOnlyList<T> results, IDataSourceParameters parameters)
         {
-            throw new NotSupportedException($"StandardDtoDataSource does not utilize {nameof(TransformResultsAsync)} - transformations should be performed in {nameof(ApplyProjection)}");
+            throw new NotSupportedException($"ProjectedDtoDataSource does not utilize {nameof(TransformResultsAsync)} - transformations should be performed in {nameof(ApplyProjection)}");
         }
 
         protected void AssertTMatchesTDto<TActual>()

--- a/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
@@ -66,7 +66,7 @@ namespace IntelliTect.Coalesce
         }
 
         /// <summary>
-        /// Allows the cancellation token to be used to cancel running queries.
+        /// Returns the cancellation token to be used to cancel running queries.
         /// Defaults to CancellationToken.None due to poor experience related to https://github.com/dotnet/efcore/issues/19526.
         /// If cancellation based on the current web request is desired, override to use <see cref="CancellationToken"/>.
         /// </summary>

--- a/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
@@ -9,6 +9,8 @@ using IntelliTect.Coalesce.TypeDefinition;
 using IntelliTect.Coalesce.Mapping;
 using IntelliTect.Coalesce.Api;
 using System.Collections.ObjectModel;
+using System.Threading;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace IntelliTect.Coalesce
 {
@@ -38,6 +40,11 @@ namespace IntelliTect.Coalesce
         /// </summary>
         public int MaxPageSize { get; set; } = 10_000;
 
+        /// <summary>
+        /// A <see cref="CancellationToken"/> that can be observed to see if the underlying request has been canceled.
+        /// </summary>
+        public CancellationToken CancellationToken => Context.CancellationToken;
+
         static StandardDataSource()
         {
             // Fixes EF Core query caching issues: https://dzone.com/articles/investigating-a-memory-leak-in-entity-framework-co
@@ -55,9 +62,17 @@ namespace IntelliTect.Coalesce
         /// <param name="query"></param>
         protected virtual bool CanEvalQueryAsynchronously(IQueryable<T> query)
         {
-            // Async disabled because of https://github.com/aspnet/EntityFrameworkCore/issues/9038.
-            // Renable once microsoft releases the fix and we upgrade our references.
-            return false; // query.Provider is IAsyncQueryProvider;
+            return query.Provider is IAsyncQueryProvider;
+        }
+
+        /// <summary>
+        /// Allows the cancellation token to be used to cancel running queries.
+        /// Defaults to CancellationToken.None due to poor experience related to https://github.com/dotnet/efcore/issues/19526.
+        /// If cancellation based on the current web request is desired, override to use <see cref="CancellationToken"/>.
+        /// </summary>
+        protected virtual CancellationToken GetEffectiveCancellationToken(IDataSourceParameters parameters)
+        {
+            return CancellationToken.None;
         }
 
         /// <summary>
@@ -635,7 +650,7 @@ namespace IntelliTect.Coalesce
         public virtual Task<int> GetListTotalCountAsync(IQueryable<T> query, IFilterParameters parameters)
         {
             var canUseAsync = CanEvalQueryAsynchronously(query);
-            return canUseAsync ? query.CountAsync() : Task.FromResult(query.Count());
+            return canUseAsync ? query.CountAsync(GetEffectiveCancellationToken(parameters)) : Task.FromResult(query.Count());
         }
 
 
@@ -658,7 +673,7 @@ namespace IntelliTect.Coalesce
             query = ApplyListPaging(query, parameters, totalCount, out int page, out int pageSize);
             
             var canUseAsync = CanEvalQueryAsynchronously(query);
-            List<T> result = canUseAsync ? await query.ToListAsync() : query.ToList();
+            List<T> result = canUseAsync ? await query.ToListAsync(GetEffectiveCancellationToken(parameters)) : query.ToList();
 
             var tree = GetIncludeTree(query, parameters);
             return (new ListResult<T>(result, page: page, totalCount: totalCount, pageSize: pageSize), tree);
@@ -703,12 +718,13 @@ namespace IntelliTect.Coalesce
         /// </summary>
         /// <param name="id">The primary key to find the desired item by.</param>
         /// <param name="query">The query to query.</param>
+        /// <param name="cancellationToken">A CancellationToken to use.</param>
         /// <returns>The requested object, or null if it was not found.</returns>
-        protected virtual async Task<T> EvaluateItemQueryAsync(object id, IQueryable<T> query)
+        protected virtual async Task<T> EvaluateItemQueryAsync(object id, IQueryable<T> query, CancellationToken cancellationToken = default)
         {
             var canUseAsync = CanEvalQueryAsynchronously(query);
             return canUseAsync
-                ? await query.FindItemAsync(id, Context.ReflectionRepository) 
+                ? await query.FindItemAsync(id, Context.ReflectionRepository, cancellationToken) 
                 : query.FindItem(id, Context.ReflectionRepository);
         }
 
@@ -722,7 +738,7 @@ namespace IntelliTect.Coalesce
         public virtual async Task<(ItemResult<T> Item, IncludeTree? IncludeTree)> GetItemAsync(object id, IDataSourceParameters parameters)
         {
             var query = await GetQueryAsync(parameters);
-            T result = await EvaluateItemQueryAsync(id, query);
+            T result = await EvaluateItemQueryAsync(id, query, GetEffectiveCancellationToken(parameters));
 
             if (result == null)
             {

--- a/src/IntelliTect.Coalesce/Application/CoalesceServiceBuilder.cs
+++ b/src/IntelliTect.Coalesce/Application/CoalesceServiceBuilder.cs
@@ -26,10 +26,11 @@ namespace IntelliTect.Coalesce
         {
             ReflectionRepository.Global.AddAssembly<TContext>();
             Services.AddScoped(sp => new CrudContext<TContext>(
-                sp.GetRequiredService<TContext>(), 
-                () => sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext?.User,
-                sp.GetService<ITimeZoneResolver>()?.GetTimeZoneInfo() ?? TimeZoneInfo.Local
-            ));
+                 sp.GetRequiredService<TContext>(),
+                 () => sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext?.User,
+                 sp.GetService<ITimeZoneResolver>()?.GetTimeZoneInfo() ?? TimeZoneInfo.Local,
+                 sp.GetRequiredService<Microsoft.AspNetCore.Http.IHttpContextAccessor>().HttpContext?.RequestAborted ?? default
+             ));
 
             return this;
         }

--- a/src/IntelliTect.Coalesce/Helpers/QueryableExtensions.cs
+++ b/src/IntelliTect.Coalesce/Helpers/QueryableExtensions.cs
@@ -51,9 +51,9 @@ namespace IntelliTect.Coalesce
         /// Asynchronously finds an object based on a specific primary key value.
         /// </summary>
         /// <returns>The desired item, or null if it was not found.</returns>
-        public static Task<T> FindItemAsync<T>(this IQueryable<T> query, object id, ReflectionRepository? reflectionRepository = null)
+        public static Task<T> FindItemAsync<T>(this IQueryable<T> query, object id, ReflectionRepository? reflectionRepository = null, CancellationToken cancellationToken = default)
         {
-            return query.WherePrimaryKeyIs(id, reflectionRepository).FirstOrDefaultAsync();
+            return query.WherePrimaryKeyIs(id, reflectionRepository).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently its a bit annoying to use because EF will log cancellations. https://github.com/dotnet/efcore/issues/19526