### PR TITLE
Don't treat zero value as absent for required validation

### DIFF
--- a/src/Coalesce.Web.Vue/src/metadata.g.ts
+++ b/src/Coalesce.Web.Vue/src/metadata.g.ts
@@ -60,7 +60,7 @@ export const Case = domain.types.Case = {
       type: "string",
       role: "value",
       rules: {
-        required: val => !!val || "You must enter a title for the case.",
+        required: val => (val != null && val !== '') || "You must enter a title for the case.",
       }
     },
     description: {
@@ -405,7 +405,7 @@ export const CaseProduct = domain.types.CaseProduct = {
       get principalType() { return (domain.types.Case as ModelType) },
       get navigationProp() { return (domain.types.CaseProduct as ModelType).props.case as ModelReferenceNavigationProperty },
       rules: {
-        required: val => !!val || "Case is required.",
+        required: val => val != null || "Case is required.",
       }
     },
     case: {
@@ -428,7 +428,7 @@ export const CaseProduct = domain.types.CaseProduct = {
       get principalType() { return (domain.types.Product as ModelType) },
       get navigationProp() { return (domain.types.CaseProduct as ModelType).props.product as ModelReferenceNavigationProperty },
       rules: {
-        required: val => !!val || "Product is required.",
+        required: val => val != null || "Product is required.",
       }
     },
     product: {
@@ -700,7 +700,7 @@ export const Person = domain.types.Person = {
       get principalType() { return (domain.types.Company as ModelType) },
       get navigationProp() { return (domain.types.Person as ModelType).props.company as ModelReferenceNavigationProperty },
       rules: {
-        required: val => !!val || "Company is required.",
+        required: val => val != null || "Company is required.",
       }
     },
     company: {

--- a/src/IntelliTect.Coalesce.CodeGeneration.Vue/Generators/Scripts/TsMetadata.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Vue/Generators/Scripts/TsMetadata.cs
@@ -298,9 +298,21 @@ namespace IntelliTect.Coalesce.CodeGeneration.Vue.Generators
 
                     var rules = new List<string>();
 
+                    // A simple falsey check will treat a numeric zero as "absent," so we explicitly check for
+                    // null/undefined instead.
+                    var requiredPredicate = "val != null";
+                    if (prop.Type.IsString)
+                    {
+                        requiredPredicate = "(val != null && val !== '')";
+                    }
+                    else if (prop.Type.IsCollection)
+                    {
+                       requiredPredicate = "(val != null && val.length !== 0)";
+                    }
+
                     if (isRequired == true)
                     {
-                        rules.Add($"required: val => !!val || \"{(errorMessage ?? $"{(prop.ReferenceNavigationProperty ?? prop).DisplayName} is required.").EscapeStringLiteralForTypeScript()}\"");
+                        rules.Add($"required: val => {requiredPredicate} || \"{(errorMessage ?? $"{(prop.ReferenceNavigationProperty ?? prop).DisplayName} is required.").EscapeStringLiteralForTypeScript()}\"");
                     }
                     else if (prop.IsRequired)
                     {
@@ -315,7 +327,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Vue.Generators
                             message = $"{name} is required.";
                         }
 
-                        rules.Add($"required: val => !!val || \"{message.EscapeStringLiteralForTypeScript()}\"");
+                        rules.Add($"required: val => {requiredPredicate} || \"{message.EscapeStringLiteralForTypeScript()}\"");
                     }
 
                     if (rules.Count > 0)

--- a/src/IntelliTect.Coalesce.CodeGeneration.Vue/Generators/Scripts/TsMetadata.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Vue/Generators/Scripts/TsMetadata.cs
@@ -300,15 +300,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Vue.Generators
 
                     // A simple falsey check will treat a numeric zero as "absent," so we explicitly check for
                     // null/undefined instead.
-                    var requiredPredicate = "val != null";
-                    if (prop.Type.IsString)
-                    {
-                        requiredPredicate = "(val != null && val !== '')";
-                    }
-                    else if (prop.Type.IsCollection)
-                    {
-                       requiredPredicate = "(val != null && val.length !== 0)";
-                    }
+                    var requiredPredicate = prop.Type.IsString ? "(val != null && val !== '')" : "val != null";
 
                     if (isRequired == true)
                     {


### PR DESCRIPTION
Instead of checking falsiness, check for `null | undefined` or empty string.