### PR TITLE
Fix #36

### DIFF
--- a/src/IntelliTect.Coalesce.CodeGeneration/Generation/GenerationExecutor.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration/Generation/GenerationExecutor.cs
@@ -86,12 +86,12 @@ namespace IntelliTect.Coalesce.CodeGeneration.Generation
             Logger.LogInformation($"Analyzing {types.Count()} Types");
             if (Config.RootTypesWhitelist?.Any() == true)
             {
-                types = types.Where(t => Config.RootTypesWhitelist.Contains(t.Name));
-                Logger.LogInformation($"Whitelisted Root Types: {string.Join(", ", types.Select(t => t.Name))}");
+                rr.SetRootTypeWhitelist(Config.RootTypesWhitelist);
+                Logger.LogInformation($"Whitelisted Root Types: {string.Join(", ", Config.RootTypesWhitelist)}");
             }
 
-            rr.DiscoverCoalescedTypes(types
-                .Select(t => new SymbolTypeViewModel(rr, t))
+            rr.DiscoverCoalescedTypes(
+                types.Select(t => new SymbolTypeViewModel(rr, t))
             );
 
 

--- a/src/IntelliTect.Coalesce.CodeGeneration/Generation/GenerationExecutor.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration/Generation/GenerationExecutor.cs
@@ -91,7 +91,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Generation
             }
 
             rr.DiscoverCoalescedTypes(types
-                .Select(t => new SymbolTypeViewModel(t))
+                .Select(t => new SymbolTypeViewModel(rr, t))
             );
 
 

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/TypeViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/TypeViewModelTests.cs
@@ -65,9 +65,9 @@ namespace IntelliTect.Coalesce.Tests.TypeDefinition
         [ClassViewModelData(typeof(double?))]
         public void IsNumber_TrueForNumbers(ClassViewModelData data)
         {
-            ClassViewModel vm = data;
+            TypeViewModel vm = data;
 
-            Assert.True(vm.Type.IsNumber);
+            Assert.True(vm.IsNumber);
         }
     }
 }

--- a/src/IntelliTect.Coalesce.Tests/Util/ClassViewModelData.cs
+++ b/src/IntelliTect.Coalesce.Tests/Util/ClassViewModelData.cs
@@ -17,7 +17,8 @@ namespace IntelliTect.Coalesce.Tests.Util
         public Type TargetType { get; private set; }
         public Type ViewModelType { get; private set; }
 
-        public ClassViewModel ClassViewModel { get; private set; }
+        public TypeViewModel TypeViewModel { get; private set; }
+        public ClassViewModel ClassViewModel => TypeViewModel.ClassViewModel;
 
         public ClassViewModelData()
         {
@@ -34,7 +35,7 @@ namespace IntelliTect.Coalesce.Tests.Util
         {
             if (ViewModelType == typeof(ReflectionClassViewModel))
             {
-                ClassViewModel = ReflectionRepositoryFactory.Reflection.GetClassViewModel(TargetType);
+                TypeViewModel = ReflectionRepositoryFactory.Reflection.GetOrAddType(TargetType);
             }
             else if (ViewModelType == typeof(SymbolClassViewModel))
             {
@@ -50,7 +51,7 @@ namespace IntelliTect.Coalesce.Tests.Util
                     throw new ArgumentException($"Class {TargetType} ({fqn}) not found in any C# embedded resources.");
                 }
 
-                ClassViewModel = ReflectionRepositoryFactory.Symbol.GetClassViewModel(locatedSymbol);
+                TypeViewModel = ReflectionRepositoryFactory.Symbol.GetOrAddType(locatedSymbol);
             }
         }
 
@@ -88,6 +89,9 @@ namespace IntelliTect.Coalesce.Tests.Util
 
         public static implicit operator ClassViewModel(ClassViewModelData self)
             => self.ClassViewModel;
+
+        public static implicit operator TypeViewModel(ClassViewModelData self)
+            => self.TypeViewModel;
 
         public override string ToString() =>
             $"({(ViewModelType.Name.StartsWith("Sym") ? "Symbol" : "Reflect")}) {new ReflectionTypeViewModel(TargetType).FullyQualifiedName}";

--- a/src/IntelliTect.Coalesce.Tests/Util/ReflectionRepositoryFactory.cs
+++ b/src/IntelliTect.Coalesce.Tests/Util/ReflectionRepositoryFactory.cs
@@ -22,7 +22,7 @@ namespace IntelliTect.Coalesce.Tests.Util
         public static ReflectionRepository MakeFromSymbols()
         {
             var rr = new ReflectionRepository();
-            rr.DiscoverCoalescedTypes(Symbols.Select(s => new SymbolTypeViewModel(s)));
+            rr.DiscoverCoalescedTypes(Symbols.Select(s => new SymbolTypeViewModel(rr, s)));
             return rr;
         }
 

--- a/src/IntelliTect.Coalesce/Api/Behaviors/BehaviorsFactory.cs
+++ b/src/IntelliTect.Coalesce/Api/Behaviors/BehaviorsFactory.cs
@@ -31,12 +31,11 @@ namespace IntelliTect.Coalesce.Api.Behaviors
         {
             // If other kinds of default are handled here in the future, add them to the collection above.
 
-            var tContext = reflectionRepository.DbContexts.FirstOrDefault(c => c.Entities.Any(e => e.ClassViewModel.Equals(servedType)));
-            var BehaviorsType = typeof(IEntityFrameworkBehaviors<,>).MakeGenericType(
+            var tContext = reflectionRepository.EntityUsages[servedType].First().Context;
+            return typeof(IEntityFrameworkBehaviors<,>).MakeGenericType(
                 servedType.Type.TypeInfo,
                 tContext.ClassViewModel.Type.TypeInfo
             );
-            return BehaviorsType;
         }
 
         public object GetDefaultBehaviors(ClassViewModel servedType)

--- a/src/IntelliTect.Coalesce/Api/Behaviors/StandardBehaviors.cs
+++ b/src/IntelliTect.Coalesce/Api/Behaviors/StandardBehaviors.cs
@@ -67,7 +67,7 @@ namespace IntelliTect.Coalesce
         public virtual (SaveKind Kind, object IncomingKey) DetermineSaveKind<TDto>(TDto incomingDto)
             where TDto : class, IClassDto<T>, new()
         {
-            var dtoClassViewModel = ReflectionRepository.Global.GetClassViewModel<TDto>();
+            var dtoClassViewModel = Context.ReflectionRepository.GetClassViewModel<TDto>();
             object idValue = dtoClassViewModel.PrimaryKey.PropertyInfo.GetValue(incomingDto);
 
             // IsNullable handles nullable value types, and reference types (mainly strings).

--- a/src/IntelliTect.Coalesce/Api/CrudStrategy/StandardCrudStrategy.cs
+++ b/src/IntelliTect.Coalesce/Api/CrudStrategy/StandardCrudStrategy.cs
@@ -11,6 +11,16 @@ namespace IntelliTect.Coalesce.Api
         where T : class, new()
         where TContext : DbContext
     {
+        public StandardCrudStrategy(CrudContext<TContext> context)
+        {
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+            ClassViewModel = Context.ReflectionRepository.GetClassViewModel<T>();
+
+            // Ensure that the DbContext is in the ReflectionRepository.
+            // We do this so that unit tests will work without having to always do this manually.
+            // Cost is very low.
+            Context.ReflectionRepository.GetOrAddType(typeof(TContext));
+        }
 
         /// <summary>
         /// Contains contextual information about the request.
@@ -31,11 +41,5 @@ namespace IntelliTect.Coalesce.Api
         /// A ClassViewModel representing the type T that is handled by these strategies.
         /// </summary>
         public ClassViewModel ClassViewModel { get; protected set; }
-
-        public StandardCrudStrategy(CrudContext<TContext> context)
-        {
-            Context = context ?? throw new ArgumentNullException(nameof(context));
-            ClassViewModel = Context.ReflectionRepository.GetClassViewModel<T>();
-        }
     }
 }

--- a/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
@@ -72,12 +72,11 @@ namespace IntelliTect.Coalesce.Api.DataSources
             }
 
             // FUTURE: If other kinds of default data sources are created, add them to the DefaultTypes dictionary above.
-            var tContext = reflectionRepository.DbContexts.FirstOrDefault(c => c.Entities.Any(e => e.ClassViewModel.Equals(servedType)));
-            var dataSourceType = typeof(IEntityFrameworkDataSource<,>).MakeGenericType(
+            var tContext = reflectionRepository.EntityUsages[servedType].First().Context;
+            return typeof(IEntityFrameworkDataSource<,>).MakeGenericType(
                 servedType.Type.TypeInfo,
                 tContext.ClassViewModel.Type.TypeInfo
             );
-            return dataSourceType;
         }
 
         public IDataSource<TServed> GetDefaultDataSource<TServed, TDeclaredFor>()

--- a/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
@@ -59,7 +59,9 @@ namespace IntelliTect.Coalesce
             var query = GetQuery(parameters);
             var canUseAsync = CanEvalQueryAsynchronously(query);
             var projectedQuery = ApplyProjection(query, parameters);
-            TDto mappedResult = canUseAsync ? await projectedQuery.FindItemAsync(id) : projectedQuery.FindItem(id);
+            TDto mappedResult = canUseAsync 
+                ? await projectedQuery.FindItemAsync(id, Context.ReflectionRepository) 
+                : projectedQuery.FindItem(id, Context.ReflectionRepository);
 
             if (mappedResult == null)
             {

--- a/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
@@ -77,7 +77,7 @@ namespace IntelliTect.Coalesce
 
             if (!string.Equals(parameters.Includes, NoDefaultIncludesString, StringComparison.OrdinalIgnoreCase))
             {
-                query = query.IncludeChildren();
+                query = query.IncludeChildren(this.Context.ReflectionRepository);
             }
 
             return query;
@@ -701,7 +701,9 @@ namespace IntelliTect.Coalesce
         protected virtual async Task<T> EvaluateItemQueryAsync(object id, IQueryable<T> query)
         {
             var canUseAsync = CanEvalQueryAsynchronously(query);
-            return canUseAsync ? await query.FindItemAsync(id) : query.FindItem(id);
+            return canUseAsync
+                ? await query.FindItemAsync(id, Context.ReflectionRepository) 
+                : query.FindItem(id, Context.ReflectionRepository);
         }
 
         /// <summary>

--- a/src/IntelliTect.Coalesce/Helpers/QueryableExtensions.cs
+++ b/src/IntelliTect.Coalesce/Helpers/QueryableExtensions.cs
@@ -19,12 +19,9 @@ namespace IntelliTect.Coalesce
         /// <summary>
         /// Includes immediate children, as well as the other side of many-to-many relationships.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        public static IQueryable<T> IncludeChildren<T>(this IQueryable<T> query) where T : class
+        public static IQueryable<T> IncludeChildren<T>(this IQueryable<T> query, ReflectionRepository reflectionRepository = null) where T : class
         {
-            var model = ReflectionRepository.Global.GetClassViewModel<T>();
+            var model = (reflectionRepository ?? ReflectionRepository.Global).GetClassViewModel<T>();
             foreach (var prop in model.ClientProperties.Where(f => !f.IsStatic && f.Object != null && f.Object.HasDbSet && !f.HasNotMapped))
             {
                 if (prop.IsManytoManyCollection)
@@ -43,9 +40,9 @@ namespace IntelliTect.Coalesce
         /// Filters a query by a given primary key value.
         /// </summary>
         /// <returns>The filtered query.</returns>
-        public static IQueryable<T> WherePrimaryKeyIs<T>(this IQueryable<T> query, object id)
+        public static IQueryable<T> WherePrimaryKeyIs<T>(this IQueryable<T> query, object id, ReflectionRepository reflectionRepository = null)
         {
-            var classViewModel = ReflectionRepository.Global.GetClassViewModel<T>();
+            var classViewModel = (reflectionRepository ?? ReflectionRepository.Global).GetClassViewModel<T>();
             var pkProp = classViewModel.PrimaryKey.PropertyInfo;
             return query.Where($"{pkProp.Name} == @0", id);
         }
@@ -53,25 +50,19 @@ namespace IntelliTect.Coalesce
         /// <summary>
         /// Asynchronously finds an object based on a specific primary key value.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="query"></param>
-        /// <param name="id"></param>
         /// <returns>The desired item, or null if it was not found.</returns>
-        public static Task<T> FindItemAsync<T>(this IQueryable<T> query, object id)
+        public static Task<T> FindItemAsync<T>(this IQueryable<T> query, object id, ReflectionRepository reflectionRepository = null)
         {
-            return query.WherePrimaryKeyIs(id).FirstOrDefaultAsync();
+            return query.WherePrimaryKeyIs(id, reflectionRepository).FirstOrDefaultAsync();
         }
 
         /// <summary>
         /// Finds an object based on a specific primary key value.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="query"></param>
-        /// <param name="id"></param>
         /// <returns>The desired item, or null if it was not found.</returns>
-        public static T FindItem<T>(this IQueryable<T> query, object id)
+        public static T FindItem<T>(this IQueryable<T> query, object id, ReflectionRepository reflectionRepository = null)
         {
-            return query.WherePrimaryKeyIs(id).FirstOrDefault();
+            return query.WherePrimaryKeyIs(id, reflectionRepository).FirstOrDefault();
         }
     }
 }

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -22,6 +22,8 @@ namespace IntelliTect.Coalesce.TypeDefinition
         protected IReadOnlyCollection<PropertyViewModel> _Properties;
         protected IReadOnlyCollection<MethodViewModel> _Methods;
 
+        public ReflectionRepository ReflectionRepository => Type.ReflectionRepository;
+
         public abstract string Name { get; }
         public abstract string Comment { get; }
         public TypeViewModel Type { get; protected set; }

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -413,9 +413,9 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public bool IsDbMappedType => HasDbSet || (DtoBaseViewModel?.HasDbSet ?? false);
 
         /// <summary>
-        /// Has a DbSet property in the Context.
+        /// True if the type has a DbSet property on any discovered DbContext types.
         /// </summary>
-        public bool HasDbSet { get; internal set; }
+        public bool HasDbSet => ReflectionRepository?.EntityUsages.Contains(this) ?? false;
 
         private ClassSecurityInfo _securityInfo;
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Helpers/IAttributeProvider.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Helpers/IAttributeProvider.cs
@@ -45,8 +45,8 @@ namespace IntelliTect.Coalesce.TypeDefinition
             where TAttribute : Attribute
         {
             var value = obj.GetAttributeValue<TAttribute>(propertyExpression.GetExpressedProperty().Name);
-            if (value is Type reflectionValue) return new ReflectionTypeViewModel(reflectionValue);
-            if (value is ITypeSymbol symbolValue) return new SymbolTypeViewModel(symbolValue);
+            if (value is Type reflectionValue) return ReflectionRepository.Global.GetOrAddType(reflectionValue);
+            if (value is ITypeSymbol symbolValue) return ReflectionRepository.Global.GetOrAddType(symbolValue);
             return null;
         }
     }

--- a/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
@@ -58,7 +58,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                 if (ReturnType.IsA(typeof(Task<>))) return ReturnType.FirstTypeArgument;
 
                 // Return type is a task, but not a generic task. Effective type is void.
-                return new ReflectionTypeViewModel(typeof(void));
+                return new ReflectionTypeViewModel(Parent.ReflectionRepository, typeof(void));
             }
         }
 
@@ -87,7 +87,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                       // For ReturnsListResult, the result will be a constructed generic IList<T>
                       ReturnsListResult ? retType.ClassViewModel.PropertyByName(nameof(ListResult<object>.List)).Type
                     : retType.IsA(typeof(ItemResult<>)) ? retType.FirstTypeArgument
-                    : retType.IsA(typeof(ItemResult)) ? new ReflectionTypeViewModel(typeof(void))
+                    : retType.IsA(typeof(ItemResult)) ? new ReflectionTypeViewModel(Parent.ReflectionRepository, typeof(void))
                     : retType;
             }
         }

--- a/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
@@ -58,7 +58,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                 if (ReturnType.IsA(typeof(Task<>))) return ReturnType.FirstTypeArgument;
 
                 // Return type is a task, but not a generic task. Effective type is void.
-                return new ReflectionTypeViewModel(Parent.ReflectionRepository, typeof(void));
+                return ReflectionTypeViewModel.GetOrCreate(Parent.ReflectionRepository, typeof(void));
             }
         }
 
@@ -87,7 +87,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                       // For ReturnsListResult, the result will be a constructed generic IList<T>
                       ReturnsListResult ? retType.ClassViewModel.PropertyByName(nameof(ListResult<object>.List)).Type
                     : retType.IsA(typeof(ItemResult<>)) ? retType.FirstTypeArgument
-                    : retType.IsA(typeof(ItemResult)) ? new ReflectionTypeViewModel(Parent.ReflectionRepository, typeof(void))
+                    : retType.IsA(typeof(ItemResult)) ? ReflectionTypeViewModel.GetOrCreate(Parent.ReflectionRepository, typeof(void))
                     : retType;
             }
         }

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
@@ -11,10 +11,14 @@ namespace IntelliTect.Coalesce.TypeDefinition
     {
         protected Type Info { get; }
 
-        public ReflectionClassViewModel(Type type)
+        public ReflectionClassViewModel(Type type) : this(null, type)
+        {
+        }
+
+        internal ReflectionClassViewModel(ReflectionRepository reflectionRepository, Type type)
         {
             Info = type;
-            Type = new ReflectionTypeViewModel(type);
+            Type = new ReflectionTypeViewModel(reflectionRepository, type);
         }
 
         public override string Name => Info.Name;
@@ -23,7 +27,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         protected override IReadOnlyCollection<PropertyViewModel> RawProperties(ClassViewModel effectiveParent) => Info
             .GetProperties()
-            .Select((p, i) => new ReflectionPropertyViewModel(effectiveParent, new ReflectionTypeViewModel(p.DeclaringType).ClassViewModel, p){ ClassFieldOrder = i })
+            .Select((p, i) => new ReflectionPropertyViewModel(effectiveParent, this, p){ ClassFieldOrder = i })
             .Cast<PropertyViewModel>()
             .ToList().AsReadOnly();
 
@@ -36,7 +40,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         protected override IReadOnlyCollection<TypeViewModel> RawNestedTypes => Info
             .GetNestedTypes()
-            .Select(t => new ReflectionTypeViewModel(t))
+            .Select(t => new ReflectionTypeViewModel(ReflectionRepository, t))
             .ToList().AsReadOnly();
     }
 }

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionMethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionMethodViewModel.cs
@@ -28,7 +28,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         public override bool IsStatic => Info.IsStatic;
 
-        public override TypeViewModel ReturnType => new ReflectionTypeViewModel(Info.ReturnType);
+        public override TypeViewModel ReturnType => new ReflectionTypeViewModel(Parent.ReflectionRepository, Info.ReturnType);
 
         public override bool IsInternalUse => base.IsInternalUse || !Info.IsPublic;
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionMethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionMethodViewModel.cs
@@ -28,7 +28,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         public override bool IsStatic => Info.IsStatic;
 
-        public override TypeViewModel ReturnType => new ReflectionTypeViewModel(Parent.ReflectionRepository, Info.ReturnType);
+        public override TypeViewModel ReturnType => ReflectionTypeViewModel.GetOrCreate(Parent.ReflectionRepository, Info.ReturnType);
 
         public override bool IsInternalUse => base.IsInternalUse || !Info.IsPublic;
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionParameterViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionParameterViewModel.cs
@@ -15,10 +15,12 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public ReflectionParameterViewModel(MethodViewModel parent, ParameterInfo info) : base(parent)
         {
             Info = info;
-            if (info.ParameterType.IsByRef)
-                Type = new ReflectionTypeViewModel(info.ParameterType.GetElementType());
-            else
-                Type = new ReflectionTypeViewModel(info.ParameterType);
+            Type = new ReflectionTypeViewModel(
+                Parent.Parent.ReflectionRepository, 
+                info.ParameterType.IsByRef 
+                    ? info.ParameterType.GetElementType() 
+                    : info.ParameterType
+            );
 
         }
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionParameterViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionParameterViewModel.cs
@@ -15,7 +15,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public ReflectionParameterViewModel(MethodViewModel parent, ParameterInfo info) : base(parent)
         {
             Info = info;
-            Type = new ReflectionTypeViewModel(
+            Type = ReflectionTypeViewModel.GetOrCreate(
                 Parent.Parent.ReflectionRepository, 
                 info.ParameterType.IsByRef 
                     ? info.ParameterType.GetElementType() 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionPropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionPropertyViewModel.cs
@@ -16,7 +16,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             Parent = declaringParent;
             EffectiveParent = effectiveParent;
             Info = propetyInfo;
-            Type = new ReflectionTypeViewModel(declaringParent.ReflectionRepository, Info.PropertyType);
+            Type = ReflectionTypeViewModel.GetOrCreate(declaringParent.ReflectionRepository, Info.PropertyType);
         }
 
         public override string Name => Info.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionPropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionPropertyViewModel.cs
@@ -16,7 +16,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             Parent = declaringParent;
             EffectiveParent = effectiveParent;
             Info = propetyInfo;
-            Type = new ReflectionTypeViewModel(Info.PropertyType);
+            Type = new ReflectionTypeViewModel(declaringParent.ReflectionRepository, Info.PropertyType);
         }
 
         public override string Name => Info.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
@@ -11,15 +11,20 @@ namespace IntelliTect.Coalesce.TypeDefinition
     {
         protected internal Type Info { get; internal set; }
 
-        public ReflectionTypeViewModel(Type type)
+        public ReflectionTypeViewModel(Type type) : this(null, type)
         {
+        }
+
+        internal ReflectionTypeViewModel(ReflectionRepository reflectionRepository, Type type) : base(reflectionRepository)
+        {
+            ReflectionRepository = reflectionRepository;
             Info = type;
 
             FirstTypeArgument = IsGeneric && Info.IsConstructedGenericType
-                ? new ReflectionTypeViewModel(Info.GenericTypeArguments[0])
+                ? new ReflectionTypeViewModel(reflectionRepository, Info.GenericTypeArguments[0])
                 : null;
 
-            ArrayType = IsArray ? new ReflectionTypeViewModel(Info.GetElementType()) : null;
+            ArrayType = IsArray ? new ReflectionTypeViewModel(reflectionRepository, Info.GetElementType()) : null;
 
             IEnumerable<Type> GetBaseClassesAndInterfaces(Type t)
             {
@@ -63,7 +68,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public override TypeViewModel[] GenericArgumentsFor(Type type) =>
             GetSatisfyingBaseType(type)?
             .GenericTypeArguments
-            .Select(t => new ReflectionTypeViewModel(t))
+            .Select(t => new ReflectionTypeViewModel(ReflectionRepository, t))
             .ToArray();
 
         public override bool IsA(Type type) => GetSatisfyingBaseType(type) != null;

--- a/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
@@ -12,6 +12,7 @@ using IntelliTect.Coalesce.Utilities;
 using System.Collections.Concurrent;
 using IntelliTect.Coalesce.TypeUsage;
 using IntelliTect.Coalesce.Api;
+using System.Threading;
 
 namespace IntelliTect.Coalesce.TypeDefinition
 {
@@ -19,20 +20,27 @@ namespace IntelliTect.Coalesce.TypeDefinition
     {
         public static readonly ReflectionRepository Global = new ReflectionRepository();
 
+
         private readonly HashSet<DbContextTypeUsage> _contexts = new HashSet<DbContextTypeUsage>();
         private readonly HashSet<ClassViewModel> _entities = new HashSet<ClassViewModel>();
+        private ILookup<ClassViewModel, EntityTypeUsage> _entityUsages = null;
+
         private readonly HashSet<CrudStrategyTypeUsage> _behaviors = new HashSet<CrudStrategyTypeUsage>();
         private readonly HashSet<CrudStrategyTypeUsage> _dataSources = new HashSet<CrudStrategyTypeUsage>();
         private readonly HashSet<ClassViewModel> _externalTypes = new HashSet<ClassViewModel>();
         private readonly HashSet<ClassViewModel> _customDtos = new HashSet<ClassViewModel>();
         private readonly HashSet<ClassViewModel> _services = new HashSet<ClassViewModel>();
 
-        private readonly ConcurrentDictionary<object, ClassViewModel> _allClassViewModels
-            = new ConcurrentDictionary<object, ClassViewModel>();
+        private readonly ConcurrentDictionary<object, TypeViewModel> _allTypeViewModels
+            = new ConcurrentDictionary<object, TypeViewModel>();
 
         private readonly object _discoverLock = new object();
 
         public ReadOnlyHashSet<DbContextTypeUsage> DbContexts => new ReadOnlyHashSet<DbContextTypeUsage>(_contexts);
+        public ILookup<ClassViewModel, EntityTypeUsage> EntityUsages => _entityUsages ??= DbContexts
+            .SelectMany(contextUsage => contextUsage.Entities)
+            .ToLookup(entityUsage => entityUsage.ClassViewModel);
+
         public ReadOnlyHashSet<ClassViewModel> Entities => new ReadOnlyHashSet<ClassViewModel>(_entities);
         public ReadOnlyHashSet<CrudStrategyTypeUsage> Behaviors => new ReadOnlyHashSet<CrudStrategyTypeUsage>(_behaviors);
         public ReadOnlyHashSet<CrudStrategyTypeUsage> DataSources => new ReadOnlyHashSet<CrudStrategyTypeUsage>(_dataSources);
@@ -63,62 +71,97 @@ namespace IntelliTect.Coalesce.TypeDefinition
         {
             lock (_discoverLock)
             {
-                foreach (var type in rootTypes
+                AddTypes(rootTypes
                     // For some reason, attribute checking can be really slow. We're talking ~350ms to determine that the DbContext type has a [Coalesce] attribute.
                     // Really not sure why, but lets parallelize to minimize that impact.
                     .AsParallel()
                     .Where(type => type.HasAttribute<CoalesceAttribute>())
-                )
-                {
-                    if (type.IsA<DbContext>())
-                    {
-                        var context = new DbContextTypeUsage(type.ClassViewModel);
-                        _contexts.Add(context);
-                        _entities.UnionWith(context.Entities.Select(e => e.ClassViewModel));
-
-                        // Force cache these since they have extra bits of info attached now.
-                        // TODO: eliminate the need for this.
-                        foreach (var e in context.Entities) Cache(e.ClassViewModel, force: true);
-
-                    }
-                    else if (AddCrudStrategy(typeof(IDataSource<>), type, _dataSources))
-                    {
-                        // Handled by helper
-                    }
-                    else if (AddCrudStrategy(typeof(IBehaviors<>), type, _behaviors))
-                    {
-                        // Handled by helper
-                    }
-                    else if (type.IsA(typeof(IClassDto<>)))
-                    {
-                        var classViewModel = type.ClassViewModel;
-
-                        // Force cache this since it has extra bits of info attached.
-                        _customDtos.Add(Cache(classViewModel, force: true));
-                    }
-                    else if (type.ClassViewModel?.IsService ?? false)
-                    {
-                        var classViewModel = type.ClassViewModel;
-                        _services.Add(Cache(classViewModel));
-                    }
-                }
-
-                foreach (var entity in ApiBackedClasses)
-                {
-                    DiscoverExternalMethodTypesOn(entity);
-                    DiscoverExternalPropertyTypesOn(entity);
-                    DiscoverNestedCrudStrategiesOn(entity);
-                }
-
-                foreach (var service in Services)
-                {
-                    DiscoverExternalMethodTypesOn(service);
-                }
+                );
             }
         }
 
-        public void AddTypes(IEnumerable<TypeViewModel> rootTypes)
+        public void AddTypes(IEnumerable<TypeViewModel> types)
         {
+            foreach (var type in types) GetOrAddType(type);
+        }
+
+        public SymbolTypeViewModel GetOrAddType(ITypeSymbol symbol) =>
+            GetOrAddType(symbol, () => new SymbolTypeViewModel(this, symbol)) as SymbolTypeViewModel;
+
+        public ReflectionTypeViewModel GetOrAddType(Type type) =>
+            GetOrAddType(type, () => new ReflectionTypeViewModel(this, type)) as ReflectionTypeViewModel;
+
+        public TypeViewModel GetOrAddType(TypeViewModel type) => 
+            GetOrAddType(GetCacheKey(type), () => type);
+
+        private TypeViewModel GetOrAddType(object key, Func<TypeViewModel> factory)
+        {
+            // First, see if we already have the type. Do not invoke the factory for this check.
+            if (_allTypeViewModels.TryGetValue(key, out var existing)) return existing;
+
+            var newType = factory();
+            if (_allTypeViewModels.TryAdd(key, newType))
+            {
+                ProcessAddedType(newType);
+            }
+
+            // Re-fetch, because this isn't strictly the one that we maybe just added.
+            return _allTypeViewModels[key];
+        }
+
+        private void ProcessAddedType(TypeViewModel type)
+        {
+            if (!type.HasAttribute<CoalesceAttribute>())
+            {
+                return;
+            }
+
+            if (type.IsA<DbContext>())
+            {
+                var context = new DbContextTypeUsage(type.ClassViewModel);
+
+                var entityCvms = context.Entities.Select(e => GetOrAddType(e.TypeViewModel).ClassViewModel);
+                lock (_contexts)
+                {
+                    _contexts.Add(context);
+                    _entities.UnionWith(entityCvms);
+                }
+
+                // Null this out so it gets recomputed on next access.
+                _entityUsages = null;
+
+                foreach (var entity in context.Entities)
+                {
+                    DiscoverOnApiBackedClass(entity.TypeViewModel.ClassViewModel);
+                }
+            }
+            else if (AddCrudStrategy(typeof(IDataSource<>), type, _dataSources))
+            {
+                // Handled by helper
+            }
+            else if (AddCrudStrategy(typeof(IBehaviors<>), type, _behaviors))
+            {
+                // Handled by helper
+            }
+            else if (type.IsA(typeof(IClassDto<>)))
+            {
+                var classViewModel = type.ClassViewModel;
+                _customDtos.Add(classViewModel);
+                DiscoverOnApiBackedClass(classViewModel);
+            }
+            else if (type.ClassViewModel?.IsService ?? false)
+            {
+                var classViewModel = type.ClassViewModel;
+                _services.Add(classViewModel);
+                DiscoverExternalMethodTypesOn(classViewModel);
+            }
+
+            void DiscoverOnApiBackedClass(ClassViewModel classViewModel)
+            {
+                DiscoverExternalMethodTypesOn(classViewModel);
+                DiscoverExternalPropertyTypesOn(classViewModel);
+                DiscoverNestedCrudStrategiesOn(classViewModel);
+            }
         }
 
         /// <summary>
@@ -128,30 +171,10 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public void AddAssembly<T>() =>
             DiscoverCoalescedTypes(typeof(T).Assembly.ExportedTypes.Select(t => new ReflectionTypeViewModel(this, t)));
 
-        /// <summary>
-        /// Cache the given model so it can be reused when an instance representing its underlying type is requested.
-        /// </summary>
-        /// <param name="classViewModel">The ClassViewModel to cache.</param>
-        /// <param name="force">
-        /// True to override any existing object for the underlying type. 
-        /// False to preserve any existing object.
-        /// </param>
-        /// <returns>The ClassViewModel that was passed in, for convenience.</returns>
-        private ClassViewModel Cache(ClassViewModel classViewModel, bool force = false)
-        {
-            object key = GetCacheKey(classViewModel);
 
-            if (force)
-                _allClassViewModels[key] = classViewModel;
-            else
-                _allClassViewModels.GetOrAdd(key, classViewModel);
-
-            return classViewModel;
-        }
-
-        private object GetCacheKey(ClassViewModel classViewModel) => 
-            (classViewModel.Type as ReflectionTypeViewModel)?.Info as object
-            ?? (classViewModel.Type as SymbolTypeViewModel)?.Symbol as object
+        private object GetCacheKey(TypeViewModel typeViewModel) =>
+            (typeViewModel as ReflectionTypeViewModel)?.Info as object
+            ?? (typeViewModel as SymbolTypeViewModel)?.Symbol as object
             ?? throw new NotSupportedException("Unknown subtype of TypeViewModel");
 
 
@@ -172,7 +195,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                 && !ExternalTypes.Contains(externalType)
                 )
             {
-                if (_externalTypes.Add(Cache(externalType)))
+                if (_externalTypes.Add(externalType))
                 {
                     DiscoverExternalPropertyTypesOn(externalType);
                 }
@@ -223,7 +246,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             {
                 throw new InvalidOperationException($"{servedType} is not a valid type argument for a {iface}.");
             }
-            var servedClass = Cache(servedType.ClassViewModel);
+            var servedClass = servedType.ClassViewModel;
 
             // See if we were expecting that the strategy be declared for a particular type
             // by virtue of its nesting. If this type has been overridden to something else by an attribute, then that's wrong.
@@ -245,7 +268,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
                     $"{strategyType} must satisfy {iface} with type parameter <{declaredFor.DtoBaseViewModel}>.");
             }
 
-            set.Add(new CrudStrategyTypeUsage(Cache(strategyType.ClassViewModel), servedClass, declaredFor));
+            set.Add(new CrudStrategyTypeUsage(strategyType.ClassViewModel, servedClass, declaredFor));
             return true;
         }
 
@@ -259,12 +282,13 @@ namespace IntelliTect.Coalesce.TypeDefinition
         }
 
         public ClassViewModel GetClassViewModel(Type classType) =>
-            _allClassViewModels.GetOrAdd(classType, _ => new ReflectionClassViewModel(this, classType));
+            GetOrAddType(classType).ClassViewModel;
 
         public ClassViewModel GetClassViewModel(INamedTypeSymbol classType) =>
-            _allClassViewModels.GetOrAdd(classType, _ => new SymbolClassViewModel(this, classType));
+            GetOrAddType(classType).ClassViewModel;
 
         public ClassViewModel GetClassViewModel<T>() => GetClassViewModel(typeof(T));
+
 
         /// <summary>
         /// Gets a propertyViewModel based on the property selector.

--- a/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
@@ -117,13 +117,16 @@ namespace IntelliTect.Coalesce.TypeDefinition
             }
         }
 
+        public void AddTypes(IEnumerable<TypeViewModel> rootTypes)
+        {
+        }
+
         /// <summary>
-        /// Adds types from the assembly that defines the given type parameter.
+        /// Adds types from the assembly where type T resides.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        internal void AddAssembly<T>() =>
-            DiscoverCoalescedTypes(typeof(T).Assembly.ExportedTypes.Select(t => new ReflectionTypeViewModel(t)));
+        public void AddAssembly<T>() =>
+            DiscoverCoalescedTypes(typeof(T).Assembly.ExportedTypes.Select(t => new ReflectionTypeViewModel(this, t)));
 
         /// <summary>
         /// Cache the given model so it can be reused when an instance representing its underlying type is requested.
@@ -256,10 +259,10 @@ namespace IntelliTect.Coalesce.TypeDefinition
         }
 
         public ClassViewModel GetClassViewModel(Type classType) =>
-            _allClassViewModels.GetOrAdd(classType, _ => new ReflectionClassViewModel(classType));
+            _allClassViewModels.GetOrAdd(classType, _ => new ReflectionClassViewModel(this, classType));
 
         public ClassViewModel GetClassViewModel(INamedTypeSymbol classType) =>
-            _allClassViewModels.GetOrAdd(classType, _ => new SymbolClassViewModel(classType));
+            _allClassViewModels.GetOrAdd(classType, _ => new SymbolClassViewModel(this, classType));
 
         public ClassViewModel GetClassViewModel<T>() => GetClassViewModel(typeof(T));
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolClassViewModel.cs
@@ -9,10 +9,14 @@ namespace IntelliTect.Coalesce.TypeDefinition
     {
         protected ITypeSymbol Symbol { get; }
 
-        public SymbolClassViewModel(INamedTypeSymbol symbol)
+        public SymbolClassViewModel(INamedTypeSymbol symbol) : this(null, symbol)
+        {
+        }
+
+        internal SymbolClassViewModel(ReflectionRepository reflectionRepository, INamedTypeSymbol symbol)
         {
             Symbol = symbol;
-            Type = new SymbolTypeViewModel(Symbol);
+            Type = new SymbolTypeViewModel(reflectionRepository, Symbol);
         }
 
         public override string Name => Symbol.Name;
@@ -31,7 +35,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             // Add properties from the base class
             if (Symbol.BaseType != null && Symbol.BaseType.Name != "Object")
             {
-                var parentSymbol = new SymbolClassViewModel(Symbol.BaseType);
+                var parentSymbol = new SymbolClassViewModel(ReflectionRepository, Symbol.BaseType);
                 result.AddRange(parentSymbol.RawProperties(effectiveParent));
             }
             return result.AsReadOnly();
@@ -50,7 +54,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
                 void AddSymbolMethods(INamedTypeSymbol symbol)
                 {
-                    var parentSymbol = new SymbolClassViewModel(symbol);
+                    var parentSymbol = new SymbolClassViewModel(ReflectionRepository, symbol);
                     result.AddRange(parentSymbol.Methods
                         .Cast<SymbolMethodViewModel>()
                         // Don't add overriden methods
@@ -81,7 +85,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         protected override IReadOnlyCollection<TypeViewModel> RawNestedTypes => Symbol
             .GetTypeMembers()
-            .Select(t => new SymbolTypeViewModel(t))
+            .Select(t => new SymbolTypeViewModel(ReflectionRepository, t))
             .ToList().AsReadOnly();
     }
 }

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolMethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolMethodViewModel.cs
@@ -26,7 +26,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         
         public override bool IsStatic => Symbol.IsStatic;
 
-        public override TypeViewModel ReturnType => new SymbolTypeViewModel(Parent.ReflectionRepository, Symbol.ReturnType);
+        public override TypeViewModel ReturnType => SymbolTypeViewModel.GetOrCreate(Parent.ReflectionRepository, Symbol.ReturnType);
 
         public override bool IsInternalUse => base.IsInternalUse || Symbol.DeclaredAccessibility != Accessibility.Public;
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolMethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolMethodViewModel.cs
@@ -26,7 +26,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         
         public override bool IsStatic => Symbol.IsStatic;
 
-        public override TypeViewModel ReturnType => new SymbolTypeViewModel(Symbol.ReturnType);
+        public override TypeViewModel ReturnType => new SymbolTypeViewModel(Parent.ReflectionRepository, Symbol.ReturnType);
 
         public override bool IsInternalUse => base.IsInternalUse || Symbol.DeclaredAccessibility != Accessibility.Public;
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolParameterViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolParameterViewModel.cs
@@ -13,7 +13,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public SymbolParameterViewModel(MethodViewModel parent, IParameterSymbol symbol) : base(parent)
         {
             Symbol = symbol;
-            Type = new SymbolTypeViewModel(symbol.Type);
+            Type = new SymbolTypeViewModel(parent.Parent.ReflectionRepository, symbol.Type);
         }
 
         public override string Name => Symbol.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolParameterViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolParameterViewModel.cs
@@ -13,7 +13,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public SymbolParameterViewModel(MethodViewModel parent, IParameterSymbol symbol) : base(parent)
         {
             Symbol = symbol;
-            Type = new SymbolTypeViewModel(parent.Parent.ReflectionRepository, symbol.Type);
+            Type = SymbolTypeViewModel.GetOrCreate(parent.Parent.ReflectionRepository, symbol.Type);
         }
 
         public override string Name => Symbol.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolPropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolPropertyViewModel.cs
@@ -17,7 +17,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             Parent = declaringParent;
             EffectiveParent = effectiveParent;
             Symbol = symbol;
-            Type = new SymbolTypeViewModel(Symbol.Type);
+            Type = new SymbolTypeViewModel(declaringParent.ReflectionRepository, Symbol.Type);
         }
 
         public override string Name => Symbol.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolPropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolPropertyViewModel.cs
@@ -17,7 +17,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             Parent = declaringParent;
             EffectiveParent = effectiveParent;
             Symbol = symbol;
-            Type = new SymbolTypeViewModel(declaringParent.ReflectionRepository, Symbol.Type);
+            Type = SymbolTypeViewModel.GetOrCreate(declaringParent.ReflectionRepository, Symbol.Type);
         }
 
         public override string Name => Symbol.Name;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
@@ -11,15 +11,19 @@ namespace IntelliTect.Coalesce.TypeDefinition
     {
         protected internal ITypeSymbol Symbol { get; internal set; }
 
-        public SymbolTypeViewModel(ITypeSymbol symbol)
+        public SymbolTypeViewModel(ITypeSymbol symbol) : this(null, symbol)
+        {
+        }
+
+        internal SymbolTypeViewModel(ReflectionRepository reflectionRepository, ITypeSymbol symbol) : base(reflectionRepository)
         {
             Symbol = symbol;
 
-            FirstTypeArgument = IsGeneric && NamedSymbol.Arity > 0 
-                ? new SymbolTypeViewModel(NamedSymbol.TypeArguments.First()) 
+            FirstTypeArgument = IsGeneric && NamedSymbol.Arity > 0
+                ? new SymbolTypeViewModel(reflectionRepository, NamedSymbol.TypeArguments.First())
                 : null;
 
-            ArrayType = IsArray ? new SymbolTypeViewModel(((IArrayTypeSymbol)Symbol).ElementType) : null;
+            ArrayType = IsArray ? new SymbolTypeViewModel(reflectionRepository, ((IArrayTypeSymbol)Symbol).ElementType) : null;
 
             var types = new List<INamedTypeSymbol>();
             var target = Symbol as INamedTypeSymbol;
@@ -153,7 +157,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public override TypeViewModel[] GenericArgumentsFor(Type type) =>
             GetSatisfyingBaseTypeSymbol(type)?
             .TypeArguments
-            .Select(t => new SymbolTypeViewModel(t))
+            .Select(t => new SymbolTypeViewModel(ReflectionRepository, t))
             .ToArray();
 
         public override bool IsA(Type type) => GetSatisfyingBaseTypeSymbol(type) != null;

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -10,6 +10,18 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
     public abstract class TypeViewModel : IAttributeProvider
     {
+        public TypeViewModel()
+        {
+
+        }
+
+        internal TypeViewModel(ReflectionRepository reflectionRepository) : this()
+        {
+            ReflectionRepository = reflectionRepository;
+        }
+
+        public ReflectionRepository ReflectionRepository { get; internal set; }
+
         public abstract string Name { get; }
 
         /// <summary>

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -192,7 +192,9 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         public virtual bool IsInternalUse => HasAttribute<InternalUseAttribute>();
 
-        public bool HasClassViewModel => !IsPrimitive && IsPOCO;
+        protected bool ShouldCreateClassViewModel => !IsPrimitive && IsPOCO;
+
+        public bool HasClassViewModel => ClassViewModel != null;
 
         public abstract ClassViewModel ClassViewModel { get; }
 
@@ -299,7 +301,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
         }
 
         /// <summary>
-        /// Returns true if the property is class outside the System namespace, and is not a string or array
+        /// Returns true if the type is class outside the System namespace.
         /// </summary>
         public bool IsPOCO => !IsArray && !IsCollection && !FullNamespace.StartsWith("System") && IsClass && !IsFile;
 

--- a/src/IntelliTect.Coalesce/TypeUsage/DbContextTypeUsage.cs
+++ b/src/IntelliTect.Coalesce/TypeUsage/DbContextTypeUsage.cs
@@ -22,15 +22,7 @@ namespace IntelliTect.Coalesce.TypeUsage
                 .Where(p => p.Parent.Equals(classViewModel) || !p.PureType.FullNamespace.StartsWith(nameof(Microsoft)))
 
                 .Where(p => p.Type.IsA(typeof(DbSet<>)))
-                .Select(p =>
-                {
-                    var usage = new EntityTypeUsage(this, p.PureType.ClassViewModel, p.Name);
-
-                    // TODO: can this be eliminated?
-                    usage.ClassViewModel.HasDbSet = true;
-
-                    return usage;
-                })
+                .Select(p => new EntityTypeUsage(this, p.PureType, p.Name))
                 .ToList()
                 .AsReadOnly();
 

--- a/src/IntelliTect.Coalesce/TypeUsage/EntityTypeUsage.cs
+++ b/src/IntelliTect.Coalesce/TypeUsage/EntityTypeUsage.cs
@@ -7,13 +7,19 @@ namespace IntelliTect.Coalesce.TypeUsage
 {
     public class EntityTypeUsage
     {
-        public EntityTypeUsage(DbContextTypeUsage context, ClassViewModel classViewModel, string contextPropertyName)
+        public EntityTypeUsage(DbContextTypeUsage context, TypeViewModel typeViewModel, string contextPropertyName)
         {
-            ClassViewModel = classViewModel;
+            Context = context;
+            TypeViewModel = typeViewModel;
+            ClassViewModel = typeViewModel.ClassViewModel;
             ContextPropertyName = contextPropertyName;
         }
 
-        public ClassViewModel ClassViewModel { get; }
+        public DbContextTypeUsage Context { get; }
+
+        public TypeViewModel TypeViewModel { get; }
+
+        public ClassViewModel ClassViewModel { get; } 
 
         public string ContextPropertyName { get; }
     }


### PR DESCRIPTION
 Type model improvements:
- TypeViewModels are now associated with a specific ReflectionRepository. Since all other metadata models can trace back to a TypeViewModel, all types can now access a shared ReflectionRepository instance that isn't necessarily the global one.
- ClassViewModel.HasDbSet is no longer a mutable property, but instead looks to the current ReflectionRepository of the ClassViewModel to see if the ClassViewModel has been found on a DbContext's DbSet. This has been a very long-standing TODO in Coalesce.
- QueryableExtensions methods that used to exclusively use ReflectionRepository.Global can now take a different one as a parameter. This is now done by StandardDataSource, where the existing ReflectionRepository from the CrudContext is used. This makes unit testing of crud strategies and any dependent code more reliable and consistent.
- StandardCrudStrategy now ensures that the DbContext on which it is based has been loaded into it's CrudContext's ReflectionRepository (again, to facilitate unit testing).

