### PR TITLE
Add additional string search methods

### DIFF
--- a/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
+++ b/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
@@ -58,6 +58,13 @@ namespace IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext
 
 
         public string String { get; set; }
+
+        [Search(SearchMethod = SearchAttribute.SearchMethods.Equals)]
+        public string StringSearchedEqualsInsensitive { get; set; }
+
+        [Search(SearchMethod = SearchAttribute.SearchMethods.EqualsNatural)]
+        public string StringSearchedEqualsNatural { get; set; }
+
         public int Int { get; set; }
         public int? IntNullable { get; set; }
         public decimal? DecimalNullable { get; set; }

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
@@ -116,6 +116,40 @@ namespace IntelliTect.Coalesce.Tests.Api
         }
 
         [Theory]
+        [InlineData(true, "a1", "a1")]
+        [InlineData(true, "A1", "a1")]
+        [InlineData(true, "a1", "A1")]
+        [InlineData(false, "a1b", "a1")]
+        public void Search_StringEqualsInsensitive_SearchesCorrectly(
+            bool shouldMatch, string propValue, string inputValue)
+        {
+            // Note about this test: the above tests cases should fail when
+            // casing matches because all these tests evaluate in memory.
+            SearchHelper(
+                (ComplexModel t) => t.StringSearchedEqualsInsensitive,
+                inputValue,
+                propValue,
+                shouldMatch);
+        }
+
+        [Theory]
+        [InlineData(true, "a1", "a1")]
+        [InlineData(false, "A1", "a1")]
+        [InlineData(false, "a1", "A1")]
+        [InlineData(false, "a1b", "a1")]
+        public void Search_StringEqualsNatural_SearchesCorrectly(
+            bool shouldMatch, string propValue, string inputValue)
+        {
+            // Note about this test: the above tests cases should fail when
+            // casing matches because all these tests evaluate in memory.
+            SearchHelper(
+                (ComplexModel t) => t.StringSearchedEqualsNatural,
+                inputValue,
+                propValue,
+                shouldMatch);
+        }
+
+        [Theory]
         [InlineData(true, 0, "0")]
         [InlineData(true, int.MaxValue, "2147483647")]
         [InlineData(false, int.MaxValue, "2147483648")]

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
@@ -123,8 +123,6 @@ namespace IntelliTect.Coalesce.Tests.Api
         public void Search_StringEqualsInsensitive_SearchesCorrectly(
             bool shouldMatch, string propValue, string inputValue)
         {
-            // Note about this test: the above tests cases should fail when
-            // casing matches because all these tests evaluate in memory.
             SearchHelper(
                 (ComplexModel t) => t.StringSearchedEqualsInsensitive,
                 inputValue,

--- a/src/IntelliTect.Coalesce/DataAnnotations/SearchAttribute.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/SearchAttribute.cs
@@ -14,8 +14,37 @@ namespace IntelliTect.Coalesce.DataAnnotations
     {
         public enum SearchMethods
         {
+            /// <summary>
+            /// Search term will be checked for at the beginning of the field's value in a case insensitive manner.
+            /// </summary>
             BeginsWith = 1,
-            Contains = 2
+
+            /// <summary>
+            /// Search term will be checked for anywhere inside the field's value in a case insensitive manner.
+            /// </summary>
+            Contains = 2,
+
+            /// <summary>
+            /// Search term must match the field exactly in a case insensitive manner.
+            /// </summary>
+            Equals = 3,
+
+            /// <summary>
+            /// <para>
+            /// Search term must match exactly, using the natural casing handling of the evaulation envrionment.
+            /// </para>
+            /// 
+            /// <para>
+            /// Default database collation will be used if evaluated in SQL,
+            /// and exact casing will be used if evaluated in memory.
+            /// </para>
+            /// 
+            /// <para>
+            /// This allows index seeks to be used instead of index scans,
+            /// providing extra high performance searches against indexed columns.
+            /// </para>
+            /// </summary>
+            EqualsNatural = 4,
         };
 
         /// <summary>
@@ -24,7 +53,13 @@ namespace IntelliTect.Coalesce.DataAnnotations
         public bool IsSplitOnSpaces { get; set; } = true;
 
         /// <summary>
-        /// Specifies whether the value of the field will be checked using 'Contains' or using 'BeginsWith'.
+        /// <para>
+        /// Specifies how string columns are searched. See individual enum members for details.
+        /// </para>
+        /// <para>
+        /// Has no effect on non-string values. Numbers, GUIDs, and enums are always searched with exact values. 
+        /// Dates are searched with lower and upper bounds if the user input could be parsed as a partial or complete date.
+        /// </para>
         /// </summary>
         public SearchMethods SearchMethod { get; set; } = SearchMethods.BeginsWith;
 

--- a/src/IntelliTect.Coalesce/DataAnnotations/SearchAttribute.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/SearchAttribute.cs
@@ -31,7 +31,7 @@ namespace IntelliTect.Coalesce.DataAnnotations
 
             /// <summary>
             /// <para>
-            /// Search term must match exactly, using the natural casing handling of the evaulation envrionment.
+            /// Search term must match exactly, using the natural casing handling of the evaluation environment.
             /// </para>
             /// 
             /// <para>

--- a/src/IntelliTect.Coalesce/TypeDefinition/PropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/PropertyViewModel.cs
@@ -349,9 +349,13 @@ namespace IntelliTect.Coalesce.TypeDefinition
         /// <summary>
         /// Returns the Linq.Dynamic-interpretable string representation of the method invocation that will perform search on the property.
         /// </summary>
-        public string SearchMethodCall => SearchMethod == SearchAttribute.SearchMethods.Contains
-            ? @"ToLower().IndexOf((""{0}"").ToLower()) >= 0"
-            : @"ToLower().StartsWith((""{0}"").ToLower())";
+        public string SearchMethodCall => SearchMethod switch {
+            SearchAttribute.SearchMethods.Contains => @"ToLower().IndexOf((""{0}"").ToLower()) >= 0",
+            SearchAttribute.SearchMethods.BeginsWith => @"ToLower().StartsWith((""{0}"").ToLower())",
+            SearchAttribute.SearchMethods.Equals => @"ToLower().Equals((""{0}"").ToLower())",
+            SearchAttribute.SearchMethods.EqualsNatural => @"Equals(""{0}"")",
+            _ => throw new InvalidOperationException()
+        };
 
         /// <summary>
         /// True if the search term should be split on spaces and evaluated individually with or.


### PR DESCRIPTION
Added two new `SearchMethods` values:
- `Equals` - Search term must match the field exactly in a case insensitive manner.
- `EqualsNatural` - Search term must match exactly, using the natural casing handling of the evaluation environment. Default database collation will be used if evaluated in SQL, and exact casing will be used if evaluated in memory. This allows index seeks to be used instead of index scans, providing extra high performance searches against exact values in indexed columns.