### PR TITLE
Add GetQueryAsync to StandardDataSource

### DIFF
--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/StandardDataSourceTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/StandardDataSourceTests.cs
@@ -11,6 +11,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace IntelliTect.Coalesce.Tests.Api.DataSources
@@ -34,6 +35,15 @@ namespace IntelliTect.Coalesce.Tests.Api.DataSources
         public void GetQuery_WhenIncludesStringNone_DoesNotIncludeChildren(string includes)
         {
             var query = Source<Case>().GetQuery(new DataSourceParameters { Includes = includes });
+            Assert.Empty(query.GetIncludeTree());
+        }
+
+        [Theory]
+        [InlineData("none")]
+        [InlineData("NONE")]
+        public async Task GetQueryAsync_WhenIncludesStringNone_DoesNotIncludeChildren(string includes)
+        {
+            var query = await Source<Case>().GetQueryAsync(new DataSourceParameters { Includes = includes });
             Assert.Empty(query.GetIncludeTree());
         }
 

--- a/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/StandardDataSource.cs
@@ -64,7 +64,14 @@ namespace IntelliTect.Coalesce
         /// Get the initial query that will be compounded upon with various other
         /// clauses in order to ultimately retrieve the final resulting data.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The initial query.</returns>
+        public virtual Task<IQueryable<T>> GetQueryAsync(IDataSourceParameters parameters) => Task.FromResult(GetQuery(parameters));
+
+        /// <summary>
+        /// Get the initial query that will be compounded upon with various other
+        /// clauses in order to ultimately retrieve the final resulting data.
+        /// </summary>
+        /// <returns>The initial query.</returns>
         public virtual IQueryable<T> GetQuery(IDataSourceParameters parameters)
         {
             IQueryable<T> query = Db.Set<T>();
@@ -639,7 +646,7 @@ namespace IntelliTect.Coalesce
         /// and an IncludeTree to be used when mapping/serializing the data.</returns>
         public virtual async Task<(ListResult<T> List, IncludeTree? IncludeTree)> GetListAsync(IListParameters parameters)
         {
-            var query = GetQuery(parameters);
+            var query = await GetQueryAsync(parameters);
 
             query = ApplyListFiltering(query, parameters);
 
@@ -714,7 +721,7 @@ namespace IntelliTect.Coalesce
         /// and an IncludeTree to be used when mapping/serializing the item.</returns>
         public virtual async Task<(ItemResult<T> Item, IncludeTree? IncludeTree)> GetItemAsync(object id, IDataSourceParameters parameters)
         {
-            var query = GetQuery(parameters);
+            var query = await GetQueryAsync(parameters);
             T result = await EvaluateItemQueryAsync(id, query);
 
             if (result == null)
@@ -753,7 +760,7 @@ namespace IntelliTect.Coalesce
 
         public virtual async Task<ItemResult<int>> GetCountAsync(IFilterParameters parameters)
         {
-            var query = GetQuery(parameters);
+            var query = await GetQueryAsync(parameters);
             query = ApplyListFiltering(query, parameters);
 
             return new ItemResult<int>(await GetListTotalCountAsync(query, parameters));


### PR DESCRIPTION
- I needed to make an async call from `GetQuery`.
- Follows the same pattern used by `StandardBehaviors`.