### PR TITLE
Use GetQueryAsync in ProjectedDtoDataSource

### DIFF
--- a/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/ProjectedDtoDataSource.cs
@@ -56,7 +56,7 @@ namespace IntelliTect.Coalesce
         {
             AssertTMatchesTDto<TRequestedDto>();
 
-            var query = GetQuery(parameters);
+            var query = await GetQueryAsync(parameters);
             var canUseAsync = CanEvalQueryAsynchronously(query);
             var projectedQuery = ApplyProjection(query, parameters);
             TDto mappedResult = canUseAsync 
@@ -81,7 +81,7 @@ namespace IntelliTect.Coalesce
         {
             AssertTMatchesTDto<TRequestedDto>();
 
-            var query = GetQuery(parameters);
+            var query = await GetQueryAsync(parameters);
 
             query = ApplyListFiltering(query, parameters);
 


### PR DESCRIPTION
I forgot this in #174, causing `GetQueryAsync()` to not work for projected data sources.