### PR TITLE
(Knockout) Make generated tables responsive and add UI indicating sortable

### DIFF
--- a/src/Coalesce.Web/Views/Generated/Case/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Case/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-case">
     <div class="table-view-header">
@@ -66,169 +69,191 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                            Title
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Title', 'fa-caret-down': orderByDescending() == 'Title'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
-                            Description
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Description', 'fa-caret-down': orderByDescending() == 'Description'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('OpenedAt')}">
-                            Opened At
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'OpenedAt', 'fa-caret-down': orderByDescending() == 'OpenedAt'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedTo')}">
-                            Assigned To
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'AssignedTo', 'fa-caret-down': orderByDescending() == 'AssignedTo'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('ReportedBy')}">
-                            Reported By
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'ReportedBy', 'fa-caret-down': orderByDescending() == 'ReportedBy'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Image')}">
-                            Image
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Image', 'fa-caret-down': orderByDescending() == 'Image'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageName')}">
-                            Image Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'ImageName', 'fa-caret-down': orderByDescending() == 'ImageName'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageSize')}">
-                            Image Size
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'ImageSize', 'fa-caret-down': orderByDescending() == 'ImageSize'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageHash')}">
-                            Image Hash
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'ImageHash', 'fa-caret-down': orderByDescending() == 'ImageHash'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Attachment')}">
-                            Attachment
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Attachment', 'fa-caret-down': orderByDescending() == 'Attachment'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('AttachmentName')}">
-                            Attachment Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'AttachmentName', 'fa-caret-down': orderByDescending() == 'AttachmentName'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('PlainAttachment')}">
-                            Plain Attachment
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'PlainAttachment', 'fa-caret-down': orderByDescending() == 'PlainAttachment'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedUploadAttachment')}">
-                            Restricted Upload Attachment
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'RestrictedUploadAttachment', 'fa-caret-down': orderByDescending() == 'RestrictedUploadAttachment'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedDownloadAttachment')}">
-                            Restricted Download Attachment
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'RestrictedDownloadAttachment', 'fa-caret-down': orderByDescending() == 'RestrictedDownloadAttachment'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedMetaAttachment')}">
-                            Restricted Meta Attachment
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'RestrictedMetaAttachment', 'fa-caret-down': orderByDescending() == 'RestrictedMetaAttachment'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Severity')}">
-                            Severity
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Severity', 'fa-caret-down': orderByDescending() == 'Severity'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Status')}">
-                            Status
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Status', 'fa-caret-down': orderByDescending() == 'Status'}"></i>
-                        </th>
-                        <th>Case Products</th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssignedId')}">
-                            Dev Team Assigned Id
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'DevTeamAssignedId', 'fa-caret-down': orderByDescending() == 'DevTeamAssignedId'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssigned')}">
-                            Dev Team Assigned
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'DevTeamAssigned', 'fa-caret-down': orderByDescending() == 'DevTeamAssigned'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Duration')}">
-                            Duration
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Duration', 'fa-caret-down': orderByDescending() == 'Duration'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseKey}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Title))</td>
-                            <td class="prop-description">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Description))</td>
-                            <td class="prop-openedAt">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.OpenedAt))</td>
-                            <td class="prop-assignedTo">@(Knockout.SelectForObject<Coalesce.Domain.Case>(p => p.AssignedTo))</td>
-                            <td class="prop-reportedBy">@(Knockout.SelectForObject<Coalesce.Domain.Case>(p => p.ReportedBy))</td>
-                            <td class="prop-image">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Image))</td>
-                            <td class="prop-imageName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageName, true))</td>
-                            <td class="prop-imageSize">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.ImageSize))</td>
-                            <td class="prop-imageHash">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.ImageHash))</td>
-                            <td class="prop-attachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Attachment))</td>
-                            <td class="prop-attachmentName">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.AttachmentName))</td>
-                            <td class="prop-plainAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.PlainAttachment))</td>
-                            <td class="prop-restrictedUploadAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.RestrictedUploadAttachment))</td>
-                            <td class="prop-restrictedDownloadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedDownloadAttachment, true))</td>
-                            <td class="prop-restrictedMetaAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.RestrictedMetaAttachment))</td>
-                            <td class="prop-severity">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Severity))</td>
-                            <td class="prop-status">@(Knockout.SelectFor<Coalesce.Domain.Case>(p => p.Status))</td>
-                            <td class="prop-caseProducts">@(Knockout.SelectForManyToMany<Coalesce.Domain.Case>(p => p.CaseProducts))</td>
-                            <td class="prop-devTeamAssignedId">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.DevTeamAssignedId))</td>
-                            <td class="prop-devTeamAssigned">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.DevTeamAssigned))</td>
-                            <td class="prop-duration">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Duration))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Title, true))</td>
-                            <td class="prop-description">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Description, true))</td>
-                            <td class="prop-openedAt">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.OpenedAt, true))</td>
-                            <td class="prop-assignedTo">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.AssignedTo, true))</td>
-                            <td class="prop-reportedBy">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ReportedBy, true))</td>
-                            <td class="prop-image">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Image, true))</td>
-                            <td class="prop-imageName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageName, true))</td>
-                            <td class="prop-imageSize">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageSize, true))</td>
-                            <td class="prop-imageHash">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageHash, true))</td>
-                            <td class="prop-attachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Attachment, true))</td>
-                            <td class="prop-attachmentName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.AttachmentName, true))</td>
-                            <td class="prop-plainAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.PlainAttachment, true))</td>
-                            <td class="prop-restrictedUploadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedUploadAttachment, true))</td>
-                            <td class="prop-restrictedDownloadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedDownloadAttachment, true))</td>
-                            <td class="prop-restrictedMetaAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedMetaAttachment, true))</td>
-                            <td class="prop-severity">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Severity, true))</td>
-                            <td class="prop-status">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Status, true))</td>
-                            <td class="prop-caseProducts">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.CaseProducts, true))</td>
-                            <td class="prop-devTeamAssignedId">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.DevTeamAssignedId, true))</td>
-                            <td class="prop-devTeamAssigned">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.DevTeamAssigned, true))</td>
-                            <td class="prop-duration">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Duration, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <!-- Action buttons -->
-                                <div class="btn-group" role="group">
-                                    <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        Actions <span class="caret"></span>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
+                                <span>Title&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
+                                <span>Description&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Description' ? 'fa-caret-up' : orderByDescending() == 'Description' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('OpenedAt')}">
+                                <span>Opened At&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'OpenedAt' ? 'fa-caret-up' : orderByDescending() == 'OpenedAt' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedTo')}">
+                                <span>Assigned To&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'AssignedTo' ? 'fa-caret-up' : orderByDescending() == 'AssignedTo' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('ReportedBy')}">
+                                <span>Reported By&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'ReportedBy' ? 'fa-caret-up' : orderByDescending() == 'ReportedBy' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Image')}">
+                                <span>Image&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Image' ? 'fa-caret-up' : orderByDescending() == 'Image' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageName')}">
+                                <span>Image Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'ImageName' ? 'fa-caret-up' : orderByDescending() == 'ImageName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageSize')}">
+                                <span>Image Size&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'ImageSize' ? 'fa-caret-up' : orderByDescending() == 'ImageSize' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageHash')}">
+                                <span>Image Hash&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'ImageHash' ? 'fa-caret-up' : orderByDescending() == 'ImageHash' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Attachment')}">
+                                <span>Attachment&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Attachment' ? 'fa-caret-up' : orderByDescending() == 'Attachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('AttachmentName')}">
+                                <span>Attachment Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'AttachmentName' ? 'fa-caret-up' : orderByDescending() == 'AttachmentName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('PlainAttachment')}">
+                                <span>Plain Attachment&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'PlainAttachment' ? 'fa-caret-up' : orderByDescending() == 'PlainAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedUploadAttachment')}">
+                                <span>Restricted Upload Attachment&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'RestrictedUploadAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedUploadAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedDownloadAttachment')}">
+                                <span>Restricted Download Attachment&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'RestrictedDownloadAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedDownloadAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedMetaAttachment')}">
+                                <span>Restricted Meta Attachment&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'RestrictedMetaAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedMetaAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Severity')}">
+                                <span>Severity&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Severity' ? 'fa-caret-up' : orderByDescending() == 'Severity' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Status')}">
+                                <span>Status&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Status' ? 'fa-caret-up' : orderByDescending() == 'Status' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th>Case Products</th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssignedId')}">
+                                <span>Dev Team Assigned Id&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'DevTeamAssignedId' ? 'fa-caret-up' : orderByDescending() == 'DevTeamAssignedId' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssigned')}">
+                                <span>Dev Team Assigned&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'DevTeamAssigned' ? 'fa-caret-up' : orderByDescending() == 'DevTeamAssigned' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Duration')}">
+                                <span>Duration&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Duration' ? 'fa-caret-up' : orderByDescending() == 'Duration' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseKey}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Title))</td>
+                                <td class="prop-description">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Description))</td>
+                                <td class="prop-openedAt">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.OpenedAt))</td>
+                                <td class="prop-assignedTo">@(Knockout.SelectForObject<Coalesce.Domain.Case>(p => p.AssignedTo))</td>
+                                <td class="prop-reportedBy">@(Knockout.SelectForObject<Coalesce.Domain.Case>(p => p.ReportedBy))</td>
+                                <td class="prop-image">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Image))</td>
+                                <td class="prop-imageName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageName, true))</td>
+                                <td class="prop-imageSize">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.ImageSize))</td>
+                                <td class="prop-imageHash">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.ImageHash))</td>
+                                <td class="prop-attachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Attachment))</td>
+                                <td class="prop-attachmentName">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.AttachmentName))</td>
+                                <td class="prop-plainAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.PlainAttachment))</td>
+                                <td class="prop-restrictedUploadAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.RestrictedUploadAttachment))</td>
+                                <td class="prop-restrictedDownloadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedDownloadAttachment, true))</td>
+                                <td class="prop-restrictedMetaAttachment">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.RestrictedMetaAttachment))</td>
+                                <td class="prop-severity">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Severity))</td>
+                                <td class="prop-status">@(Knockout.SelectFor<Coalesce.Domain.Case>(p => p.Status))</td>
+                                <td class="prop-caseProducts">@(Knockout.SelectForManyToMany<Coalesce.Domain.Case>(p => p.CaseProducts))</td>
+                                <td class="prop-devTeamAssignedId">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.DevTeamAssignedId))</td>
+                                <td class="prop-devTeamAssigned">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.DevTeamAssigned))</td>
+                                <td class="prop-duration">@(Knockout.InputFor<Coalesce.Domain.Case>(p => p.Duration))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Title, true))</td>
+                                <td class="prop-description">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Description, true))</td>
+                                <td class="prop-openedAt">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.OpenedAt, true))</td>
+                                <td class="prop-assignedTo">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.AssignedTo, true))</td>
+                                <td class="prop-reportedBy">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ReportedBy, true))</td>
+                                <td class="prop-image">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Image, true))</td>
+                                <td class="prop-imageName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageName, true))</td>
+                                <td class="prop-imageSize">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageSize, true))</td>
+                                <td class="prop-imageHash">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.ImageHash, true))</td>
+                                <td class="prop-attachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Attachment, true))</td>
+                                <td class="prop-attachmentName">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.AttachmentName, true))</td>
+                                <td class="prop-plainAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.PlainAttachment, true))</td>
+                                <td class="prop-restrictedUploadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedUploadAttachment, true))</td>
+                                <td class="prop-restrictedDownloadAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedDownloadAttachment, true))</td>
+                                <td class="prop-restrictedMetaAttachment">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.RestrictedMetaAttachment, true))</td>
+                                <td class="prop-severity">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Severity, true))</td>
+                                <td class="prop-status">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Status, true))</td>
+                                <td class="prop-caseProducts">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.CaseProducts, true))</td>
+                                <td class="prop-devTeamAssignedId">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.DevTeamAssignedId, true))</td>
+                                <td class="prop-devTeamAssigned">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.DevTeamAssigned, true))</td>
+                                <td class="prop-duration">@(Knockout.DisplayFor<Coalesce.Domain.Case>(p => p.Duration, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <!-- Action buttons -->
+                                    <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            Actions <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="#" data-bind='click: function(){ uploadAttachment.invokeWithPrompts() }'>Upload Attachment</a></li>
+                                            <li><a href="#" data-bind='click: function(){ uploadByteArray.invokeWithPrompts() }'>Upload Byte Array</a></li>
+                                        </ul>
+                                    </div>
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
                                     </button>
-                                    <ul class="dropdown-menu">
-                                        <li><a href="#" data-bind='click: function(){ uploadAttachment.invokeWithPrompts() }'>Upload Attachment</a></li>
-                                        <li><a href="#" data-bind='click: function(){ uploadByteArray.invokeWithPrompts() }'>Upload Byte Array</a></li>
-                                    </ul>
                                 </div>
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/Case/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Case/Table.cshtml
@@ -74,105 +74,85 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                                <span>Title&nbsp;&nbsp;
+                                Title
                                 <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
-                                <span>Description&nbsp;&nbsp;
+                                Description
                                 <i class="fa" data-bind="css: orderBy() == 'Description' ? 'fa-caret-up' : orderByDescending() == 'Description' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('OpenedAt')}">
-                                <span>Opened At&nbsp;&nbsp;
+                                Opened At
                                 <i class="fa" data-bind="css: orderBy() == 'OpenedAt' ? 'fa-caret-up' : orderByDescending() == 'OpenedAt' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedTo')}">
-                                <span>Assigned To&nbsp;&nbsp;
+                                Assigned To
                                 <i class="fa" data-bind="css: orderBy() == 'AssignedTo' ? 'fa-caret-up' : orderByDescending() == 'AssignedTo' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('ReportedBy')}">
-                                <span>Reported By&nbsp;&nbsp;
+                                Reported By
                                 <i class="fa" data-bind="css: orderBy() == 'ReportedBy' ? 'fa-caret-up' : orderByDescending() == 'ReportedBy' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Image')}">
-                                <span>Image&nbsp;&nbsp;
+                                Image
                                 <i class="fa" data-bind="css: orderBy() == 'Image' ? 'fa-caret-up' : orderByDescending() == 'Image' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageName')}">
-                                <span>Image Name&nbsp;&nbsp;
+                                Image Name
                                 <i class="fa" data-bind="css: orderBy() == 'ImageName' ? 'fa-caret-up' : orderByDescending() == 'ImageName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageSize')}">
-                                <span>Image Size&nbsp;&nbsp;
+                                Image Size
                                 <i class="fa" data-bind="css: orderBy() == 'ImageSize' ? 'fa-caret-up' : orderByDescending() == 'ImageSize' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('ImageHash')}">
-                                <span>Image Hash&nbsp;&nbsp;
+                                Image Hash
                                 <i class="fa" data-bind="css: orderBy() == 'ImageHash' ? 'fa-caret-up' : orderByDescending() == 'ImageHash' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Attachment')}">
-                                <span>Attachment&nbsp;&nbsp;
+                                Attachment
                                 <i class="fa" data-bind="css: orderBy() == 'Attachment' ? 'fa-caret-up' : orderByDescending() == 'Attachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('AttachmentName')}">
-                                <span>Attachment Name&nbsp;&nbsp;
+                                Attachment Name
                                 <i class="fa" data-bind="css: orderBy() == 'AttachmentName' ? 'fa-caret-up' : orderByDescending() == 'AttachmentName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('PlainAttachment')}">
-                                <span>Plain Attachment&nbsp;&nbsp;
+                                Plain Attachment
                                 <i class="fa" data-bind="css: orderBy() == 'PlainAttachment' ? 'fa-caret-up' : orderByDescending() == 'PlainAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedUploadAttachment')}">
-                                <span>Restricted Upload Attachment&nbsp;&nbsp;
+                                Restricted Upload Attachment
                                 <i class="fa" data-bind="css: orderBy() == 'RestrictedUploadAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedUploadAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedDownloadAttachment')}">
-                                <span>Restricted Download Attachment&nbsp;&nbsp;
+                                Restricted Download Attachment
                                 <i class="fa" data-bind="css: orderBy() == 'RestrictedDownloadAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedDownloadAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('RestrictedMetaAttachment')}">
-                                <span>Restricted Meta Attachment&nbsp;&nbsp;
+                                Restricted Meta Attachment
                                 <i class="fa" data-bind="css: orderBy() == 'RestrictedMetaAttachment' ? 'fa-caret-up' : orderByDescending() == 'RestrictedMetaAttachment' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Severity')}">
-                                <span>Severity&nbsp;&nbsp;
+                                Severity
                                 <i class="fa" data-bind="css: orderBy() == 'Severity' ? 'fa-caret-up' : orderByDescending() == 'Severity' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Status')}">
-                                <span>Status&nbsp;&nbsp;
+                                Status
                                 <i class="fa" data-bind="css: orderBy() == 'Status' ? 'fa-caret-up' : orderByDescending() == 'Status' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th>Case Products</th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssignedId')}">
-                                <span>Dev Team Assigned Id&nbsp;&nbsp;
+                                Dev Team Assigned Id
                                 <i class="fa" data-bind="css: orderBy() == 'DevTeamAssignedId' ? 'fa-caret-up' : orderByDescending() == 'DevTeamAssignedId' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('DevTeamAssigned')}">
-                                <span>Dev Team Assigned&nbsp;&nbsp;
+                                Dev Team Assigned
                                 <i class="fa" data-bind="css: orderBy() == 'DevTeamAssigned' ? 'fa-caret-up' : orderByDescending() == 'DevTeamAssigned' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Duration')}">
-                                <span>Duration&nbsp;&nbsp;
+                                Duration
                                 <i class="fa" data-bind="css: orderBy() == 'Duration' ? 'fa-caret-up' : orderByDescending() == 'Duration' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/CaseDto/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseDto/Table.cshtml
@@ -74,14 +74,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                                <span>Title&nbsp;&nbsp;
+                                Title
                                 <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedToName')}">
-                                <span>Assigned To Name&nbsp;&nbsp;
+                                Assigned To Name
                                 <i class="fa" data-bind="css: orderBy() == 'AssignedToName' ? 'fa-caret-up' : orderByDescending() == 'AssignedToName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/CaseDto/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseDto/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-caseDto">
     <div class="table-view-header">
@@ -66,57 +69,61 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                            Title
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Title', 'fa-caret-down': orderByDescending() == 'Title'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedToName')}">
-                            Assigned To Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'AssignedToName', 'fa-caret-down': orderByDescending() == 'AssignedToName'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.CaseDto>(p => p.Title))</td>
-                            <td class="prop-assignedToName">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.AssignedToName, true))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.Title, true))</td>
-                            <td class="prop-assignedToName">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.AssignedToName, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <!-- Action buttons -->
-                                <div class="btn-group" role="group">
-                                    <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        Actions <span class="caret"></span>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
+                                <span>Title&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('AssignedToName')}">
+                                <span>Assigned To Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'AssignedToName' ? 'fa-caret-up' : orderByDescending() == 'AssignedToName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.CaseDto>(p => p.Title))</td>
+                                <td class="prop-assignedToName">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.AssignedToName, true))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.Title, true))</td>
+                                <td class="prop-assignedToName">@(Knockout.DisplayFor<Coalesce.Domain.CaseDto>(p => p.AssignedToName, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <!-- Action buttons -->
+                                    <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            Actions <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="#" data-bind='click: function(){ asyncMethodOnIClassDto.invokeWithPrompts() }'>Async Method On I Class Dto</a></li>
+                                        </ul>
+                                    </div>
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
                                     </button>
-                                    <ul class="dropdown-menu">
-                                        <li><a href="#" data-bind='click: function(){ asyncMethodOnIClassDto.invokeWithPrompts() }'>Async Method On I Class Dto</a></li>
-                                    </ul>
                                 </div>
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/CaseDtoStandalone/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseDtoStandalone/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-caseDtoStandalone">
     <div class="table-view-header">
@@ -66,42 +69,45 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                            Title
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Title', 'fa-caret-down': orderByDescending() == 'Title'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.CaseDtoStandalone>(p => p.Title))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.CaseDtoStandalone>(p => p.Title, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
+                                <span>Title&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-title">@(Knockout.InputFor<Coalesce.Domain.CaseDtoStandalone>(p => p.Title))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.CaseDtoStandalone>(p => p.Title, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/CaseDtoStandalone/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseDtoStandalone/Table.cshtml
@@ -74,9 +74,8 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                                <span>Title&nbsp;&nbsp;
+                                Title
                                 <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/CaseProduct/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseProduct/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-caseProduct">
     <div class="table-view-header">
@@ -66,48 +69,52 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Case')}">
-                            Case
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Case', 'fa-caret-down': orderByDescending() == 'Case'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Product')}">
-                            Product
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Product', 'fa-caret-down': orderByDescending() == 'Product'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseProductId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-case">@(Knockout.SelectForObject<Coalesce.Domain.CaseProduct>(p => p.Case))</td>
-                            <td class="prop-product">@(Knockout.SelectForObject<Coalesce.Domain.CaseProduct>(p => p.Product))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-case">@(Knockout.DisplayFor<Coalesce.Domain.CaseProduct>(p => p.Case, true))</td>
-                            <td class="prop-product">@(Knockout.DisplayFor<Coalesce.Domain.CaseProduct>(p => p.Product, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Case')}">
+                                <span>Case&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Case' ? 'fa-caret-up' : orderByDescending() == 'Case' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Product')}">
+                                <span>Product&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Product' ? 'fa-caret-up' : orderByDescending() == 'Product' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: caseProductId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-case">@(Knockout.SelectForObject<Coalesce.Domain.CaseProduct>(p => p.Case))</td>
+                                <td class="prop-product">@(Knockout.SelectForObject<Coalesce.Domain.CaseProduct>(p => p.Product))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-case">@(Knockout.DisplayFor<Coalesce.Domain.CaseProduct>(p => p.Case, true))</td>
+                                <td class="prop-product">@(Knockout.DisplayFor<Coalesce.Domain.CaseProduct>(p => p.Product, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/CaseProduct/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/CaseProduct/Table.cshtml
@@ -74,14 +74,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Case')}">
-                                <span>Case&nbsp;&nbsp;
+                                Case
                                 <i class="fa" data-bind="css: orderBy() == 'Case' ? 'fa-caret-up' : orderByDescending() == 'Case' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Product')}">
-                                <span>Product&nbsp;&nbsp;
+                                Product
                                 <i class="fa" data-bind="css: orderBy() == 'Product' ? 'fa-caret-up' : orderByDescending() == 'Product' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/Company/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Company/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-company">
     <div class="table-view-header">
@@ -65,75 +68,83 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                            Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Name', 'fa-caret-down': orderByDescending() == 'Name'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Address1')}">
-                            Address1
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Address1', 'fa-caret-down': orderByDescending() == 'Address1'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Address2')}">
-                            Address2
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Address2', 'fa-caret-down': orderByDescending() == 'Address2'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
-                            State
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'State', 'fa-caret-down': orderByDescending() == 'State'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('IsDeleted')}">
-                            Is Deleted
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'IsDeleted', 'fa-caret-down': orderByDescending() == 'IsDeleted'}"></i>
-                        </th>
-                        <th>Employees</th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('AltName')}">
-                            Alt Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'AltName', 'fa-caret-down': orderByDescending() == 'AltName'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: companyId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Name))</td>
-                            <td class="prop-address1">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Address1))</td>
-                            <td class="prop-address2">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Address2))</td>
-                            <td class="prop-state">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.State))</td>
-                            <td class="prop-isDeleted">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.IsDeleted))</td>
-                            <td class="prop-employees"><a data-bind='attr: {href: employeesListUrl}, text: employees().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-altName">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.AltName, true))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Name, true))</td>
-                            <td class="prop-address1">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Address1, true))</td>
-                            <td class="prop-address2">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Address2, true))</td>
-                            <td class="prop-state">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.State, true))</td>
-                            <td class="prop-isDeleted">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.IsDeleted, true))</td>
-                            <td class="prop-employees"><a data-bind='attr: {href: employeesListUrl}, text: employees().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-altName">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.AltName, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
+                                <span>Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Address1')}">
+                                <span>Address1&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Address1' ? 'fa-caret-up' : orderByDescending() == 'Address1' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Address2')}">
+                                <span>Address2&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Address2' ? 'fa-caret-up' : orderByDescending() == 'Address2' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
+                                <span>State&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'State' ? 'fa-caret-up' : orderByDescending() == 'State' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('IsDeleted')}">
+                                <span>Is Deleted&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'IsDeleted' ? 'fa-caret-up' : orderByDescending() == 'IsDeleted' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th>Employees</th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('AltName')}">
+                                <span>Alt Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'AltName' ? 'fa-caret-up' : orderByDescending() == 'AltName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: companyId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Name))</td>
+                                <td class="prop-address1">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Address1))</td>
+                                <td class="prop-address2">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.Address2))</td>
+                                <td class="prop-state">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.State))</td>
+                                <td class="prop-isDeleted">@(Knockout.InputFor<Coalesce.Domain.Company>(p => p.IsDeleted))</td>
+                                <td class="prop-employees"><a data-bind='attr: {href: employeesListUrl}, text: employees().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-altName">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.AltName, true))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Name, true))</td>
+                                <td class="prop-address1">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Address1, true))</td>
+                                <td class="prop-address2">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.Address2, true))</td>
+                                <td class="prop-state">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.State, true))</td>
+                                <td class="prop-isDeleted">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.IsDeleted, true))</td>
+                                <td class="prop-employees"><a data-bind='attr: {href: employeesListUrl}, text: employees().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-altName">@(Knockout.DisplayFor<Coalesce.Domain.Company>(p => p.AltName, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/Company/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Company/Table.cshtml
@@ -73,35 +73,29 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                                <span>Name&nbsp;&nbsp;
+                                Name
                                 <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Address1')}">
-                                <span>Address1&nbsp;&nbsp;
+                                Address1
                                 <i class="fa" data-bind="css: orderBy() == 'Address1' ? 'fa-caret-up' : orderByDescending() == 'Address1' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Address2')}">
-                                <span>Address2&nbsp;&nbsp;
+                                Address2
                                 <i class="fa" data-bind="css: orderBy() == 'Address2' ? 'fa-caret-up' : orderByDescending() == 'Address2' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
-                                <span>State&nbsp;&nbsp;
+                                State
                                 <i class="fa" data-bind="css: orderBy() == 'State' ? 'fa-caret-up' : orderByDescending() == 'State' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('IsDeleted')}">
-                                <span>Is Deleted&nbsp;&nbsp;
+                                Is Deleted
                                 <i class="fa" data-bind="css: orderBy() == 'IsDeleted' ? 'fa-caret-up' : orderByDescending() == 'IsDeleted' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th>Employees</th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('AltName')}">
-                                <span>Alt Name&nbsp;&nbsp;
+                                Alt Name
                                 <i class="fa" data-bind="css: orderBy() == 'AltName' ? 'fa-caret-up' : orderByDescending() == 'AltName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/Log/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Log/Table.cshtml
@@ -69,14 +69,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Level')}">
-                                <span>Level&nbsp;&nbsp;
+                                Level
                                 <i class="fa" data-bind="css: orderBy() == 'Level' ? 'fa-caret-up' : orderByDescending() == 'Level' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Message')}">
-                                <span>Message&nbsp;&nbsp;
+                                Message
                                 <i class="fa" data-bind="css: orderBy() == 'Message' ? 'fa-caret-up' : orderByDescending() == 'Message' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/Log/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Log/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-log">
     <div class="table-view-header">
@@ -61,42 +64,46 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Level')}">
-                            Level
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Level', 'fa-caret-down': orderByDescending() == 'Level'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Message')}">
-                            Message
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Message', 'fa-caret-down': orderByDescending() == 'Message'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: logId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-level">@(Knockout.InputFor<Coalesce.Domain.Log>(p => p.Level))</td>
-                            <td class="prop-message">@(Knockout.InputFor<Coalesce.Domain.Log>(p => p.Message))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-level">@(Knockout.DisplayFor<Coalesce.Domain.Log>(p => p.Level, true))</td>
-                            <td class="prop-message">@(Knockout.DisplayFor<Coalesce.Domain.Log>(p => p.Message, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Level')}">
+                                <span>Level&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Level' ? 'fa-caret-up' : orderByDescending() == 'Level' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Message')}">
+                                <span>Message&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Message' ? 'fa-caret-up' : orderByDescending() == 'Message' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: logId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-level">@(Knockout.InputFor<Coalesce.Domain.Log>(p => p.Level))</td>
+                                <td class="prop-message">@(Knockout.InputFor<Coalesce.Domain.Log>(p => p.Message))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-level">@(Knockout.DisplayFor<Coalesce.Domain.Log>(p => p.Level, true))</td>
+                                <td class="prop-message">@(Knockout.DisplayFor<Coalesce.Domain.Log>(p => p.Message, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/Person/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Person/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-person">
     <div class="table-view-header">
@@ -66,107 +69,117 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                            Title
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Title', 'fa-caret-down': orderByDescending() == 'Title'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('FirstName')}">
-                            First Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'FirstName', 'fa-caret-down': orderByDescending() == 'FirstName'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('LastName')}">
-                            Last Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'LastName', 'fa-caret-down': orderByDescending() == 'LastName'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Email')}">
-                            Email
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Email', 'fa-caret-down': orderByDescending() == 'Email'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Gender')}">
-                            Gender
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Gender', 'fa-caret-down': orderByDescending() == 'Gender'}"></i>
-                        </th>
-                        <th>Cases Assigned</th>
-                        <th>Cases Reported</th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('BirthDate')}">
-                            Birth Date
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'BirthDate', 'fa-caret-down': orderByDescending() == 'BirthDate'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                            Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Name', 'fa-caret-down': orderByDescending() == 'Name'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Company')}">
-                            Company
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Company', 'fa-caret-down': orderByDescending() == 'Company'}"></i>
-                        </th>
-                        <th>Arbitrary Collection Of Strings</th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: personId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-title">@(Knockout.SelectFor<Coalesce.Domain.Person>(p => p.Title))</td>
-                            <td class="prop-firstName">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.FirstName))</td>
-                            <td class="prop-lastName">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.LastName))</td>
-                            <td class="prop-email">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.Email))</td>
-                            <td class="prop-gender">@(Knockout.SelectFor<Coalesce.Domain.Person>(p => p.Gender))</td>
-                            <td class="prop-casesAssigned"><a data-bind='attr: {href: casesAssignedListUrl}, text: casesAssigned().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-casesReported"><a data-bind='attr: {href: casesReportedListUrl}, text: casesReported().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-birthDate">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.BirthDate))</td>
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Name, true))</td>
-                            <td class="prop-company">@(Knockout.SelectForObject<Coalesce.Domain.Person>(p => p.Company))</td>
-                            <td class="prop-arbitraryCollectionOfStrings"><div class='form-control-static' style='font-family: monospace; white-space: nowrap' data-bind='text: (arbitraryCollectionOfStrings() || []).length + " Items"' ></div></td>
-                        }
-                        else
-                        {
-                            <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Title, true))</td>
-                            <td class="prop-firstName">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.FirstName, true))</td>
-                            <td class="prop-lastName">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.LastName, true))</td>
-                            <td class="prop-email">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Email, true))</td>
-                            <td class="prop-gender">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Gender, true))</td>
-                            <td class="prop-casesAssigned"><a data-bind='attr: {href: casesAssignedListUrl}, text: casesAssigned().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-casesReported"><a data-bind='attr: {href: casesReportedListUrl}, text: casesReported().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
-                            <td class="prop-birthDate">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.BirthDate, true))</td>
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Name, true))</td>
-                            <td class="prop-company">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Company, true))</td>
-                            <td class="prop-arbitraryCollectionOfStrings"><div class='form-control-static' style='font-family: monospace; white-space: nowrap' data-bind='text: (arbitraryCollectionOfStrings() || []).length + " Items"' ></div></td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <!-- Action buttons -->
-                                <div class="btn-group" role="group">
-                                    <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        Actions <span class="caret"></span>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
+                                <span>Title&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('FirstName')}">
+                                <span>First Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'FirstName' ? 'fa-caret-up' : orderByDescending() == 'FirstName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('LastName')}">
+                                <span>Last Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'LastName' ? 'fa-caret-up' : orderByDescending() == 'LastName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Email')}">
+                                <span>Email&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Email' ? 'fa-caret-up' : orderByDescending() == 'Email' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Gender')}">
+                                <span>Gender&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Gender' ? 'fa-caret-up' : orderByDescending() == 'Gender' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th>Cases Assigned</th>
+                            <th>Cases Reported</th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('BirthDate')}">
+                                <span>Birth Date&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'BirthDate' ? 'fa-caret-up' : orderByDescending() == 'BirthDate' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
+                                <span>Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Company')}">
+                                <span>Company&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Company' ? 'fa-caret-up' : orderByDescending() == 'Company' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th>Arbitrary Collection Of Strings</th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: personId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-title">@(Knockout.SelectFor<Coalesce.Domain.Person>(p => p.Title))</td>
+                                <td class="prop-firstName">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.FirstName))</td>
+                                <td class="prop-lastName">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.LastName))</td>
+                                <td class="prop-email">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.Email))</td>
+                                <td class="prop-gender">@(Knockout.SelectFor<Coalesce.Domain.Person>(p => p.Gender))</td>
+                                <td class="prop-casesAssigned"><a data-bind='attr: {href: casesAssignedListUrl}, text: casesAssigned().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-casesReported"><a data-bind='attr: {href: casesReportedListUrl}, text: casesReported().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-birthDate">@(Knockout.InputFor<Coalesce.Domain.Person>(p => p.BirthDate))</td>
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Name, true))</td>
+                                <td class="prop-company">@(Knockout.SelectForObject<Coalesce.Domain.Person>(p => p.Company))</td>
+                                <td class="prop-arbitraryCollectionOfStrings"><div class='form-control-static' style='font-family: monospace; white-space: nowrap' data-bind='text: (arbitraryCollectionOfStrings() || []).length + " Items"' ></div></td>
+                            }
+                            else
+                            {
+                                <td class="prop-title">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Title, true))</td>
+                                <td class="prop-firstName">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.FirstName, true))</td>
+                                <td class="prop-lastName">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.LastName, true))</td>
+                                <td class="prop-email">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Email, true))</td>
+                                <td class="prop-gender">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Gender, true))</td>
+                                <td class="prop-casesAssigned"><a data-bind='attr: {href: casesAssignedListUrl}, text: casesAssigned().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-casesReported"><a data-bind='attr: {href: casesReportedListUrl}, text: casesReported().length + " - Edit"' class='btn btn-default btn-sm'></a></td>
+                                <td class="prop-birthDate">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.BirthDate, true))</td>
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Name, true))</td>
+                                <td class="prop-company">@(Knockout.DisplayFor<Coalesce.Domain.Person>(p => p.Company, true))</td>
+                                <td class="prop-arbitraryCollectionOfStrings"><div class='form-control-static' style='font-family: monospace; white-space: nowrap' data-bind='text: (arbitraryCollectionOfStrings() || []).length + " Items"' ></div></td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <!-- Action buttons -->
+                                    <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            Actions <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <li><a href="#" data-bind='click: function(){ rename.invokeWithPrompts() }'>Rename</a></li>
+                                            <li><a href="#" data-bind='click: function(){ changeSpacesToDashesInName.invoke() }'>Change Spaces To Dashes In Name</a></li>
+                                            <li><a href="#" data-bind='click: function(){ getBirthdate.invoke() }'>Get Birthdate</a></li>
+                                            <li><a href="#" data-bind='click: function(){ fullNameAndAge.invoke() }'>Full Name And Age</a></li>
+                                            <li><a href="#" data-bind='click: function(){ obfuscateEmail.invoke() }'>Obfuscate Email</a></li>
+                                            <li><a href="#" data-bind='click: function(){ changeFirstName.invokeWithPrompts() }'>Change First Name</a></li>
+                                        </ul>
+                                    </div>
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
                                     </button>
-                                    <ul class="dropdown-menu">
-                                        <li><a href="#" data-bind='click: function(){ rename.invokeWithPrompts() }'>Rename</a></li>
-                                        <li><a href="#" data-bind='click: function(){ changeSpacesToDashesInName.invoke() }'>Change Spaces To Dashes In Name</a></li>
-                                        <li><a href="#" data-bind='click: function(){ getBirthdate.invoke() }'>Get Birthdate</a></li>
-                                        <li><a href="#" data-bind='click: function(){ fullNameAndAge.invoke() }'>Full Name And Age</a></li>
-                                        <li><a href="#" data-bind='click: function(){ obfuscateEmail.invoke() }'>Obfuscate Email</a></li>
-                                        <li><a href="#" data-bind='click: function(){ changeFirstName.invokeWithPrompts() }'>Change First Name</a></li>
-                                    </ul>
                                 </div>
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/Person/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Person/Table.cshtml
@@ -74,46 +74,38 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Title')}">
-                                <span>Title&nbsp;&nbsp;
+                                Title
                                 <i class="fa" data-bind="css: orderBy() == 'Title' ? 'fa-caret-up' : orderByDescending() == 'Title' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('FirstName')}">
-                                <span>First Name&nbsp;&nbsp;
+                                First Name
                                 <i class="fa" data-bind="css: orderBy() == 'FirstName' ? 'fa-caret-up' : orderByDescending() == 'FirstName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('LastName')}">
-                                <span>Last Name&nbsp;&nbsp;
+                                Last Name
                                 <i class="fa" data-bind="css: orderBy() == 'LastName' ? 'fa-caret-up' : orderByDescending() == 'LastName' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Email')}">
-                                <span>Email&nbsp;&nbsp;
+                                Email
                                 <i class="fa" data-bind="css: orderBy() == 'Email' ? 'fa-caret-up' : orderByDescending() == 'Email' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Gender')}">
-                                <span>Gender&nbsp;&nbsp;
+                                Gender
                                 <i class="fa" data-bind="css: orderBy() == 'Gender' ? 'fa-caret-up' : orderByDescending() == 'Gender' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th>Cases Assigned</th>
                             <th>Cases Reported</th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('BirthDate')}">
-                                <span>Birth Date&nbsp;&nbsp;
+                                Birth Date
                                 <i class="fa" data-bind="css: orderBy() == 'BirthDate' ? 'fa-caret-up' : orderByDescending() == 'BirthDate' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                                <span>Name&nbsp;&nbsp;
+                                Name
                                 <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Company')}">
-                                <span>Company&nbsp;&nbsp;
+                                Company
                                 <i class="fa" data-bind="css: orderBy() == 'Company' ? 'fa-caret-up' : orderByDescending() == 'Company' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th>Arbitrary Collection Of Strings</th>
                             <th style="width: 1%">

--- a/src/Coalesce.Web/Views/Generated/Product/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Product/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-product">
     <div class="table-view-header">
@@ -66,54 +69,59 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                            Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Name', 'fa-caret-down': orderByDescending() == 'Name'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Details')}">
-                            Details
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Details', 'fa-caret-down': orderByDescending() == 'Details'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('UniqueId')}">
-                            Unique Id
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'UniqueId', 'fa-caret-down': orderByDescending() == 'UniqueId'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: productId}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.Name))</td>
-                            <td class="prop-details">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.Details))</td>
-                            <td class="prop-uniqueId">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.UniqueId))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.Name, true))</td>
-                            <td class="prop-details">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.Details, true))</td>
-                            <td class="prop-uniqueId">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.UniqueId, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
+                                <span>Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Details')}">
+                                <span>Details&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Details' ? 'fa-caret-up' : orderByDescending() == 'Details' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('UniqueId')}">
+                                <span>Unique Id&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'UniqueId' ? 'fa-caret-up' : orderByDescending() == 'UniqueId' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: productId}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.Name))</td>
+                                <td class="prop-details">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.Details))</td>
+                                <td class="prop-uniqueId">@(Knockout.InputFor<Coalesce.Domain.Product>(p => p.UniqueId))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.Name, true))</td>
+                                <td class="prop-details">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.Details, true))</td>
+                                <td class="prop-uniqueId">@(Knockout.DisplayFor<Coalesce.Domain.Product>(p => p.UniqueId, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/Product/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/Product/Table.cshtml
@@ -74,19 +74,16 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                                <span>Name&nbsp;&nbsp;
+                                Name
                                 <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Details')}">
-                                <span>Details&nbsp;&nbsp;
+                                Details
                                 <i class="fa" data-bind="css: orderBy() == 'Details' ? 'fa-caret-up' : orderByDescending() == 'Details' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('UniqueId')}">
-                                <span>Unique Id&nbsp;&nbsp;
+                                Unique Id
                                 <i class="fa" data-bind="css: orderBy() == 'UniqueId' ? 'fa-caret-up' : orderByDescending() == 'UniqueId' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/StandaloneReadWrite/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/StandaloneReadWrite/Table.cshtml
@@ -74,14 +74,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                                <span>Name&nbsp;&nbsp;
+                                Name
                                 <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Date')}">
-                                <span>Date&nbsp;&nbsp;
+                                Date
                                 <i class="fa" data-bind="css: orderBy() == 'Date' ? 'fa-caret-up' : orderByDescending() == 'Date' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/StandaloneReadWrite/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/StandaloneReadWrite/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-standaloneReadWrite">
     <div class="table-view-header">
@@ -66,48 +69,52 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                            Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Name', 'fa-caret-down': orderByDescending() == 'Name'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Date')}">
-                            Date
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Date', 'fa-caret-down': orderByDescending() == 'Date'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: id}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Name))</td>
-                            <td class="prop-date">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Date))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Name, true))</td>
-                            <td class="prop-date">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Date, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
+                                <span>Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Date')}">
+                                <span>Date&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Date' ? 'fa-caret-up' : orderByDescending() == 'Date' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: id}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Name))</td>
+                                <td class="prop-date">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Date))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Name, true))</td>
+                                <td class="prop-date">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadWrite>(p => p.Date, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/StandaloneReadonly/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/StandaloneReadonly/Table.cshtml
@@ -69,14 +69,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                                <span>Name&nbsp;&nbsp;
+                                Name
                                 <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
-                                <span>Description&nbsp;&nbsp;
+                                Description
                                 <i class="fa" data-bind="css: orderBy() == 'Description' ? 'fa-caret-up' : orderByDescending() == 'Description' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/Coalesce.Web/Views/Generated/StandaloneReadonly/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/StandaloneReadonly/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-standaloneReadonly">
     <div class="table-view-header">
@@ -61,42 +64,46 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
-                            Name
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Name', 'fa-caret-down': orderByDescending() == 'Name'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
-                            Description
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Description', 'fa-caret-down': orderByDescending() == 'Description'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: id}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadonly>(p => p.Name))</td>
-                            <td class="prop-description">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadonly>(p => p.Description))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadonly>(p => p.Name, true))</td>
-                            <td class="prop-description">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadonly>(p => p.Description, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Name')}">
+                                <span>Name&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Name' ? 'fa-caret-up' : orderByDescending() == 'Name' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Description')}">
+                                <span>Description&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Description' ? 'fa-caret-up' : orderByDescending() == 'Description' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: id}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-name">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadonly>(p => p.Name))</td>
+                                <td class="prop-description">@(Knockout.InputFor<Coalesce.Domain.StandaloneReadonly>(p => p.Description))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-name">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadonly>(p => p.Name, true))</td>
+                                <td class="prop-description">@(Knockout.DisplayFor<Coalesce.Domain.StandaloneReadonly>(p => p.Description, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/ZipCode/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/ZipCode/Table.cshtml
@@ -22,6 +22,9 @@
     .coalesce-upload-icon {
         cursor: pointer;
     }
+    .fa-sort {
+        color: lightgray;
+    }
 </style>
 <div class="table-view obj-zipCode">
     <div class="table-view-header">
@@ -66,48 +69,52 @@
     <hr />
     <div class="card table-view-body">
         <div class="card-body">
-            <table class="table @(ViewBag.Editable ? "editable" : "" )">
-                <thead>
-                    <tr>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('Zip')}">
-                            Zip
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'Zip', 'fa-caret-down': orderByDescending() == 'Zip'}"></i>
-                        </th>
-                        <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
-                            State
-                            <i class="pull-right fa" data-bind="css:{'fa-caret-up': orderBy() == 'State', 'fa-caret-down': orderByDescending() == 'State'}"></i>
-                        </th>
-                        <th style="width: 1%">
-                        </th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: items">
-                    <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: zip}">
-                        @if (@ViewBag.Editable)
-                        {
-                            <td class="prop-zip">@(Knockout.InputFor<Coalesce.Domain.ZipCode>(p => p.Zip))</td>
-                            <td class="prop-state">@(Knockout.InputFor<Coalesce.Domain.ZipCode>(p => p.State))</td>
-                        }
-                        else
-                        {
-                            <td class="prop-zip">@(Knockout.DisplayFor<Coalesce.Domain.ZipCode>(p => p.Zip, true))</td>
-                            <td class="prop-state">@(Knockout.DisplayFor<Coalesce.Domain.ZipCode>(p => p.State, true))</td>
-                        }
-                        <td>
-                            <!-- Editor buttons -->
-                            <div class="btn-group pull-right" role="group" style="display: inline-flex">
-                                <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
-                                    <i class="fa fa-pencil"></i>
-                                </a>
-                                <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
-                                    <i class="fa fa-remove"></i>
-                                </button>
-                            </div>
-                            <div class="form-control-static" data-bind="text: errorMessage"></div>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="table-responsive">
+                <table class="table @(ViewBag.Editable ? "editable" : "" )">
+                    <thead>
+                        <tr>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('Zip')}">
+                                <span>Zip&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'Zip' ? 'fa-caret-up' : orderByDescending() == 'Zip' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
+                                <span>State&nbsp;&nbsp;
+                                <i class="fa" data-bind="css: orderBy() == 'State' ? 'fa-caret-up' : orderByDescending() == 'State' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                                </span>
+                            </th>
+                            <th style="width: 1%">
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: items">
+                        <tr data-bind="css: {'btn-warning': errorMessage()}, attr: {id: zip}">
+                            @if (@ViewBag.Editable)
+                            {
+                                <td class="prop-zip">@(Knockout.InputFor<Coalesce.Domain.ZipCode>(p => p.Zip))</td>
+                                <td class="prop-state">@(Knockout.InputFor<Coalesce.Domain.ZipCode>(p => p.State))</td>
+                            }
+                            else
+                            {
+                                <td class="prop-zip">@(Knockout.DisplayFor<Coalesce.Domain.ZipCode>(p => p.Zip, true))</td>
+                                <td class="prop-state">@(Knockout.DisplayFor<Coalesce.Domain.ZipCode>(p => p.State, true))</td>
+                            }
+                            <td>
+                                <!-- Editor buttons -->
+                                <div class="btn-group pull-right" role="group" style="display: inline-flex">
+                                    <a class="btn btn-sm btn-default" data-bind="attr: { href: editUrl }">
+                                        <i class="fa fa-pencil"></i>
+                                    </a>
+                                    <button class="btn btn-sm btn-danger" data-bind="click: deleteItemWithConfirmation">
+                                        <i class="fa fa-remove"></i>
+                                    </button>
+                                </div>
+                                <div class="form-control-static" data-bind="text: errorMessage"></div>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Coalesce.Web/Views/Generated/ZipCode/Table.cshtml
+++ b/src/Coalesce.Web/Views/Generated/ZipCode/Table.cshtml
@@ -74,14 +74,12 @@
                     <thead>
                         <tr>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('Zip')}">
-                                <span>Zip&nbsp;&nbsp;
+                                Zip
                                 <i class="fa" data-bind="css: orderBy() == 'Zip' ? 'fa-caret-up' : orderByDescending() == 'Zip' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('State')}">
-                                <span>State&nbsp;&nbsp;
+                                State
                                 <i class="fa" data-bind="css: orderBy() == 'State' ? 'fa-caret-up' : orderByDescending() == 'State' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
-                                </span>
                             </th>
                             <th style="width: 1%">
                             </th>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
@@ -43,6 +43,9 @@ namespace IntelliTect.Coalesce.CodeGeneration.Knockout.Generators
                     "}",
                     ".coalesce-upload-icon {",
                     "    cursor: pointer;",
+                    "}",
+                    ".fa-sort {",
+                    "    color: lightgray;",
                     "}"
                 );
             }
@@ -69,6 +72,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Knockout.Generators
                 using (b
                     .TagBlock("div", "card table-view-body")
                     .TagBlock("div", "card-body")
+                    .TagBlock("div", "table-responsive")
                     .TagBlock("table", "table @(ViewBag.Editable ? \"editable\" : \"\" )")
                 )
                 {
@@ -79,10 +83,12 @@ namespace IntelliTect.Coalesce.CodeGeneration.Knockout.Generators
                         {
                             if (!prop.Type.IsCollection)
                             {
+                                string sortIconVisibleLogic = $"orderBy() != '{prop.Name}' &&  orderByDescending() != '{prop.Name}'";
                                 using (b.TagBlock("th", "sortable-header", dataBind: $"click: function(){{orderByToggle('{prop.Name}')}}"))
                                 {
-                                    b.Line(prop.DisplayName);
-                                    b.Line($"<i class=\"pull-right fa\" data-bind=\"css:{{'fa-caret-up': orderBy() == '{prop.Name}', 'fa-caret-down': orderByDescending() == '{prop.Name}'}}\"></i>");
+                                    b.Line($"<span>{prop.DisplayName}&nbsp;&nbsp;");
+                                    b.Line($@"<i class=""fa"" data-bind=""css:{{'fa-caret-up': orderBy() == '{prop.Name}', 'fa-caret-down': orderByDescending() == '{prop.Name}', 'fa-sort': {sortIconVisibleLogic} }}"" style =""float: right; padding: .3em 0 0 0 ""></i>");
+                                    b.Line("</span>");
                                 }
                             }
                             else

--- a/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
@@ -84,10 +84,9 @@ namespace IntelliTect.Coalesce.CodeGeneration.Knockout.Generators
                             if (!prop.Type.IsCollection)
                             {                           
                                 using (b.TagBlock("th", "sortable-header", dataBind: $"click: function(){{orderByToggle('{prop.Name}')}}"))
-                                {
-                                    b.Line($"<span>{prop.DisplayName}&nbsp;&nbsp;");
-                                    b.Line($@"<i class=""fa"" data-bind=""css: orderBy() == '{prop.Name}' ? 'fa-caret-up' : orderByDescending() == '{prop.Name}' ? 'fa-caret-down' : 'fa-sort'"" style=""float: right; padding: .3em 0 0 0 ""></i>");
-                                    b.Line("</span>");
+                                {                                  
+                                    b.Line(prop.DisplayName);                                   
+                                    b.Line($@"<i class=""fa"" data-bind=""css: orderBy() == '{prop.Name}' ? 'fa-caret-up' : orderByDescending() == '{prop.Name}' ? 'fa-caret-down' : 'fa-sort'"" style=""float: right; padding: .3em 0 0 0 ""></i>");                                 
                                 }
                             }
                             else

--- a/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Knockout/Generators/Views/TableView.cs
@@ -82,12 +82,11 @@ namespace IntelliTect.Coalesce.CodeGeneration.Knockout.Generators
                         foreach (var prop in Model.AdminPageProperties.Where(f => !f.IsHidden(HiddenAttribute.Areas.List)).OrderBy(f => f.EditorOrder))
                         {
                             if (!prop.Type.IsCollection)
-                            {
-                                string sortIconVisibleLogic = $"orderBy() != '{prop.Name}' &&  orderByDescending() != '{prop.Name}'";
+                            {                           
                                 using (b.TagBlock("th", "sortable-header", dataBind: $"click: function(){{orderByToggle('{prop.Name}')}}"))
                                 {
                                     b.Line($"<span>{prop.DisplayName}&nbsp;&nbsp;");
-                                    b.Line($@"<i class=""fa"" data-bind=""css:{{'fa-caret-up': orderBy() == '{prop.Name}', 'fa-caret-down': orderByDescending() == '{prop.Name}', 'fa-sort': {sortIconVisibleLogic} }}"" style =""float: right; padding: .3em 0 0 0 ""></i>");
+                                    b.Line($@"<i class=""fa"" data-bind=""css: orderBy() == '{prop.Name}' ? 'fa-caret-up' : orderByDescending() == '{prop.Name}' ? 'fa-caret-down' : 'fa-sort'"" style=""float: right; padding: .3em 0 0 0 ""></i>");
                                     b.Line("</span>");
                                 }
                             }


### PR DESCRIPTION
Previously if the windows was too small the table columns would run out of the card:
![image](https://user-images.githubusercontent.com/11265760/122611556-5c488500-d036-11eb-9f32-e00a5e499cd9.png)
Now:
![image](https://user-images.githubusercontent.com/11265760/122611406-23101500-d036-11eb-94d1-45ad4c6727ea.png)
And some font-awesome css to indicate that the table is sortable, as well as indicate which column the table is currently being sorted by:
![image](https://user-images.githubusercontent.com/11265760/122611401-20152480-d036-11eb-9197-ebfb74edc73a.png)
(previously no icons in the header would show):
![image](https://user-images.githubusercontent.com/11265760/122611733-a7629800-d036-11eb-84f2-ff1335033bfd.png)

