### PR TITLE
feat: #331 implement custom property restrictions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 *.g.cs linguist-generated=true
 *.g.ts linguist-generated=true
 *.generated.d.ts linguist-generated=true
-src/Coalesce.Web/Scripts/Coalesce/* linguist-generated=true
-src/Coalesce.Web/Views/Generated/* linguist-generated=true
+playground/**/Scripts/Coalesce/* linguist-generated=true
+playground/**/Views/Generated/* linguist-generated=true
 
 * text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
 
 *.g.cs linguist-generated=true
-# *.g.ts linguist-generated=true
+*.g.ts linguist-generated=true
 *.generated.d.ts linguist-generated=true
 playground/**/Scripts/Coalesce/* linguist-generated=true
+playground/**/Scripts/Coalesce/**/* linguist-generated=true
 playground/**/Views/Generated/* linguist-generated=true
+playground/**/Views/Generated/**/* linguist-generated=true
 
 * text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 
 *.g.cs linguist-generated=true
-*.g.ts linguist-generated=true
+# *.g.ts linguist-generated=true
 *.generated.d.ts linguist-generated=true
 playground/**/Scripts/Coalesce/* linguist-generated=true
 playground/**/Views/Generated/* linguist-generated=true

--- a/docs/modeling/model-components/attributes/restrict.md
+++ b/docs/modeling/model-components/attributes/restrict.md
@@ -1,0 +1,39 @@
+# [Restrict]
+
+In addition to [role-based](/modeling/model-components/attributes/security-attribute.md) property restrictions, you can also define property restrictions that can execute custom code for each model instance if your logic require more nuanced decisions than can be made with roles.
+
+``` c#:no-line-numbers
+using IntelliTect.Coalesce.DataAnnotations;
+public class Employee 
+{
+  public int Id { get; set; }
+
+  [Read]
+  public string UserId { get; set; }
+
+  [Restrict<SalaryRestriction>]
+  public decimal Salary { get; set; }
+}
+
+public class SalaryRestriction(MyUserService userService) : IPropertyRestriction<Employee>
+{
+  public bool UserCanRead(IMappingContext context, string propertyName, Employee model)
+    => context.User.GetUserId() == model.UserId || userService.IsPayroll(context.User);
+
+  public bool UserCanWrite(IMappingContext context, string propertyName, Employee model, object incomingValue)
+    => userService.IsPayroll(context.User);
+
+  public bool UserCanFilter(IMappingContext context, string propertyName)
+    => userService.IsPayroll(context.User);
+}
+```
+
+Restriction classes support dependency injection, so you can inject any supplemental services needed to make a determination.
+
+The `UserCanRead` method controls whether values of the restricted property will be mapped from model instances to the generated DTO. Similarly, `UserCanWrite` controls whether the property can be mapped back to the model instance from the generated DTO.
+
+The `UserCanFilter` method has a default implementation that returns `false`, but can be implemented if there is an appropriate, instance-agnostic way to determine if a user can sort, search, or filter values of that property.
+
+Multiple different restrictions can be placed on a single property; all of them must succeed for the operation to be permitted. Restrictions also stack on top of role attribute restrictions (`[Read]` and `[Edit]`).
+
+A non-generic variant of `IPropertyRestriction` also exists for restrictions that might be reused across multiple model types.

--- a/docs/modeling/model-components/properties.md
+++ b/docs/modeling/model-components/properties.md
@@ -52,4 +52,4 @@ Properties will be ignored if received by the client if authorization checks aga
 The [Default Loading Behavior](/modeling/model-components/data-sources.md#default-loading-behavior), any custom functionality defined in [Data Sources](/modeling/model-components/data-sources.md), and [[DtoIncludes] & [DtoExcludes]](/modeling/model-components/attributes/dto-includes-excludes.md) may also restrict which properties are sent to the client when requested.
 
 ### NotMapped
-While Coalesce does not do anything special for the `[NotMapped]` attribute, it is still and important attribute to keep in mind while building your model, as it prevents EF Core from doing anything with the property.
+While Coalesce does not do anything special for the `[NotMapped]` attribute, it is still an important attribute to keep in mind while building your model, as it prevents EF Core from doing anything with the property.

--- a/docs/stacks/agnostic/dtos.md
+++ b/docs/stacks/agnostic/dtos.md
@@ -16,5 +16,5 @@ Every class that is exposed through Coalesce's generated API will have a corresp
 
 The [[Read] and [Edit] attributes](/modeling/model-components/attributes/security-attribute.md) can be used to apply property-level security, which manifests as conditional logic in the mapping methods on the generated DTOs.
 
-See the [Security](/topics/security.md#attributes) page to read more about property-level security, as well as all other security mechanisms in Coalesce.
+See the [Security](/topics/security.md#property-column-security) page to read more about property-level security, as well as all other security mechanisms in Coalesce.
 

--- a/docs/topics/audit-logging.md
+++ b/docs/topics/audit-logging.md
@@ -36,7 +36,7 @@ public class AuditLog : DefaultAuditLog
 }
 ```
 
-This entity only needs to implement `IAuditLog`, but a default implementation of this interface  `DefaultAuditLog` is provided for your convenience. `DefaultAuditLog` contains additional properties `ClientIp`, `Referrer`, and `Endpoint` for recording information about the HTTP request (if available), and also has attributes to disable Create, Edit, and Delete APIs.
+This entity only needs to implement `IAuditLog`, but a default implementation of this interface  `DefaultAuditLog` is provided for your convenience. `DefaultAuditLog` contains additional properties `ClientIp`, `Referrer`, and `Endpoint` for recording information about the HTTP request (if available), and also comes pre-configured for security with Create, Edit, and Delete APIs disabled.
 
 You should further augment this type with any additional properties that you would like to track on each change record. A property to track the user who performed the change should be added, since it is not provided by the default implementation so that you can declare it yourself with the correct type for the foreign key and navigation property.
 

--- a/docs/topics/security.md
+++ b/docs/topics/security.md
@@ -1,9 +1,26 @@
 
 # Security
 
-This page is a comprehensive overview of all the techniques that can be used in a Coalesce application to restrict the usage of  API endpoints that Coalesce generates.
+This page is a comprehensive overview of all the techniques that can be used in a Coalesce application to restrict the capabilities of API endpoints that Coalesce generates.
 
-[[toc]]
+The following table is a quick reference of scenarios you might encounter and how you might handle them. If you're unfamiliar with these techniques, though, then you are encouraged to read through this page to get a deeper understanding of what's available before selecting a solution.
+
+| <div style="width:290px">When I want to...</div> | ... I should use ... |
+| - | - |
+| Remove an entity CRUD operation               | [Class Security Attributes](#class-security-attributes) with `DenyAll` |
+| Restrict an entity CRUD operation with roles  | [Class Security Attributes](#class-security-attributes) |
+| Restrict a method or service with roles       | [Method Security Attributes](#method-security-attributes) |
+| Remove a property from Coalesce               | • annotate with [[InternalUse]](#internal-properties) <br> • `internal` access modifier |
+| Restrict a property by roles                  | [Property Security Attributes](#property-role-restrictions) |
+| Restrict a property with custom logic         | • save operations: [custom Behaviors](#behaviors) <br> • nav prop loading: [custom Default Data Source](#data-sources) <br> • any property: [custom Property Restrictions](#custom-restrictions)  |
+| Make a property read-only                     | • make the setter `internal` <br> • add a `[Read]` attribute without `[Edit]` <br> • [other techniques](#read-only-properties) |
+| Make a property write-once (init-only)        | use an [`init`-only setter](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init) |
+| Prevent [auto-include](/modeling/model-components/data-sources.md#default-loading-behavior) | annotate the navigation property or the included type's class with `[Read(NoAutoInclude = true)]` |
+| Restrict results of `/get`, `/list`           | [custom Default Data Source](#data-sources)
+| Restrict `/save`, `/bulkSave`, `/delete`      | • any custom logic: [custom Behaviors](#behaviors) <br> • restrict targets: [custom Default Data Source](#data-sources) <br> • static role restrictions: [Class Security Attributes](#class-security-attributes) |
+| Restrict targets of instance methods          | • [custom Default Data Source](#data-sources) <br> • specify data source: [LoadFromDataSource](/modeling/model-components/methods.md#loadfromdatasource-type-datasourcetype) <br> • [custom logic](#custom-methods-and-services) in the method |
+| Apply server-side data validation             | • implement [validation attributes](#attribute-validation) <br> • [custom Behaviors](#saves-and-deletes) (for entity CRUD) <br> • [custom logic](#custom-methods-and-services) (for methods/services) |
+
 
 ## Endpoint Security
 
@@ -13,7 +30,7 @@ Classes can be hidden from Coalesce entirely by annotating them with `[InternalU
 
 `DbSet<>` properties on your `DbContext` class can also be annotated with `[InternalUse]`, causing that type to be treated by Coalesce like an [External Type](/modeling/model-types/external-types.md) rather than an [Entity](/modeling/model-types/entities.md), once again preventing generation of API endpoints but _without_ preventing properties of that type from being exposed.
 
-### Standard CRUD Endpoints 
+### Class Security Attributes
 For each of your [Entities](/modeling/model-types/entities.md) and [Custom DTOs](/modeling/model-types/dtos.md), Coalesce generates a set of CRUD API endpoints (`/get`, `/list`, `/count`, `/save`, `/bulkSave`, and `/delete`). 
 
 The default behavior is that all endpoints require an authenticated user (anonymous users are rejected).
@@ -33,15 +50,13 @@ This security is applied to the generated [controllers](https://learn.microsoft.
 <tr>
 <td>
 
-`/get`, `/list`, `/count`, `/bulkSave` 
+`/get`, `/list`, `/count`
 </td>
 <td>
 
 ``` c#:no-line-numbers
 [ReadAttribute]
 ```
-
-Note: the root model for a bulk save operation requires read permission. All other entities affected by the bulk save operation require their respective attribute for Create/Edit/Delete.
 </td>
 </tr>
 <tr>
@@ -69,6 +84,24 @@ Note: the root model for a bulk save operation requires read permission. All oth
 ```
 </td>
 </tr>
+<tr>
+<td>
+
+`/bulkSave` 
+</td>
+<td>
+
+``` c#:no-line-numbers
+// Read permission required for the root entity:
+[ReadAttribute]
+
+// Control of each entity affected by the bulk save:
+[CreateAttribute]
+[EditAttribute]
+[DeleteAttribute]
+```
+</td>
+</tr>
 </table>
 
 Here are some examples of applying security attributes to an entity class. If a particular action doesn't need to be restricted, you can omit that attribute, but this example shows usages of all four:
@@ -88,7 +121,7 @@ public class Employee
 }
 ```
 
-### Custom Methods and Services
+### Method Security Attributes
 
 To secure the endpoints generated for your [Custom Methods](/modeling/model-components/methods.md) and [Services](/modeling/model-types/services.md), the [[Execute] attribute](/modeling/model-components/attributes/execute.md) can be used to specify a set of required roles for that endpoint, or to open that endpoint to anonymous users.
 
@@ -115,6 +148,13 @@ public class Employee
 
 ## Property/Column Security
 
+Security applied via attributes to properties in Coalesce affects all usages of that property across all Coalesce-generated APIs. This includes usages of that property on types that occur as children of other types, which is a spot where class-level or endpoint-level security generally does not apply. [These attributes](/modeling/model-components/attributes/security-attribute.md) can be placed on the properties on your [Entities](/modeling/model-types/entities.md) and [External Types](/modeling/model-types/external-types.md) to apply role-based restrictions to that property.
+
+* `ReadAttribute` limits the roles that can read values from that property in responses from the server.
+* `EditAttribute` limits the roles that can write values to that property in requests made to the server.
+* `RestrictAttribute` registers an implementation of [IPropertyRestriction](#custom-restrictions) that allows for writing custom code to implement these restrictions.
+
+This security is executed and enforced by the mapping that occurs in the [generated DTOs](/stacks/agnostic/dtos.md), meaning it affects both entity CRUD APIs as well as [Custom Methods](/modeling/model-components/methods.md). It is also checked by the [Standard Data Source](/modeling/model-components/data-sources.md#standard-data-source) to prevent sorting, searching, and filtering by properties that a user is not permitted to read.
 
 ### Internal Properties
 
@@ -146,12 +186,6 @@ public class Department
 }
 ```
 
-### Attributes
-The [[Read] and [Edit] attributes](/modeling/model-components/attributes/security-attribute.md) can be placed on the properties on your [Entities](/modeling/model-types/entities.md) and [External Types](/modeling/model-types/external-types.md) to apply role-based restrictions to the usage of that property.
-
-This security is primarily executed and enforced by the mapping that occurs in the [generated DTOs](/stacks/agnostic/dtos.md). It is also checked by the [Standard Data Source](/modeling/model-components/data-sources.md#standard-data-source) to prevent sorting, searching, and filtering by properties that a user is not permitted to read.
-
-
 ### Read-Only Properties
 
 A property in Coalesce can be made read-only in any of the following ways:
@@ -176,13 +210,16 @@ public class Employee
   // Non-public setter:
   public DateTime StartDate { get; internal set; }
 
+  // No setter:
+  public string EmploymentDuration => (DateTime.Now - StartDate).ToString();
+
   // Edits denied:
   [Edit(SecurityPermissionLevels.DenyAll)]
   public string EmployeeNumber { get; set; }
 }
 ```
 
-### Read/Write Properties
+### Role Restrictions
 
 Reading and writing a property in Coalesce can be restricted by roles:
 
@@ -218,6 +255,11 @@ those roles are also required when editing that property. This is because it usu
 for a user to change a value when they have no way of knowing what the original value was.
 If you have a situation where a property should be editable without knowing the original value,
 use a custom method on the model to accept and set the new value.
+
+
+### Custom Restrictions
+
+@[import-md "after":"# [Restrict]"](../modeling/model-components/attributes/restrict.md)  
 
 
 ## Row-level Security
@@ -390,8 +432,16 @@ public override async Task TransformResultsAsync(
 }
 ```
 
+### Behaviors
 
-For a more complete explanation of everything you can do with data sources, see the full [Data Sources](/modeling/model-components/data-sources.md) documentation page.
+In Coalesce, [Behaviors](/modeling/model-components/behaviors.md) are the extension point to implement row-level security or other customizations of create/edit/delete operations on your [Entities](/modeling/model-types/entities.md) and [Custom DTOs](/modeling/model-types/dtos.md). Behaviors are implemented on top of data sources, meaning the client request will be rejected if the requested entity for modification cannot be loaded from the entity's default data source.
+
+By default, each entity will use the [Standard Behaviors](/modeling/model-components/behaviors.md#behaviors), but you can declare a [custom behaviors class](/modeling/model-components/behaviors.md#defining-behaviors) for each of your entities to override this default functionality.
+
+For most use cases, all your security rules will be implemented in the [BeforeSave/BeforeSaveAsync](/modeling/model-components/behaviors.md#member-BeforeSaveAsync) and [BeforeDelete/BeforeDeleteAsync](/modeling/model-components/behaviors.md#member-BeforeDeleteAsync) methods.
+
+For a more complete explanation of everything you can do with behaviors, see the full [Behaviors](/modeling/model-components/behaviors.md) documentation page.
+
 
 ### EF Global Query Filters
 

--- a/docs/topics/security.md
+++ b/docs/topics/security.md
@@ -11,7 +11,7 @@ The following table is a quick reference of scenarios you might encounter and ho
 | Restrict an entity CRUD operation with roles  | [Class Security Attributes](#class-security-attributes) |
 | Restrict a method or service with roles       | [Method Security Attributes](#method-security-attributes) |
 | Remove a property from Coalesce               | • annotate with [[InternalUse]](#internal-properties) <br> • `internal` access modifier |
-| Restrict a property by roles                  | [Property Security Attributes](#property-role-restrictions) |
+| Restrict a property by roles                  | [Property Security Attributes](#role-restrictions) |
 | Restrict a property with custom logic         | • save operations: [custom Behaviors](#behaviors) <br> • nav prop loading: [custom Default Data Source](#data-sources) <br> • any property: [custom Property Restrictions](#custom-restrictions)  |
 | Make a property read-only                     | • make the setter `internal` <br> • add a `[Read]` attribute without `[Edit]` <br> • [other techniques](#read-only-properties) |
 | Make a property write-once (init-only)        | use an [`init`-only setter](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init) |
@@ -438,7 +438,7 @@ In Coalesce, [Behaviors](/modeling/model-components/behaviors.md) are the extens
 
 By default, each entity will use the [Standard Behaviors](/modeling/model-components/behaviors.md#behaviors), but you can declare a [custom behaviors class](/modeling/model-components/behaviors.md#defining-behaviors) for each of your entities to override this default functionality.
 
-For most use cases, all your security rules will be implemented in the [BeforeSave/BeforeSaveAsync](/modeling/model-components/behaviors.md#member-BeforeSaveAsync) and [BeforeDelete/BeforeDeleteAsync](/modeling/model-components/behaviors.md#member-BeforeDeleteAsync) methods.
+For most use cases, all your security rules will be implemented in the [BeforeSave/BeforeSaveAsync](/modeling/model-components/behaviors.md#member-beforesaveasync) and [BeforeDelete/BeforeDeleteAsync](/modeling/model-components/behaviors.md#member-beforedeleteasync) methods.
 
 For a more complete explanation of everything you can do with behaviors, see the full [Behaviors](/modeling/model-components/behaviors.md) documentation page.
 

--- a/playground/Coalesce.Domain/Case.cs
+++ b/playground/Coalesce.Domain/Case.cs
@@ -79,13 +79,15 @@ namespace Coalesce.Domain
 
         [Read]
         public long AttachmentSize { get; set; }
-        [Read]
+        [Read, Restrict<TestRestriction>]
         public string AttachmentName { get; set; }
+        [Restrict<TestRestriction>]
         public string AttachmentType { get; set; }
         [Read, MaxLength(32)]
         public byte[] AttachmentHash { get; set; }
         [InternalUse]
         public CaseAttachmentContent AttachmentContent { get; set; } 
+
         public class CaseAttachmentContent
         {
             public int CaseKey { get; set; }
@@ -231,6 +233,20 @@ namespace Coalesce.Domain
             int[] a = [1, 2, 3, 4, 5, 6, 7, 8];
 
             return CaseSummary.GetCaseSummary(db);
+        }
+
+        public class TestRestriction(AppDbContext db) : IPropertyRestriction<Case>
+        {
+            public bool UserCanRead(IMappingContext context, string propertyName, Case model)
+            {
+                // Nonsense arbitrary logic
+                return db.Cases.Any() && propertyName != null;
+            }
+
+            public bool UserCanWrite(IMappingContext context, string propertyName, Case? model, object? incomingValue)
+            {
+                return false;
+            }
         }
     }
 }

--- a/playground/Coalesce.Web.Ko/Api/Generated/CaseController.g.cs
+++ b/playground/Coalesce.Web.Ko/Api/Generated/CaseController.g.cs
@@ -119,7 +119,7 @@ namespace Coalesce.Web.Ko.Api
         public virtual ItemResult<System.Collections.Generic.ICollection<CaseDtoGen>> GetSomeCases()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetSomeCases(
                 Db
             );
@@ -386,7 +386,7 @@ namespace Coalesce.Web.Ko.Api
         public virtual ItemResult<CaseSummaryDtoGen> GetCaseSummary()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetCaseSummary(
                 Db
             );

--- a/playground/Coalesce.Web.Ko/Api/Generated/CompanyController.g.cs
+++ b/playground/Coalesce.Web.Ko/Api/Generated/CompanyController.g.cs
@@ -113,7 +113,7 @@ namespace Coalesce.Web.Ko.Api
                 if (!_validationResult.WasSuccessful) return _validationResult;
             }
 
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             item.ConflictingParameterNames(
                 _params.companyParam.MapToNew(_mappingContext),
                 _params.name
@@ -144,7 +144,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Company.GetCertainItems(
                 Db,
                 _params.isDeleted

--- a/playground/Coalesce.Web.Ko/Api/Generated/PersonController.g.cs
+++ b/playground/Coalesce.Web.Ko/Api/Generated/PersonController.g.cs
@@ -112,7 +112,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.Rename(
                 _params.name,
                 out includeTree
@@ -394,7 +394,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.ChangeFirstName(
                 _params.firstName,
                 _params.title
@@ -499,7 +499,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
                 Db,
                 _params.person.MapToNew(_mappingContext)
@@ -532,7 +532,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.SearchPeople(
                 Db,
                 _params.criteria.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Ko/Api/Generated/WeatherServiceController.g.cs
+++ b/playground/Coalesce.Web.Ko/Api/Generated/WeatherServiceController.g.cs
@@ -63,7 +63,7 @@ namespace Coalesce.Web.Ko.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = await Service.GetWeatherAsync(
                 parameterDbContext,
                 _params.location.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Ko/Models/Generated/AuditLogDto.g.cs
+++ b/playground/Coalesce.Web.Ko/Models/Generated/AuditLogDto.g.cs
@@ -94,9 +94,9 @@ namespace Coalesce.Web.Ko.Models
             if (obj == null) return;
             var includes = context.Includes;
 
+            this.Id = obj.Id;
             this.Message = obj.Message;
             this.UserId = obj.UserId;
-            this.Id = obj.Id;
             this.Type = obj.Type;
             this.KeyValue = obj.KeyValue;
             this.State = obj.State;
@@ -130,9 +130,9 @@ namespace Coalesce.Web.Ko.Models
 
             if (OnUpdate(entity, context)) return;
 
+            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Message))) entity.Message = Message;
             if (ShouldMapTo(nameof(UserId))) entity.UserId = UserId;
-            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Type))) entity.Type = Type;
             if (ShouldMapTo(nameof(KeyValue))) entity.KeyValue = KeyValue;
             if (ShouldMapTo(nameof(State))) entity.State = (State ?? entity.State);

--- a/playground/Coalesce.Web.Ko/Models/Generated/AuditLogPropertyDto.g.cs
+++ b/playground/Coalesce.Web.Ko/Models/Generated/AuditLogPropertyDto.g.cs
@@ -16,7 +16,9 @@ namespace Coalesce.Web.Ko.Models
         private long? _ParentId;
         private string _PropertyName;
         private string _OldValue;
+        private string _OldValueDescription;
         private string _NewValue;
+        private string _NewValueDescription;
 
         public long? Id
         {
@@ -38,10 +40,20 @@ namespace Coalesce.Web.Ko.Models
             get => _OldValue;
             set { _OldValue = value; Changed(nameof(OldValue)); }
         }
+        public string OldValueDescription
+        {
+            get => _OldValueDescription;
+            set { _OldValueDescription = value; Changed(nameof(OldValueDescription)); }
+        }
         public string NewValue
         {
             get => _NewValue;
             set { _NewValue = value; Changed(nameof(NewValue)); }
+        }
+        public string NewValueDescription
+        {
+            get => _NewValueDescription;
+            set { _NewValueDescription = value; Changed(nameof(NewValueDescription)); }
         }
 
         /// <summary>
@@ -56,7 +68,9 @@ namespace Coalesce.Web.Ko.Models
             this.ParentId = obj.ParentId;
             this.PropertyName = obj.PropertyName;
             this.OldValue = obj.OldValue;
+            this.OldValueDescription = obj.OldValueDescription;
             this.NewValue = obj.NewValue;
+            this.NewValueDescription = obj.NewValueDescription;
         }
 
         /// <summary>
@@ -72,7 +86,9 @@ namespace Coalesce.Web.Ko.Models
             if (ShouldMapTo(nameof(ParentId))) entity.ParentId = (ParentId ?? entity.ParentId);
             if (ShouldMapTo(nameof(PropertyName))) entity.PropertyName = PropertyName;
             if (ShouldMapTo(nameof(OldValue))) entity.OldValue = OldValue;
+            if (ShouldMapTo(nameof(OldValueDescription))) entity.OldValueDescription = OldValueDescription;
             if (ShouldMapTo(nameof(NewValue))) entity.NewValue = NewValue;
+            if (ShouldMapTo(nameof(NewValueDescription))) entity.NewValueDescription = NewValueDescription;
         }
 
         /// <summary>

--- a/playground/Coalesce.Web.Ko/Models/Generated/CaseDto.g.cs
+++ b/playground/Coalesce.Web.Ko/Models/Generated/CaseDto.g.cs
@@ -137,8 +137,6 @@ namespace Coalesce.Web.Ko.Models
             this.AssignedToId = obj.AssignedToId;
             this.ReportedById = obj.ReportedById;
             this.AttachmentSize = obj.AttachmentSize;
-            this.AttachmentName = obj.AttachmentName;
-            this.AttachmentType = obj.AttachmentType;
             this.AttachmentHash = obj.AttachmentHash;
             this.Severity = obj.Severity;
             this.Status = obj.Status;
@@ -159,6 +157,8 @@ namespace Coalesce.Web.Ko.Models
 
             this.DevTeamAssigned = obj.DevTeamAssigned.MapToDto<Coalesce.Domain.External.DevTeam, DevTeamDtoGen>(context, tree?[nameof(this.DevTeamAssigned)]);
 
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentName), obj)) this.AttachmentName = obj.AttachmentName;
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentType), obj)) this.AttachmentType = obj.AttachmentType;
             if (!(includes == "PersonListGen"))
             {
                 if (tree == null || tree[nameof(this.AssignedTo)] != null)
@@ -168,6 +168,7 @@ namespace Coalesce.Web.Ko.Models
                     this.ReportedBy = obj.ReportedBy.MapToDto<Coalesce.Domain.Person, PersonDtoGen>(context, tree?[nameof(this.ReportedBy)]);
 
             }
+
         }
 
         /// <summary>
@@ -185,7 +186,7 @@ namespace Coalesce.Web.Ko.Models
             if (ShouldMapTo(nameof(OpenedAt))) entity.OpenedAt = (OpenedAt ?? entity.OpenedAt);
             if (ShouldMapTo(nameof(AssignedToId))) entity.AssignedToId = AssignedToId;
             if (ShouldMapTo(nameof(ReportedById))) entity.ReportedById = ReportedById;
-            if (ShouldMapTo(nameof(AttachmentType))) entity.AttachmentType = AttachmentType;
+            if (ShouldMapTo(nameof(AttachmentType)) && context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanWrite(context, nameof(AttachmentType), entity, AttachmentType)) entity.AttachmentType = AttachmentType;
             if (ShouldMapTo(nameof(Severity))) entity.Severity = Severity;
             if (ShouldMapTo(nameof(Status))) entity.Status = (Status ?? entity.Status);
             if (ShouldMapTo(nameof(DevTeamAssignedId))) entity.DevTeamAssignedId = DevTeamAssignedId;

--- a/playground/Coalesce.Web.Ko/Models/Generated/ProductDto.g.cs
+++ b/playground/Coalesce.Web.Ko/Models/Generated/ProductDto.g.cs
@@ -58,10 +58,7 @@ namespace Coalesce.Web.Ko.Models
 
             this.Details = obj.Details.MapToDto<Coalesce.Domain.ProductDetails, ProductDetailsDtoGen>(context, tree?[nameof(this.Details)]);
 
-            if ((context.IsInRoleCached("User")))
-            {
-                this.UniqueId = obj.UniqueId;
-            }
+            if ((context.IsInRoleCached("User"))) this.UniqueId = obj.UniqueId;
         }
 
         /// <summary>
@@ -75,11 +72,8 @@ namespace Coalesce.Web.Ko.Models
 
             if (ShouldMapTo(nameof(ProductId))) entity.ProductId = (ProductId ?? entity.ProductId);
             if (ShouldMapTo(nameof(Name))) entity.Name = Name;
+            if (ShouldMapTo(nameof(UniqueId)) && (context.IsInRoleCached("User") && context.IsInRoleCached("Admin"))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
             if (ShouldMapTo(nameof(Unknown))) entity.Unknown = Unknown;
-            if ((context.IsInRoleCached("User") && context.IsInRoleCached("Admin")))
-            {
-                if (ShouldMapTo(nameof(UniqueId))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
-            }
         }
 
         /// <summary>

--- a/playground/Coalesce.Web.Ko/Scripts/Generated/Ko.AuditLogProperty.g.ts
+++ b/playground/Coalesce.Web.Ko/Scripts/Generated/Ko.AuditLogProperty.g.ts
@@ -28,7 +28,9 @@ module ViewModels {
         public parentId: KnockoutObservable<number | null> = ko.observable(null);
         public propertyName: KnockoutObservable<string | null> = ko.observable(null);
         public oldValue: KnockoutObservable<string | null> = ko.observable(null);
+        public oldValueDescription: KnockoutObservable<string | null> = ko.observable(null);
         public newValue: KnockoutObservable<string | null> = ko.observable(null);
+        public newValueDescription: KnockoutObservable<string | null> = ko.observable(null);
         
         
         
@@ -56,7 +58,9 @@ module ViewModels {
             this.parentId(data.parentId);
             this.propertyName(data.propertyName);
             this.oldValue(data.oldValue);
+            this.oldValueDescription(data.oldValueDescription);
             this.newValue(data.newValue);
+            this.newValueDescription(data.newValueDescription);
             if (this.coalesceConfig.onLoadFromDto()){
                 this.coalesceConfig.onLoadFromDto()(this as any);
             }
@@ -73,7 +77,9 @@ module ViewModels {
             dto.parentId = this.parentId();
             dto.propertyName = this.propertyName();
             dto.oldValue = this.oldValue();
+            dto.oldValueDescription = this.oldValueDescription();
             dto.newValue = this.newValue();
+            dto.newValueDescription = this.newValueDescription();
             
             return dto;
         }
@@ -110,7 +116,9 @@ module ViewModels {
             self.parentId.subscribe(self.autoSave);
             self.propertyName.subscribe(self.autoSave);
             self.oldValue.subscribe(self.autoSave);
+            self.oldValueDescription.subscribe(self.autoSave);
             self.newValue.subscribe(self.autoSave);
+            self.newValueDescription.subscribe(self.autoSave);
             
             if (newItem) {
                 self.loadFromDto(newItem, true);

--- a/playground/Coalesce.Web.Ko/Scripts/Generated/Ko.AuditLogPropertyList.g.ts
+++ b/playground/Coalesce.Web.Ko/Scripts/Generated/Ko.AuditLogPropertyList.g.ts
@@ -20,7 +20,9 @@ module ListViewModels {
             parentId?: string;
             propertyName?: string;
             oldValue?: string;
+            oldValueDescription?: string;
             newValue?: string;
+            newValueDescription?: string;
         } | null = null;
         
         /** The namespace containing all possible values of this.dataSource. */

--- a/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/Cards.cshtml
+++ b/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/Cards.cshtml
@@ -70,9 +70,17 @@
                     <dd>
                         @(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValue, false))
                     </dd>
+                    <dt>Old Value Description</dt>
+                    <dd>
+                        @(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValueDescription, false))
+                    </dd>
                     <dt>New Value</dt>
                     <dd>
                         @(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValue, false))
+                    </dd>
+                    <dt>New Value Description</dt>
+                    <dd>
+                        @(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValueDescription, false))
                     </dd>
                 </dl>
                 

--- a/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/CreateEdit.cshtml
+++ b/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/CreateEdit.cshtml
@@ -39,8 +39,16 @@
                 <div class="col-md-8 prop-oldValue">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValue))</div>
             </div>
             <div class="form-group">
+                <label class="col-md-4 control-label">Old Value Description</label>
+                <div class="col-md-8 prop-oldValueDescription">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValueDescription))</div>
+            </div>
+            <div class="form-group">
                 <label class="col-md-4 control-label">New Value</label>
                 <div class="col-md-8 prop-newValue">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValue))</div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-4 control-label">New Value Description</label>
+                <div class="col-md-8 prop-newValueDescription">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValueDescription))</div>
             </div>
         </div>
     </div>

--- a/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/Table.cshtml
+++ b/playground/Coalesce.Web.Ko/Views/Generated/AuditLogProperty/Table.cshtml
@@ -80,9 +80,17 @@
                                 Old Value
                                 <i class="fa" data-bind="css: orderBy() == 'OldValue' ? 'fa-caret-up' : orderByDescending() == 'OldValue' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
                             </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('OldValueDescription')}">
+                                Old Value Description
+                                <i class="fa" data-bind="css: orderBy() == 'OldValueDescription' ? 'fa-caret-up' : orderByDescending() == 'OldValueDescription' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                            </th>
                             <th class="sortable-header" data-bind="click: function(){orderByToggle('NewValue')}">
                                 New Value
                                 <i class="fa" data-bind="css: orderBy() == 'NewValue' ? 'fa-caret-up' : orderByDescending() == 'NewValue' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
+                            </th>
+                            <th class="sortable-header" data-bind="click: function(){orderByToggle('NewValueDescription')}">
+                                New Value Description
+                                <i class="fa" data-bind="css: orderBy() == 'NewValueDescription' ? 'fa-caret-up' : orderByDescending() == 'NewValueDescription' ? 'fa-caret-down' : 'fa-sort'" style="float: right; padding: .3em 0 0 0 "></i>
                             </th>
                             <th style="width: 1%">
                             </th>
@@ -95,14 +103,18 @@
                                 <td class="prop-parentId">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.ParentId))</td>
                                 <td class="prop-propertyName">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.PropertyName))</td>
                                 <td class="prop-oldValue">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValue))</td>
+                                <td class="prop-oldValueDescription">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValueDescription))</td>
                                 <td class="prop-newValue">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValue))</td>
+                                <td class="prop-newValueDescription">@(Knockout.InputFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValueDescription))</td>
                             }
                             else
                             {
                                 <td class="prop-parentId">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.ParentId, true))</td>
                                 <td class="prop-propertyName">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.PropertyName, true))</td>
                                 <td class="prop-oldValue">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValue, true))</td>
+                                <td class="prop-oldValueDescription">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.OldValueDescription, true))</td>
                                 <td class="prop-newValue">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValue, true))</td>
+                                <td class="prop-newValueDescription">@(Knockout.DisplayFor<IntelliTect.Coalesce.AuditLogging.AuditLogProperty>(p => p.NewValueDescription, true))</td>
                             }
                             <td>
                                 <!-- Editor buttons -->

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CaseController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CaseController.g.cs
@@ -119,7 +119,7 @@ namespace Coalesce.Web.Vue2.Api
         public virtual ItemResult<System.Collections.Generic.ICollection<CaseDtoGen>> GetSomeCases()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetSomeCases(
                 Db
             );
@@ -386,7 +386,7 @@ namespace Coalesce.Web.Vue2.Api
         public virtual ItemResult<CaseSummaryDtoGen> GetCaseSummary()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetCaseSummary(
                 Db
             );

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CompanyController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CompanyController.g.cs
@@ -113,7 +113,7 @@ namespace Coalesce.Web.Vue2.Api
                 if (!_validationResult.WasSuccessful) return _validationResult;
             }
 
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             item.ConflictingParameterNames(
                 _params.companyParam.MapToNew(_mappingContext),
                 _params.name
@@ -144,7 +144,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Company.GetCertainItems(
                 Db,
                 _params.isDeleted

--- a/playground/Coalesce.Web.Vue2/Api/Generated/PersonController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/PersonController.g.cs
@@ -112,7 +112,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.Rename(
                 _params.name,
                 out includeTree
@@ -394,7 +394,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.ChangeFirstName(
                 _params.firstName,
                 _params.title
@@ -499,7 +499,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
                 Db,
                 _params.person.MapToNew(_mappingContext)
@@ -532,7 +532,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.SearchPeople(
                 Db,
                 _params.criteria.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Vue2/Api/Generated/WeatherServiceController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/WeatherServiceController.g.cs
@@ -63,7 +63,7 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = await Service.GetWeatherAsync(
                 parameterDbContext,
                 _params.location.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Vue2/Models/Generated/AuditLogDto.g.cs
+++ b/playground/Coalesce.Web.Vue2/Models/Generated/AuditLogDto.g.cs
@@ -94,9 +94,9 @@ namespace Coalesce.Web.Vue2.Models
             if (obj == null) return;
             var includes = context.Includes;
 
+            this.Id = obj.Id;
             this.Message = obj.Message;
             this.UserId = obj.UserId;
-            this.Id = obj.Id;
             this.Type = obj.Type;
             this.KeyValue = obj.KeyValue;
             this.State = obj.State;
@@ -130,9 +130,9 @@ namespace Coalesce.Web.Vue2.Models
 
             if (OnUpdate(entity, context)) return;
 
+            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Message))) entity.Message = Message;
             if (ShouldMapTo(nameof(UserId))) entity.UserId = UserId;
-            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Type))) entity.Type = Type;
             if (ShouldMapTo(nameof(KeyValue))) entity.KeyValue = KeyValue;
             if (ShouldMapTo(nameof(State))) entity.State = (State ?? entity.State);

--- a/playground/Coalesce.Web.Vue2/Models/Generated/AuditLogPropertyDto.g.cs
+++ b/playground/Coalesce.Web.Vue2/Models/Generated/AuditLogPropertyDto.g.cs
@@ -16,7 +16,9 @@ namespace Coalesce.Web.Vue2.Models
         private long? _ParentId;
         private string _PropertyName;
         private string _OldValue;
+        private string _OldValueDescription;
         private string _NewValue;
+        private string _NewValueDescription;
 
         public long? Id
         {
@@ -38,10 +40,20 @@ namespace Coalesce.Web.Vue2.Models
             get => _OldValue;
             set { _OldValue = value; Changed(nameof(OldValue)); }
         }
+        public string OldValueDescription
+        {
+            get => _OldValueDescription;
+            set { _OldValueDescription = value; Changed(nameof(OldValueDescription)); }
+        }
         public string NewValue
         {
             get => _NewValue;
             set { _NewValue = value; Changed(nameof(NewValue)); }
+        }
+        public string NewValueDescription
+        {
+            get => _NewValueDescription;
+            set { _NewValueDescription = value; Changed(nameof(NewValueDescription)); }
         }
 
         /// <summary>
@@ -56,7 +68,9 @@ namespace Coalesce.Web.Vue2.Models
             this.ParentId = obj.ParentId;
             this.PropertyName = obj.PropertyName;
             this.OldValue = obj.OldValue;
+            this.OldValueDescription = obj.OldValueDescription;
             this.NewValue = obj.NewValue;
+            this.NewValueDescription = obj.NewValueDescription;
         }
 
         /// <summary>
@@ -72,7 +86,9 @@ namespace Coalesce.Web.Vue2.Models
             if (ShouldMapTo(nameof(ParentId))) entity.ParentId = (ParentId ?? entity.ParentId);
             if (ShouldMapTo(nameof(PropertyName))) entity.PropertyName = PropertyName;
             if (ShouldMapTo(nameof(OldValue))) entity.OldValue = OldValue;
+            if (ShouldMapTo(nameof(OldValueDescription))) entity.OldValueDescription = OldValueDescription;
             if (ShouldMapTo(nameof(NewValue))) entity.NewValue = NewValue;
+            if (ShouldMapTo(nameof(NewValueDescription))) entity.NewValueDescription = NewValueDescription;
         }
 
         /// <summary>

--- a/playground/Coalesce.Web.Vue2/Models/Generated/CaseDto.g.cs
+++ b/playground/Coalesce.Web.Vue2/Models/Generated/CaseDto.g.cs
@@ -137,8 +137,6 @@ namespace Coalesce.Web.Vue2.Models
             this.AssignedToId = obj.AssignedToId;
             this.ReportedById = obj.ReportedById;
             this.AttachmentSize = obj.AttachmentSize;
-            this.AttachmentName = obj.AttachmentName;
-            this.AttachmentType = obj.AttachmentType;
             this.AttachmentHash = obj.AttachmentHash;
             this.Severity = obj.Severity;
             this.Status = obj.Status;
@@ -159,6 +157,8 @@ namespace Coalesce.Web.Vue2.Models
 
             this.DevTeamAssigned = obj.DevTeamAssigned.MapToDto<Coalesce.Domain.External.DevTeam, DevTeamDtoGen>(context, tree?[nameof(this.DevTeamAssigned)]);
 
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentName), obj)) this.AttachmentName = obj.AttachmentName;
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentType), obj)) this.AttachmentType = obj.AttachmentType;
             if (!(includes == "PersonListGen"))
             {
                 if (tree == null || tree[nameof(this.AssignedTo)] != null)
@@ -168,6 +168,7 @@ namespace Coalesce.Web.Vue2.Models
                     this.ReportedBy = obj.ReportedBy.MapToDto<Coalesce.Domain.Person, PersonDtoGen>(context, tree?[nameof(this.ReportedBy)]);
 
             }
+
         }
 
         /// <summary>
@@ -185,7 +186,7 @@ namespace Coalesce.Web.Vue2.Models
             if (ShouldMapTo(nameof(OpenedAt))) entity.OpenedAt = (OpenedAt ?? entity.OpenedAt);
             if (ShouldMapTo(nameof(AssignedToId))) entity.AssignedToId = AssignedToId;
             if (ShouldMapTo(nameof(ReportedById))) entity.ReportedById = ReportedById;
-            if (ShouldMapTo(nameof(AttachmentType))) entity.AttachmentType = AttachmentType;
+            if (ShouldMapTo(nameof(AttachmentType)) && context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanWrite(context, nameof(AttachmentType), entity, AttachmentType)) entity.AttachmentType = AttachmentType;
             if (ShouldMapTo(nameof(Severity))) entity.Severity = Severity;
             if (ShouldMapTo(nameof(Status))) entity.Status = (Status ?? entity.Status);
             if (ShouldMapTo(nameof(DevTeamAssignedId))) entity.DevTeamAssignedId = DevTeamAssignedId;

--- a/playground/Coalesce.Web.Vue2/Models/Generated/ProductDto.g.cs
+++ b/playground/Coalesce.Web.Vue2/Models/Generated/ProductDto.g.cs
@@ -58,10 +58,7 @@ namespace Coalesce.Web.Vue2.Models
 
             this.Details = obj.Details.MapToDto<Coalesce.Domain.ProductDetails, ProductDetailsDtoGen>(context, tree?[nameof(this.Details)]);
 
-            if ((context.IsInRoleCached("User")))
-            {
-                this.UniqueId = obj.UniqueId;
-            }
+            if ((context.IsInRoleCached("User"))) this.UniqueId = obj.UniqueId;
         }
 
         /// <summary>
@@ -75,11 +72,8 @@ namespace Coalesce.Web.Vue2.Models
 
             if (ShouldMapTo(nameof(ProductId))) entity.ProductId = (ProductId ?? entity.ProductId);
             if (ShouldMapTo(nameof(Name))) entity.Name = Name;
+            if (ShouldMapTo(nameof(UniqueId)) && (context.IsInRoleCached("User") && context.IsInRoleCached("Admin"))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
             if (ShouldMapTo(nameof(Unknown))) entity.Unknown = Unknown;
-            if ((context.IsInRoleCached("User") && context.IsInRoleCached("Admin")))
-            {
-                if (ShouldMapTo(nameof(UniqueId))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
-            }
         }
 
         /// <summary>

--- a/playground/Coalesce.Web.Vue2/src/metadata.g.ts
+++ b/playground/Coalesce.Web.Vue2/src/metadata.g.ts
@@ -287,9 +287,21 @@ export const AuditLogProperty = domain.types.AuditLogProperty = {
       type: "string",
       role: "value",
     },
+    oldValueDescription: {
+      name: "oldValueDescription",
+      displayName: "Old Value Description",
+      type: "string",
+      role: "value",
+    },
     newValue: {
       name: "newValue",
       displayName: "New Value",
+      type: "string",
+      role: "value",
+    },
+    newValueDescription: {
+      name: "newValueDescription",
+      displayName: "New Value Description",
       type: "string",
       role: "value",
     },

--- a/playground/Coalesce.Web.Vue2/src/models.g.ts
+++ b/playground/Coalesce.Web.Vue2/src/models.g.ts
@@ -81,7 +81,9 @@ export interface AuditLogProperty extends Model<typeof metadata.AuditLogProperty
   parentId: number | null
   propertyName: string | null
   oldValue: string | null
+  oldValueDescription: string | null
   newValue: string | null
+  newValueDescription: string | null
 }
 export class AuditLogProperty {
   

--- a/playground/Coalesce.Web.Vue2/src/viewmodels.g.ts
+++ b/playground/Coalesce.Web.Vue2/src/viewmodels.g.ts
@@ -43,7 +43,9 @@ export interface AuditLogPropertyViewModel extends $models.AuditLogProperty {
   parentId: number | null;
   propertyName: string | null;
   oldValue: string | null;
+  oldValueDescription: string | null;
   newValue: string | null;
+  newValueDescription: string | null;
 }
 export class AuditLogPropertyViewModel extends ViewModel<$models.AuditLogProperty, $apiClients.AuditLogPropertyApiClient, number> implements $models.AuditLogProperty  {
   

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CaseController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CaseController.g.cs
@@ -119,7 +119,7 @@ namespace Coalesce.Web.Vue3.Api
         public virtual ItemResult<System.Collections.Generic.ICollection<CaseDtoGen>> GetSomeCases()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetSomeCases(
                 Db
             );
@@ -386,7 +386,7 @@ namespace Coalesce.Web.Vue3.Api
         public virtual ItemResult<CaseSummaryDtoGen> GetCaseSummary()
         {
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Case.GetCaseSummary(
                 Db
             );

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CompanyController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CompanyController.g.cs
@@ -113,7 +113,7 @@ namespace Coalesce.Web.Vue3.Api
                 if (!_validationResult.WasSuccessful) return _validationResult;
             }
 
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             item.ConflictingParameterNames(
                 _params.companyParam.MapToNew(_mappingContext),
                 _params.name
@@ -144,7 +144,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Company.GetCertainItems(
                 Db,
                 _params.isDeleted

--- a/playground/Coalesce.Web.Vue3/Api/Generated/PersonController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/PersonController.g.cs
@@ -112,7 +112,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.Rename(
                 _params.name,
                 out includeTree
@@ -394,7 +394,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = item.ChangeFirstName(
                 _params.firstName,
                 _params.title
@@ -499,7 +499,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
                 Db,
                 _params.person.MapToNew(_mappingContext)
@@ -532,7 +532,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.SearchPeople(
                 Db,
                 _params.criteria.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Vue3/Api/Generated/WeatherServiceController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/WeatherServiceController.g.cs
@@ -63,7 +63,7 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             IncludeTree includeTree = null;
-            var _mappingContext = new MappingContext(User);
+            var _mappingContext = new MappingContext(Context);
             var _methodResult = await Service.GetWeatherAsync(
                 parameterDbContext,
                 _params.location.MapToNew(_mappingContext),

--- a/playground/Coalesce.Web.Vue3/Models/Generated/AuditLogDto.g.cs
+++ b/playground/Coalesce.Web.Vue3/Models/Generated/AuditLogDto.g.cs
@@ -94,9 +94,9 @@ namespace Coalesce.Web.Vue3.Models
             if (obj == null) return;
             var includes = context.Includes;
 
+            this.Id = obj.Id;
             this.Message = obj.Message;
             this.UserId = obj.UserId;
-            this.Id = obj.Id;
             this.Type = obj.Type;
             this.KeyValue = obj.KeyValue;
             this.State = obj.State;
@@ -130,9 +130,9 @@ namespace Coalesce.Web.Vue3.Models
 
             if (OnUpdate(entity, context)) return;
 
+            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Message))) entity.Message = Message;
             if (ShouldMapTo(nameof(UserId))) entity.UserId = UserId;
-            if (ShouldMapTo(nameof(Id))) entity.Id = (Id ?? entity.Id);
             if (ShouldMapTo(nameof(Type))) entity.Type = Type;
             if (ShouldMapTo(nameof(KeyValue))) entity.KeyValue = KeyValue;
             if (ShouldMapTo(nameof(State))) entity.State = (State ?? entity.State);

--- a/playground/Coalesce.Web.Vue3/Models/Generated/CaseDto.g.cs
+++ b/playground/Coalesce.Web.Vue3/Models/Generated/CaseDto.g.cs
@@ -137,8 +137,6 @@ namespace Coalesce.Web.Vue3.Models
             this.AssignedToId = obj.AssignedToId;
             this.ReportedById = obj.ReportedById;
             this.AttachmentSize = obj.AttachmentSize;
-            this.AttachmentName = obj.AttachmentName;
-            this.AttachmentType = obj.AttachmentType;
             this.AttachmentHash = obj.AttachmentHash;
             this.Severity = obj.Severity;
             this.Status = obj.Status;
@@ -159,6 +157,8 @@ namespace Coalesce.Web.Vue3.Models
 
             this.DevTeamAssigned = obj.DevTeamAssigned.MapToDto<Coalesce.Domain.External.DevTeam, DevTeamDtoGen>(context, tree?[nameof(this.DevTeamAssigned)]);
 
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentName), obj)) this.AttachmentName = obj.AttachmentName;
+            if (context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanRead(context, nameof(AttachmentType), obj)) this.AttachmentType = obj.AttachmentType;
             if (!(includes == "PersonListGen"))
             {
                 if (tree == null || tree[nameof(this.AssignedTo)] != null)
@@ -168,6 +168,7 @@ namespace Coalesce.Web.Vue3.Models
                     this.ReportedBy = obj.ReportedBy.MapToDto<Coalesce.Domain.Person, PersonDtoGen>(context, tree?[nameof(this.ReportedBy)]);
 
             }
+
         }
 
         /// <summary>
@@ -185,7 +186,7 @@ namespace Coalesce.Web.Vue3.Models
             if (ShouldMapTo(nameof(OpenedAt))) entity.OpenedAt = (OpenedAt ?? entity.OpenedAt);
             if (ShouldMapTo(nameof(AssignedToId))) entity.AssignedToId = AssignedToId;
             if (ShouldMapTo(nameof(ReportedById))) entity.ReportedById = ReportedById;
-            if (ShouldMapTo(nameof(AttachmentType))) entity.AttachmentType = AttachmentType;
+            if (ShouldMapTo(nameof(AttachmentType)) && context.GetPropertyRestriction<Coalesce.Domain.Case.TestRestriction>().UserCanWrite(context, nameof(AttachmentType), entity, AttachmentType)) entity.AttachmentType = AttachmentType;
             if (ShouldMapTo(nameof(Severity))) entity.Severity = Severity;
             if (ShouldMapTo(nameof(Status))) entity.Status = (Status ?? entity.Status);
             if (ShouldMapTo(nameof(DevTeamAssignedId))) entity.DevTeamAssignedId = DevTeamAssignedId;

--- a/playground/Coalesce.Web.Vue3/Models/Generated/ProductDto.g.cs
+++ b/playground/Coalesce.Web.Vue3/Models/Generated/ProductDto.g.cs
@@ -58,10 +58,7 @@ namespace Coalesce.Web.Vue3.Models
 
             this.Details = obj.Details.MapToDto<Coalesce.Domain.ProductDetails, ProductDetailsDtoGen>(context, tree?[nameof(this.Details)]);
 
-            if ((context.IsInRoleCached("User")))
-            {
-                this.UniqueId = obj.UniqueId;
-            }
+            if ((context.IsInRoleCached("User"))) this.UniqueId = obj.UniqueId;
         }
 
         /// <summary>
@@ -75,11 +72,8 @@ namespace Coalesce.Web.Vue3.Models
 
             if (ShouldMapTo(nameof(ProductId))) entity.ProductId = (ProductId ?? entity.ProductId);
             if (ShouldMapTo(nameof(Name))) entity.Name = Name;
+            if (ShouldMapTo(nameof(UniqueId)) && (context.IsInRoleCached("User") && context.IsInRoleCached("Admin"))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
             if (ShouldMapTo(nameof(Unknown))) entity.Unknown = Unknown;
-            if ((context.IsInRoleCached("User") && context.IsInRoleCached("Admin")))
-            {
-                if (ShouldMapTo(nameof(UniqueId))) entity.UniqueId = (UniqueId ?? entity.UniqueId);
-            }
         }
 
         /// <summary>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ClassDto.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ClassDto.cs
@@ -118,7 +118,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
 
                 var orderedProps = Model
                     .ClientProperties
-                    // PK always first so it is available to guide decisions in IMappingRestirctions
+                    // PK always first so it is available to guide decisions in IPropertyRestrictions
                     .OrderBy(p => !p.IsPrimaryKey)
                         // Scalars before objects
                         .ThenBy(p => p.PureType.HasClassViewModel)

--- a/src/IntelliTect.Coalesce.Tests/TargetClasses/SecurityTargets.cs
+++ b/src/IntelliTect.Coalesce.Tests/TargetClasses/SecurityTargets.cs
@@ -38,6 +38,32 @@ namespace IntelliTect.Coalesce.Tests.TargetClasses
         [Read("ReadRole"), Edit("EditRole")]
         public string ReadWriteDifferentRoles { get; set; }
 
+        [Restrict<AuthenticatedRestriction>]
+        public string RestrictFilter { get; set; }
+
+        [Restrict<AuthenticatedRestriction>]
+        [Restrict<Restrict2>]
+        public string RestrictMultiple { get; set; }
+
         public DbSetIsInternalUse ExternalTypeUsageOfEntityWithInternalDbSet { get; set; }
+    }
+
+    public class AuthenticatedRestriction : IPropertyRestriction
+    {
+        public bool UserCanFilter(IMappingContext context, string propertyName)
+            => context.User.Identity?.IsAuthenticated == true;
+
+        public bool UserCanRead(IMappingContext context, string propertyName, object model)
+            => context.User.Identity?.IsAuthenticated == true;
+
+        public bool UserCanWrite(IMappingContext context, string propertyName, object model, object incomingValue)
+            => context.User.Identity?.IsAuthenticated == true;
+    }
+
+    public class Restrict2 : IPropertyRestriction
+    {
+        public bool UserCanRead(IMappingContext context, string propertyName, object model) => true;
+
+        public bool UserCanWrite(IMappingContext context, string propertyName, object model, object incomingValue) => true;
     }
 }

--- a/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
+++ b/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
@@ -61,6 +61,12 @@ namespace IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext
         [Read(RoleNames.Admin)]
         public string AdminReadableString { get; set; }
 
+        [Restrict<AuthenticatedRestriction>]
+        public string RestrictedString { get; set; }
+
+        [Restrict<AuthenticatedRestriction>]
+        public string RestrictInit { get; init; }
+
         [Read(RoleNames.Admin)]
         public int? AdminReadableReferenceNavigationId { get; set; }
 

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/StandardDataSourceTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/StandardDataSourceTests.cs
@@ -6,6 +6,7 @@ using IntelliTect.Coalesce.Tests.Util;
 using IntelliTect.Coalesce.TypeDefinition;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -123,7 +124,20 @@ namespace IntelliTect.Coalesce.Tests.Api.DataSources
             // Preconditions
             Assert.False(CrudContext.User.IsInRole(role));
             Assert.Collection(prop.SecurityInfo.Read.RoleList, r => Assert.Equal(role, r));
-            
+
+            Assert.Single(query);
+        }
+
+        [Fact]
+        public void ApplyListPropertyFilters_WhenPropRestricted_IgnoresProp()
+        {
+            var (prop, query) = PropertyFiltersTestHelper<ComplexModel, string>(
+                m => m.RestrictedString, "propValue", "inputValue");
+
+            // Preconditions
+            Assert.NotEqual(true, CrudContext.User.Identity?.IsAuthenticated);
+            Assert.NotEmpty(prop.SecurityInfo.Restrictions);
+
             Assert.Single(query);
         }
 
@@ -141,8 +155,22 @@ namespace IntelliTect.Coalesce.Tests.Api.DataSources
             
             Assert.Empty(query);
         }
-        
-        
+
+        [Fact]
+        public void ApplyListPropertyFilters_WhenPropRestrictionPasses_FiltersProp()
+        {
+            CrudContext.User.AddIdentity(new ClaimsIdentity("foo"));
+            var (prop, query) = PropertyFiltersTestHelper<ComplexModel, string>(
+                m => m.RestrictedString, "propValue", "inputValue");
+
+            // Preconditions
+            Assert.True(CrudContext.User.Identity?.IsAuthenticated);
+            Assert.NotEmpty(prop.SecurityInfo.Restrictions);
+
+            Assert.Empty(query);
+        }
+
+
         public static IEnumerable<object[]> Filter_MatchesDateTimesData = new[]
         {
             new object[] { true, "2017-08-02", new DateTime(2017, 08, 02, 0, 0, 0) },
@@ -363,6 +391,12 @@ namespace IntelliTect.Coalesce.Tests.Api.DataSources
             source
                 .Query(s => s.ApplyListSorting(s.Query(), new ListParameters
                 {
+                    OrderBy = $"{nameof(ComplexModel.RestrictedString)}"
+                }))
+                .AssertOrder(models);
+            source
+                .Query(s => s.ApplyListSorting(s.Query(), new ListParameters
+                {
                     OrderBy = $"{nameof(ComplexModel.AdminReadableReferenceNavigation)}.{nameof(ComplexModel.ComplexModelId)}"
                 }))
                 .AssertOrder(models);
@@ -552,6 +586,20 @@ namespace IntelliTect.Coalesce.Tests.Api.DataSources
 
             // Since searching by prop isn't valid for this specific property,
             // the search will instead treat the entire input as the search term.
+            // Since this search term doesn't match the property's value, the results should be empty.
+            query.AssertMatched(false);
+        }
+
+        [Fact]
+        public void ApplyListSearchTerm_WhenTargetedPropRestricted_IgnoresProp()
+        {
+            var query = Source<ComplexModel>()
+                .AddModel(m => m.RestrictedString, "propValue", out PropertyViewModel prop)
+                .Query(s => s.ApplyListSearchTerm(s.Query(), new FilterParameters
+                {
+                    Search = "RestrictedString:propV"
+                }));
+
             // Since this search term doesn't match the property's value, the results should be empty.
             query.AssertMatched(false);
         }

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/SearchTests.cs
@@ -179,12 +179,12 @@ namespace IntelliTect.Coalesce.Tests.Api
         {
             var classViewModel = new ReflectionClassViewModel(typeof(T));
             var prop = classViewModel.PropertyBySelector(propSelector);
+            var context = new CrudContext(() => new ClaimsPrincipal(), timeZoneInfo ?? TimeZoneInfo.Local);
 
             var searchClauses = prop
                 .SearchProperties(classViewModel, maxDepth: 1, force: true)
                 .SelectMany(p => p.GetLinqDynamicSearchStatements(
-                    new ClaimsPrincipal(),
-                    timeZoneInfo ?? TimeZoneInfo.Local,
+                    context,
                     "it",
                     searchTerm
                 ))

--- a/src/IntelliTect.Coalesce.Tests/Util/PropertyViewModelDataAttribute.cs
+++ b/src/IntelliTect.Coalesce.Tests/Util/PropertyViewModelDataAttribute.cs
@@ -40,4 +40,12 @@ namespace IntelliTect.Coalesce.Tests.Util
         {
         }
     }
+
+    internal class ReflectionPropertyViewModelDataAttribute<T> : PropertyViewModelDataAttribute<T>
+    {
+        public ReflectionPropertyViewModelDataAttribute(string propName, params object[] additionalInlineData) : base(propName, additionalInlineData)
+        {
+            symbol = false;
+        }
+    }
 }

--- a/src/IntelliTect.Coalesce/Api/CrudContext.cs
+++ b/src/IntelliTect.Coalesce/Api/CrudContext.cs
@@ -1,4 +1,5 @@
-﻿using IntelliTect.Coalesce.TypeDefinition;
+﻿using IntelliTect.Coalesce.Mapping;
+using IntelliTect.Coalesce.TypeDefinition;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -53,6 +54,16 @@ namespace IntelliTect.Coalesce
             ServiceProvider = baseContext.ServiceProvider;
         }
 
+
+        /// <summary>
+        /// A shared mapping context instance for this operation.
+        /// Use intended for handling inputs before any mutations (if any)
+        /// have occurred that might invalidate local state on cached instances
+        /// of IPropertyRestriction.
+        /// </summary>
+        internal MappingContext MappingContext => _mappingContext ??= new MappingContext(this);
+        private MappingContext? _mappingContext;
+
         /// <summary>
         /// The user making the request for a CRUD action.
         /// </summary>
@@ -89,7 +100,7 @@ namespace IntelliTect.Coalesce
     public class CrudContext<TContext> : CrudContext
         where TContext : DbContext
     {
-        public CrudContext(TContext dbContext, Func<ClaimsPrincipal?> userAccessor)
+        public CrudContext(TContext dbContext, Func<ClaimsPrincipal> userAccessor)
             : base(userAccessor)
         {
             DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
@@ -97,7 +108,7 @@ namespace IntelliTect.Coalesce
 
         public CrudContext(
             TContext dbContext, 
-            Func<ClaimsPrincipal?> userAccessor, 
+            Func<ClaimsPrincipal> userAccessor, 
             TimeZoneInfo timeZone,
             CancellationToken cancellationToken = default
         )

--- a/src/IntelliTect.Coalesce/Api/DataSources/QueryableDataSourceBase`1.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/QueryableDataSourceBase`1.cs
@@ -73,7 +73,7 @@ namespace IntelliTect.Coalesce
                 var prop = ClassViewModel.PropertyByName(clause.Key);
                 if (prop != null
                     && prop.IsUrlFilterParameter
-                    && prop.SecurityInfo.IsReadAllowed(User))
+                    && prop.SecurityInfo.IsFilterAllowed(Context))
                 {
                     query = ApplyListPropertyFilter(query, prop, clause.Value);
                 }
@@ -269,7 +269,7 @@ namespace IntelliTect.Coalesce
                 {
                     var expressions = prop
                         .SearchProperties(ClassViewModel, maxDepth: 1, force: true)
-                        .SelectMany(p => p.GetLinqDynamicSearchStatements(Context.User, Context.TimeZone, "it", value))
+                        .SelectMany(p => p.GetLinqDynamicSearchStatements(Context, "it", value))
                         .Select(t => t.statement)
                         .ToList();
 
@@ -303,7 +303,7 @@ namespace IntelliTect.Coalesce
             {
                 var splitOnStringClauses = ClassViewModel
                     .SearchProperties(ClassViewModel)
-                    .SelectMany(p => p.GetLinqDynamicSearchStatements(Context.User, Context.TimeZone, "it", termWord))
+                    .SelectMany(p => p.GetLinqDynamicSearchStatements(Context, "it", termWord))
                     .Where(f => f.property.SearchIsSplitOnSpaces)
                     .Select(t => t.statement)
                     .ToList();
@@ -328,7 +328,7 @@ namespace IntelliTect.Coalesce
             // we only require that the entire search term match at least one of these properties.
             var searchClauses = ClassViewModel
                 .SearchProperties(ClassViewModel)
-                .SelectMany(p => p.GetLinqDynamicSearchStatements(Context.User, Context.TimeZone, "it", searchTerm))
+                .SelectMany(p => p.GetLinqDynamicSearchStatements(Context, "it", searchTerm))
                 .Where(f => !f.property.SearchIsSplitOnSpaces)
                 .Select(t => t.statement)
                 .ToList();
@@ -405,7 +405,7 @@ namespace IntelliTect.Coalesce
                         prop = (prop?.Object ?? ClassViewModel).PropertyByName(part);
 
                         // Check if the new prop exists and is readable by user.
-                        if (prop == null || !prop.IsClientProperty || !prop.SecurityInfo.IsReadAllowed(User))
+                        if (prop == null || !prop.IsClientProperty || !prop.SecurityInfo.IsFilterAllowed(Context))
                         {
                             return null;
                         }

--- a/src/IntelliTect.Coalesce/Application/CoalesceApplicationBuilderExtensions.cs
+++ b/src/IntelliTect.Coalesce/Application/CoalesceApplicationBuilderExtensions.cs
@@ -65,7 +65,8 @@ public static class CoalesceApplicationBuilderExtensions
         {
             CrudTypes = repo
                 .CrudApiBackedClasses
-                .OrderBy(c => c.Name)
+                .OrderBy(c => c.IsDto)
+                .ThenBy(c => c.Name)
                 .Select(c =>
                 {
                     var isImmutable = c.SecurityInfo is
@@ -181,6 +182,7 @@ public static class CoalesceApplicationBuilderExtensions
             p.SecurityInfo.Read,
             p.SecurityInfo.Init,
             p.SecurityInfo.Edit,
+            Restrictions = p.SecurityInfo.Restrictions.Select(t => t.Name).ToList(),
             p.IsCreateOnly,
             p.IsPrimaryKey
         };

--- a/src/IntelliTect.Coalesce/Application/CoalesceServiceCollectionExtensions.cs
+++ b/src/IntelliTect.Coalesce/Application/CoalesceServiceCollectionExtensions.cs
@@ -64,7 +64,7 @@ namespace IntelliTect.Coalesce
             services.TryAddScoped<ITimeZoneResolver>(_ => new StaticTimeZoneResolver(TimeZoneInfo.Local));
 
             services.TryAddScoped(sp => new CrudContext(
-                 () => sp.GetRequiredService<IHttpContextAccessor>().HttpContext?.User,
+                 () => sp.GetRequiredService<IHttpContextAccessor>().HttpContext?.User ?? new System.Security.Claims.ClaimsPrincipal(),
                  sp.GetService<ITimeZoneResolver>()?.GetTimeZoneInfo() ?? TimeZoneInfo.Local,
                  sp.GetRequiredService<IHttpContextAccessor>().HttpContext?.RequestAborted ?? default,
                  sp.GetRequiredService<IOptions<CoalesceOptions>>().Value,

--- a/src/IntelliTect.Coalesce/Application/SecurityOverview.html
+++ b/src/IntelliTect.Coalesce/Application/SecurityOverview.html
@@ -7,11 +7,29 @@
     <title>Coalesce Security Overview</title>
 
     <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+      integrity="sha256-MBffSnbbXwHCuZtgPYiwMQbfE7z+GOZ7fBPCNB06Z98="
       crossorigin="anonymous"
     />
+    <script>
+      const getStoredTheme = () => localStorage.getItem("coalesce-sec-theme");
+      const setStoredTheme = (theme) =>
+        localStorage.setItem("coalesce-sec-theme", theme);
+
+      const getTheme = () =>
+        getStoredTheme() ||
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+
+      const setTheme = (theme) => {
+        document.documentElement.setAttribute("data-bs-theme", theme);
+        setStoredTheme(theme);
+      };
+
+      setTheme(getTheme());
+    </script>
     <style>
       [v-cloak] {
         display: none;
@@ -78,25 +96,30 @@
               max-height: calc(100vh - 16px);
             "
           >
+            <span class="float-end">
+              Theme:
+              <a
+                class="text-capitalize"
+                role="button"
+                @click="setTheme(theme = (theme == 'dark' ? 'light' : 'dark'))"
+              >
+                {{ theme }}
+              </a>
+            </span>
             <a href="#top">Top</a>
 
-            <h6 class="mt-4">Entities &amp; Custom DTOs</h6>
-            <div v-if="!crudTypes.length" class="text-muted">None</div>
-            <div v-for="type in crudTypes">
-              <a :href="'#type-' + type.name">{{type.name}}</a>
-            </div>
-
-            <h6 class="mt-4">Services</h6>
-            <div v-if="!serviceTypes.length" class="text-muted">None</div>
-            <div v-for="type in serviceTypes">
-              <a :href="'#type-' + type.name">{{type.name}}</a>
-            </div>
-
-            <h6 class="mt-4">External Types</h6>
-            <div v-if="!externalTypes.length" class="text-muted">None</div>
-            <div v-for="type in externalTypes">
-              <a :href="'#type-' + type.name">{{type.name}}</a>
-            </div>
+            <template v-for="set in [
+              {heading: 'Entities', types: crudTypes.filter(t => !t.dtoBaseType)},
+              {heading: 'Custom DTOs', types: crudTypes.filter(t => t.dtoBaseType), hideEmpty: true},
+              {heading: 'Services', types: serviceTypes},
+              {heading: 'External Types', types: externalTypes}
+            ].filter(s => s.types.length || !s.hideEmpty)">
+              <h6 class="mt-4">{{set.heading}}</h6>
+              <div v-if="!set.types.length" class="text-muted">None</div>
+              <div v-for="t in set.types">
+                <a :href="'#type-' + t.name">{{t.name}}</a>
+              </div>
+            </template>
           </nav>
         </div>
         <div class="col">
@@ -155,9 +178,9 @@
                       <tr
                         v-for="({action, subtitle}, idx) in [
                           {action: type.read, subtitle: '/get, /list, /count'},
-                          {action: type.create, subtitle: '/save'},
-                          {action: type.edit, subtitle: '/save'},
-                          {action: type.delete, subtitle: '/delete'}
+                          {action: type.create, subtitle: '/save, /bulkSave'},
+                          {action: type.edit, subtitle: '/save, /bulkSave'},
+                          {action: type.delete, subtitle: '/delete, /bulkSave'}
                         ]"
                       >
                         <td>
@@ -257,7 +280,7 @@
                   </div>
                 </div>
 
-                <div class="col" style="flex-basis: 450px; max-width: 500px">
+                <div class="col" style="flex-basis: 450px">
                   <div class="card mb-4">
                     <div class="card-body">
                       <h4 class="card-title" v-if="type.dtoBaseType">
@@ -267,7 +290,10 @@
                         Generated DTO Properties
                       </h4>
 
-                      <properties-table :type="type" :is-crud="true"></properties-table>
+                      <properties-table
+                        :type="type"
+                        :is-crud="true"
+                      ></properties-table>
 
                       <div
                         v-if="type.dtoBaseType"
@@ -328,7 +354,10 @@
                   <div class="card mb-4">
                     <div class="card-body">
                       <h4 class="card-title">Generated DTO Properties</h4>
-                      <properties-table :type="type" :is-crud="false"></properties-table>
+                      <properties-table
+                        :type="type"
+                        :is-crud="false"
+                      ></properties-table>
                     </div>
                   </div>
                 </div>
@@ -421,12 +450,36 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th width="100px" title="Security rules for any place that this entity is served in a response to the client.">Read</th>
+            <th
+              class="text-center"
+              width="100px"
+              title="Security rules for any place that this entity is served in a response to the client."
+            >
+              Read
+            </th>
             <template v-if="isCrud">
-              <th width="100px" title="Security rules for Create saves, and usage as a custom method parameter.">Create</th>
-              <th width="100px" title="Security rules for Edit saves.">Edit</th>
+              <th
+                class="text-center"
+                width="100px"
+                title="Security rules for Create saves, and usage as a custom method parameter."
+              >
+                Create
+              </th>
+              <th
+                class="text-center"
+                width="100px"
+                title="Security rules for Edit saves."
+              >
+                Edit
+              </th>
             </template>
-            <th v-else width="100px">Write</th>
+            <th
+              v-else
+              width="100px"
+              title="Security rules for any place that this type is provided as an input to the server."
+            >
+              Write
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -439,32 +492,47 @@
               </small>
             </td>
             <template v-if="type.dtoBaseType">
-              <td><span class="badge bg-custom-code">Custom</span></td>
-              <td><span class="badge bg-custom-code">Custom</span></td>
-              <td><span class="badge bg-custom-code">Custom</span></td>
+              <td v-for="i in 3" class="text-center">
+                <span class="badge bg-custom-code">Custom</span>
+              </td>
             </template>
             <template v-else>
-              <td>
-                <security-badge :action="prop.read"></security-badge>
+              <td class="text-center">
+                <security-badge
+                  :action="prop.read"
+                  :restrict="prop.restrictions"
+                ></security-badge>
               </td>
-              <td>
-                <security-badge :action="prop.init"></security-badge>
-                <div v-if="prop.isPrimaryKey && !prop.isCreateOnly"
-                     class="text-muted"
-                     title="The property is the primary key. &#013;&#013;During a save, its absence is what triggers a Create save. &#013;As a custom method parameter, it is mapped like any other property.">
+              <td class="text-center">
+                <security-badge
+                  :action="prop.init"
+                  :restrict="prop.restrictions"
+                ></security-badge>
+                <div
+                  v-if="prop.isPrimaryKey && !prop.isCreateOnly"
+                  class="text-muted"
+                  title="The property is the primary key. &#013;&#013;During a save, its absence is what triggers a Create save. &#013;As a custom method parameter, it is mapped like any other property."
+                >
                   <small>🔑 PK</small>
                 </div>
-                <div v-if="prop.isPrimaryKey && prop.isCreateOnly"
-                     class="text-muted"
-                     title="The property is the primary key. &#013;&#013;During a save, an existing entity with this key will be looked up in the database, and the absence of a match is what triggers a Create save. &#013;As a custom method parameter, it is mapped like any other property.">
+                <div
+                  v-if="prop.isPrimaryKey && prop.isCreateOnly"
+                  class="text-muted"
+                  title="The property is the primary key. &#013;&#013;During a save, an existing entity with this key will be looked up in the database, and the absence of a match is what triggers a Create save. &#013;As a custom method parameter, it is mapped like any other property."
+                >
                   <small>🔑 PK</small>
                 </div>
               </td>
-              <td v-if="isCrud">
-                <security-badge :action="prop.edit"></security-badge>
-                <div v-if="prop.isPrimaryKey"
-                      class="text-muted"
-                      title="The property is the primary key. &#013;&#013;During an Edit, it is used to look up the existing entity to edit.">
+              <td class="text-center" v-if="isCrud">
+                <security-badge
+                  :action="prop.edit"
+                  :restrict="prop.restrictions"
+                ></security-badge>
+                <div
+                  v-if="prop.isPrimaryKey"
+                  class="text-muted"
+                  title="The property is the primary key. &#013;&#013;During an Edit, it is used to look up the existing entity to edit."
+                >
                   <small>🔑 PK</small>
                 </div>
               </td>
@@ -487,54 +555,59 @@
       <span>
         <span
           v-if="action.noAccess"
-          class="badge border border-danger text-dark"
+          class="badge border border-danger text-body"
           :title="action.reason"
         >
           Deny
         </span>
-        <span v-else-if="action.allowAnonymous" class="badge bg-danger">
-          Allow Anonymous
-        </span>
         <span
           v-else
           class="badge"
-          :class="action.isUnused ? 'border text-dark' : !action.hasRoles ? 'bg-success' : 'bg-success'"
+          :class="
+            action.isUnused ? 'border text-body' : 
+            action.allowAnonymous ? 'bg-danger' : 
+            !action.hasRoles ? 'bg-success' : 
+            'bg-success'"
           :title="
-              ('Allow' + ('allowAnonymous' in action ? ' Authenticated' : '')) + ' - ' +
+              ('Allow' + (action.allowAnonymous === false ? ' Authenticated' : action.allowAnonymous === true ? ' Anonymous' : '')) + ' - ' +
               (!action.hasRoles 
                 ? 'No specific role requirements' 
                 : action.roleLists.length == 1 
                   ? 'One of these roles is required: \n' + action.roleLists[0].join('\n')
                   : 'One role from each role group is required: \n' + action.roleLists.map(rl => 'Role Group: ' + rl.join(', ')).join('\n')
               ) +
+              (!restrict?.length ? '' : '\n\nThe following custom restrictions are applied: \n' + restrict.join('\n')) +
               (action.isUnused ? '\n\nAnalyzed as unused by any API endpoint.' : '')
             "
         >
-          <div v-if="action.isUnused">Unused</div>
-          <div v-else>
-            Allow {{'allowAnonymous' in action ? 'Authenticated' : ''}}
+            <template v-if="action.isUnused">
+              Unused
+            </template>
+            <template v-else>
+              Allow {{(action.allowAnonymous === false ? ' Authenticated' :
+              action.allowAnonymous === true ? ' Anonymous' : '')}}
+            </template>
             <div v-if="action.roleLists.length" class="fw-normal text-start">
-              <div v-for="rl in action.roleLists">
-                {{rl.join(',')}}
-              </div>
+              <div v-for="rl in action.roleLists">{{rl.join(', ')}}</div>
             </div>
+            <div v-if="restrict?.length" class="fw-normal text-start">
+              <div v-for="restriction in restrict">
+                <span class="badge bg-custom-code mt-1" style="font-size: 0.8em"
+                  >{{restriction}}</span
+                >
+              </div>
           </div>
         </span>
       </span>
     </script>
 
-    <script src="https://unpkg.com/vue@3"></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
-      crossorigin="anonymous"
-    ></script>
+    <script src="https://unpkg.com/vue@3.3.8/dist/vue.global.js"></script>
 
     <script>
       const app = Vue.createApp({
         data() {
           // DATA is injected by the route handler that serves this content.
-          return DATA;
+          return { ...DATA, theme: getTheme(), setTheme };
         },
         mounted() {
           // Scroll to hash after page load - this won't otherwise happen since there's a delay in mounting the vue app.
@@ -549,7 +622,7 @@
       });
       app.component("security-badge", {
         template: "#security-badge",
-        props: ["action"],
+        props: ["action", "restrict"],
       });
       app.component("methods-table", {
         template: "#methods-table",

--- a/src/IntelliTect.Coalesce/DataAnnotations/IMappingRestriction.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/IMappingRestriction.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace IntelliTect.Coalesce.DataAnnotations
+{
+    /// <summary>
+    /// Implements restrictions that are declared on properties using <see cref="RestrictAttribute{T}"/>.
+    /// These restrictions will be checked each time such a property is mapped to or from a generated <see cref="IClassDto{T}"/>,
+    /// allowing for per-row, per-column security restrictions to be implemented.
+    /// </summary>
+    public interface IPropertyRestriction
+    {
+        /// <summary>
+        /// <para>
+        /// Restricts whether the user can sort, search, or filter the values 
+        /// of a property. By default, this always returns <see langword="false"/> 
+        /// and can be overridden with a nuanced implementation if it can be determined for a 
+        /// particular user if these actions are allowed.
+        /// </para>
+        /// <para>
+        /// Improper permissions implemented here can result in information disclosure vulnerabilities.
+        /// In general, filtering should only be allowed by users for whom 
+        /// <see cref="UserCanRead(IMappingContext, string, object)"/> will always return <see langword="true"/>,
+        /// regardless of the particular `model` instance.
+        /// </para>
+        /// </summary>
+        bool UserCanFilter(IMappingContext context, string propertyName) => false;
+
+        /// <summary>
+        /// Restricts whether values of a property will be mapped from a model instance to its DTO.
+        /// </summary>
+        bool UserCanRead(IMappingContext context, string propertyName, object model);
+
+        /// <summary>
+        /// <para>
+        /// Restricts whether values of a property will be mapped from a DTO to a model instance.
+        /// </para>
+        /// <para>
+        /// The <paramref name="model"/> parameter may be null if mapping to a new model instance
+        /// where property initializers must be used - for example, when
+        /// a <see langword="required"/> or <see langword="init"/> property is used.
+        /// </para>
+        /// <para>
+        /// The <paramref name="model"/> parameter may also already contain some user input
+        /// data from other properties that have already been mapped. If your result is predicated
+        /// on user-modifiable properties, consider injecting a <see cref="DbContext"/> and reading the
+        /// original, fresh values from the database.
+        /// </para>
+        /// </summary>
+        bool UserCanWrite(IMappingContext context, string propertyName, object? model, object? incomingValue);
+    }
+
+    public interface IPropertyRestriction<TModel> : IPropertyRestriction
+        where TModel : class
+    {
+        /// <inheritdoc cref="IPropertyRestriction.UserCanRead(IMappingContext, string, object)"/>
+        bool UserCanRead(IMappingContext context, string propertyName, TModel model);
+
+        /// <inheritdoc cref="IPropertyRestriction.UserCanWrite(IMappingContext, string, object, object)"/>
+        bool UserCanWrite(IMappingContext context, string propertyName, TModel? model, object? incomingValue);
+
+        bool IPropertyRestriction.UserCanRead(IMappingContext context, string propertyName, object model)
+            => this.UserCanRead(context, propertyName, (TModel)model);
+
+        bool IPropertyRestriction.UserCanWrite(IMappingContext context, string propertyName, object? model, object? incomingValue)
+            => this.UserCanWrite(context, propertyName, (TModel?)model, incomingValue);
+    }
+}

--- a/src/IntelliTect.Coalesce/DataAnnotations/RestrictAttribute.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/RestrictAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace IntelliTect.Coalesce.DataAnnotations
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
+    public sealed class RestrictAttribute<T> : Attribute
+        where T : IPropertyRestriction
+    {
+        // Originally, there was a design of this attribute that had the attribute itself implementing 
+        // `IPropertyRestriction`, but this design of the attribute itself implementing the functionality
+        // presents with a major problem:
+
+        // We'd like to have a `IPropertyRestriction` instance per mapping operation
+        // so that instances can be constructed with dependency injection and also cache
+        // state for reuse within the same mapping operation. This doesn't work with 
+        // attribute instances which are instantiated by the runtime.
+
+        // So, this attribute only functions as a marker attribute for discovery of T.
+    }
+}

--- a/src/IntelliTect.Coalesce/Helpers/Search/SearchableCollectionProperty.cs
+++ b/src/IntelliTect.Coalesce/Helpers/Search/SearchableCollectionProperty.cs
@@ -18,9 +18,9 @@ namespace IntelliTect.Coalesce.Helpers.Search
         internal ICollection<SearchableProperty> Children { get; }
 
         public override IEnumerable<(PropertyViewModel property, string statement)> GetLinqDynamicSearchStatements(
-            ClaimsPrincipal? user, TimeZoneInfo timeZone, string? propertyParent, string rawSearchTerm)
+            CrudContext context, string? propertyParent, string rawSearchTerm)
         {
-            if (!Property.SecurityInfo.IsReadAllowed(user))
+            if (!Property.SecurityInfo.IsFilterAllowed(context))
             {
                 return Enumerable.Empty<(PropertyViewModel, string)>();
             }
@@ -31,7 +31,7 @@ namespace IntelliTect.Coalesce.Helpers.Search
 
             return Children
                 .SelectMany(c => {
-                    return c.GetLinqDynamicSearchStatements(user, timeZone, null, rawSearchTerm).Select(t =>
+                    return c.GetLinqDynamicSearchStatements(context, null, rawSearchTerm).Select(t =>
                     {
                         return (t.property, $"{accessor}.Any({t.statement})");
                     });

--- a/src/IntelliTect.Coalesce/Helpers/Search/SearchableObjectProperty.cs
+++ b/src/IntelliTect.Coalesce/Helpers/Search/SearchableObjectProperty.cs
@@ -18,9 +18,9 @@ namespace IntelliTect.Coalesce.Helpers.Search
         internal ICollection<SearchableProperty> Children { get; } = new List<SearchableProperty>();
 
         public override IEnumerable<(PropertyViewModel property, string statement)> GetLinqDynamicSearchStatements(
-            ClaimsPrincipal? user, TimeZoneInfo timeZone, string? propertyParent, string rawSearchTerm)
+            CrudContext context, string? propertyParent, string rawSearchTerm)
         {
-            if (!Property.SecurityInfo.IsReadAllowed(user))
+            if (!Property.SecurityInfo.IsFilterAllowed(context))
             {
                 return Enumerable.Empty<(PropertyViewModel, string)>();
             }
@@ -30,7 +30,7 @@ namespace IntelliTect.Coalesce.Helpers.Search
                 : $"{propertyParent}.{Property.Name}";
 
             return Children
-                .SelectMany(c => c.GetLinqDynamicSearchStatements(user, timeZone, parent, rawSearchTerm));
+                .SelectMany(c => c.GetLinqDynamicSearchStatements(context, parent, rawSearchTerm));
 
 
         }

--- a/src/IntelliTect.Coalesce/Helpers/Search/SearchableProperty.cs
+++ b/src/IntelliTect.Coalesce/Helpers/Search/SearchableProperty.cs
@@ -20,6 +20,6 @@ namespace IntelliTect.Coalesce.Helpers.Search
         protected virtual string PropertyNamePath => Property.Name;
 
         public abstract IEnumerable<(PropertyViewModel property, string statement)> GetLinqDynamicSearchStatements(
-            ClaimsPrincipal? user, TimeZoneInfo timeZone, string? propertyParent, string rawSearchTerm);
+            CrudContext context, string? propertyParent, string rawSearchTerm);
     }
 }

--- a/src/IntelliTect.Coalesce/Helpers/Search/SearchableValueProperty.cs
+++ b/src/IntelliTect.Coalesce/Helpers/Search/SearchableValueProperty.cs
@@ -68,9 +68,9 @@ namespace IntelliTect.Coalesce.Helpers.Search
         };
 
         public override IEnumerable<(PropertyViewModel property, string statement)> GetLinqDynamicSearchStatements(
-            ClaimsPrincipal? user, TimeZoneInfo timeZone, string? propertyParent, string rawSearchTerm)
+            CrudContext context, string? propertyParent, string rawSearchTerm)
         {
-            if (!Property.SecurityInfo.IsReadAllowed(user))
+            if (!Property.SecurityInfo.IsFilterAllowed(context))
             {
                 yield break;
             }
@@ -107,7 +107,7 @@ namespace IntelliTect.Coalesce.Helpers.Search
                     ))
                     {
                         if (propType.IsDateTimeOffset)
-                            dt = TimeZoneInfo.ConvertTimeToUtc(dt, timeZone);
+                            dt = TimeZoneInfo.ConvertTimeToUtc(dt, context.TimeZone);
 
                         if (formatInfo.Value == (ParseFlags.HaveYear | ParseFlags.HaveMonth))
                         {
@@ -154,7 +154,7 @@ namespace IntelliTect.Coalesce.Helpers.Search
                     }
 
                     if (propType.IsDateTimeOffset)
-                        dt = TimeZoneInfo.ConvertTimeToUtc(dt, timeZone);
+                        dt = TimeZoneInfo.ConvertTimeToUtc(dt, context.TimeZone);
 
                     yield return (
                         Property,

--- a/src/IntelliTect.Coalesce/Mapping/IMappingContext.cs
+++ b/src/IntelliTect.Coalesce/Mapping/IMappingContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using IntelliTect.Coalesce.DataAnnotations;
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace IntelliTect.Coalesce
@@ -19,5 +21,10 @@ namespace IntelliTect.Coalesce
             out TDto? mappedObject
         )
             where TDto : class;
+
+        IPropertyRestriction GetPropertyRestriction(Type type);
+        TRestriction GetPropertyRestriction<TRestriction>()
+            where TRestriction : IPropertyRestriction
+            => (TRestriction)GetPropertyRestriction(typeof(TRestriction));
     }
 }

--- a/src/IntelliTect.Coalesce/Mapping/MappingContext.cs
+++ b/src/IntelliTect.Coalesce/Mapping/MappingContext.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using IntelliTect.Coalesce.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -14,10 +16,10 @@ namespace IntelliTect.Coalesce.Mapping
 
         public IServiceProvider? Services { get; }
 
-        public Dictionary<object, object> MappedObjects { get; }
-            = new Dictionary<object, object>();
+        public Dictionary<object, object> MappedObjects { get; } = new();
 
-        private readonly Dictionary<string, bool> _roleCache = new Dictionary<string, bool>();
+        private Dictionary<string, bool>? _roleCache;
+        private Dictionary<Type, IPropertyRestriction>? _restrictionCache;
 
         public MappingContext(
             ClaimsPrincipal? user = null, 
@@ -35,6 +37,7 @@ namespace IntelliTect.Coalesce.Mapping
 
         public bool IsInRoleCached(string role)
         {
+            _roleCache ??= new();
             if (_roleCache.TryGetValue(role, out bool inRole)) return inRole;
 
             return _roleCache[role] = User?.IsInRole(role) ?? false;
@@ -52,13 +55,27 @@ namespace IntelliTect.Coalesce.Mapping
         )
             where TDto : class
         {
-            if (!MappedObjects.TryGetValue(sourceObject, out object? existingMapped) || !(existingMapped is TDto))
+            if (!MappedObjects.TryGetValue(sourceObject, out object? existingMapped) || existingMapped is not TDto)
             {
                 mappedObject = default;
                 return false; 
             }
             mappedObject = (TDto)existingMapped;
             return true;
+        }
+
+        public IPropertyRestriction GetPropertyRestriction(Type type)
+        {
+            _restrictionCache ??= new();
+            if (_restrictionCache.TryGetValue(type, out var restriction)) return restriction;
+
+            restriction = Services is {} 
+                ? (IPropertyRestriction)ActivatorUtilities.GetServiceOrCreateInstance(Services, type) 
+                : (IPropertyRestriction)Activator.CreateInstance(type)!;
+
+            _restrictionCache.Add(type, restriction);
+
+            return restriction;
         }
     }
 }

--- a/src/IntelliTect.Coalesce/TypeDefinition/Helpers/SymbolExtensions.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Helpers/SymbolExtensions.cs
@@ -126,7 +126,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
 
         public static IEnumerable<SymbolAttributeViewModel<TAttribute>> GetAttributes<TAttribute>(
             this ISymbol symbol, 
-            ReflectionRepository rr = null)
+            ReflectionRepository? rr = null)
             where TAttribute : Attribute
         {
             return (symbol is INamedTypeSymbol named

--- a/src/IntelliTect.Coalesce/TypeDefinition/Security/PropertySecurityInfo.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Security/PropertySecurityInfo.cs
@@ -1,6 +1,8 @@
 ﻿using IntelliTect.Coalesce.DataAnnotations;
 using IntelliTect.Coalesce.Helpers;
+using IntelliTect.Coalesce.Mapping;
 using IntelliTect.Coalesce.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -15,8 +17,12 @@ namespace IntelliTect.Coalesce.TypeDefinition
     /// </summary>
     public class PropertySecurityInfo
     {
+        private PropertyViewModel Prop { get; }
+
         public PropertySecurityInfo(PropertyViewModel prop)
         {
+            Prop = prop;
+
             var read = prop.GetSecurityPermission<ReadAttribute>();
             var edit = prop.GetSecurityPermission<EditAttribute>();
 
@@ -86,6 +92,11 @@ namespace IntelliTect.Coalesce.TypeDefinition
                     Edit = new PropertySecurityPermission(prop, edit.Name, roles, IsEditUnused);
                 }
             }
+
+            Restrictions = prop.GetAttributes<Attribute>()
+                .Select(a => a.Type.GenericArgumentsFor(typeof(RestrictAttribute<>))?[0])
+                .Where(a => a != null)
+                .ToArray()!;
         }
 
         /// <summary>
@@ -104,19 +115,51 @@ namespace IntelliTect.Coalesce.TypeDefinition
         public PropertySecurityPermission Edit { get; }
 
         /// <summary>
+        /// Dynamic restrictions to be applied for both Reads and Writes.
+        /// </summary>
+        public IReadOnlyList<TypeViewModel> Restrictions { get; }
+
+        /// <summary>
         /// If true, the user can read the field.
         /// </summary>
+        [Obsolete("This method cannot account for any custom IPropertyRestrictions.")]
         public bool IsReadAllowed(ClaimsPrincipal? user) => Read.IsAllowed(user);
 
         /// <summary>
         /// If true, the user can initialize the field on a new instance of the object.
         /// </summary>
+        [Obsolete("This method cannot account for any custom IPropertyRestrictions.")]
         public bool IsInitAllowed(ClaimsPrincipal? user) => Init.IsAllowed(user);
 
         /// <summary>
         /// If true, the user can edit the field on an existing instance of the object.
         /// </summary>
+        [Obsolete("This method cannot account for any custom IPropertyRestrictions.")]
         public bool IsEditAllowed(ClaimsPrincipal? user) => Edit.IsAllowed(user);
+
+        /// <inheritdoc cref="IsFilterAllowed(IMappingContext)"/>
+        public bool IsFilterAllowed(CrudContext context) => IsFilterAllowed(context.MappingContext);
+
+        /// <summary>
+        /// If true, the user can sort/search/filter the field.
+        /// </summary>
+        public bool IsFilterAllowed(IMappingContext context)
+        {
+            if (!Read.IsAllowed(context.User)) return false;
+
+            if (Restrictions.Count > 0)
+            {
+                foreach (var restrictionType in Restrictions)
+                {
+                    if (!context.GetPropertyRestriction(restrictionType.TypeInfo).UserCanFilter(context, Prop.Name))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
 
         private static bool? IsReadUnused(ValueViewModel value, HashSet<PropertyViewModel> visited)
         {

--- a/src/IntelliTect.Coalesce/TypeDefinition/Security/PropertySecurityPermission.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Security/PropertySecurityPermission.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IntelliTect.Coalesce.DataAnnotations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -55,6 +56,10 @@ namespace IntelliTect.Coalesce.TypeDefinition
         /// </summary>
         public bool IsUnused => ComputeIsUnused(Prop, new())!.Value;
 
+        /// <summary>
+        /// Return whether the action is allowed for the specified user.
+        /// Does not account for <see cref="IPropertyRestriction"/>s.
+        /// </summary>
         public override bool IsAllowed(ClaimsPrincipal? user)
         {
             if (NoAccess) return false;

--- a/src/IntelliTect.Coalesce/Validation/ValidateContext.cs
+++ b/src/IntelliTect.Coalesce/Validation/ValidateContext.cs
@@ -76,6 +76,9 @@ namespace IntelliTect.Coalesce.Validation
                             assert.IsFalse(prop.HasAttribute<EditAttribute>(),
                                 dtoPropSecWarningPreamble + "EditAttribute has no effect here.");
 
+                            assert.IsFalse(prop.SecurityInfo.Restrictions.Count > 0,
+                                dtoPropSecWarningPreamble + "RestrictAttribute has no effect here.");
+
                             assert.IsFalse(prop.HasAttribute<DtoIncludesAttribute>(),
                                 "[DtoIncludesAttribute] has no effect on an IClassDto. This logic must be implemented manually in MapFrom.");
                             assert.IsFalse(prop.HasAttribute<DtoExcludesAttribute>(),


### PR DESCRIPTION
# [Restrict]

You can now define property restrictions that can execute custom code for each model instance if your logic require more nuanced decisions than can be made with roles.

``` c#
using IntelliTect.Coalesce.DataAnnotations;
public class Employee 
{
  public int Id { get; set; }

  [Read]
  public string UserId { get; set; }

  [Restrict<SalaryRestriction>]
  public decimal Salary { get; set; }
}

public class SalaryRestriction(MyUserService userService) : IPropertyRestriction<Employee>
{
  public bool UserCanRead(IMappingContext context, string propertyName, Employee model)
    => context.User.GetUserId() == model.UserId || userService.IsPayroll(context.User);

  public bool UserCanWrite(IMappingContext context, string propertyName, Employee model, object incomingValue)
    => userService.IsPayroll(context.User);

  public bool UserCanFilter(IMappingContext context, string propertyName)
    => userService.IsPayroll(context.User);
}
```

Restriction classes support dependency injection, so you can inject any supplemental services needed to make a determination.

The `UserCanRead` method controls whether values of the restricted property will be mapped from model instances to the generated DTO. Similarly, `UserCanWrite` controls whether the property can be mapped back to the model instance from the generated DTO.

The `UserCanFilter` method has a default implementation that returns `false`, but can be implemented if there is an appropriate, instance-agnostic way to determine if a user can sort, search, or filter values of that property.

Multiple different restrictions can be placed on a single property; all of them must succeed for the operation to be permitted. Restrictions also stack on top of role attribute restrictions (`[Read]` and `[Edit]`).

A non-generic variant of `IPropertyRestriction` also exists for restrictions that might be reused across multiple model types.