### PR TITLE
fix: Move TFM out from Directory.Build.Props

### DIFF
--- a/Coalesce.sln
+++ b/Coalesce.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.lutignore = .lutignore
 		Coalesce.lutconfig = Coalesce.lutconfig
+		src\Common.props = src\Common.props
 		version.txt = version.txt
 	EndProjectSection
 EndProject

--- a/src/Common.props
+++ b/src/Common.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,5 @@
 <Project>
   <PropertyGroup>
-	  <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-	  
     <Company>IntelliTect</Company>
     <Authors>IntelliTect</Authors>
     <Product>Coalesce Web Framework</Product>

--- a/src/IntelliTect.Coalesce.AuditLogging.Tests/IntelliTect.Coalesce.AuditLogging.Tests.csproj
+++ b/src/IntelliTect.Coalesce.AuditLogging.Tests/IntelliTect.Coalesce.AuditLogging.Tests.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/IntelliTect.Coalesce.AuditLogging/IntelliTect.Coalesce.AuditLogging.csproj
+++ b/src/IntelliTect.Coalesce.AuditLogging/IntelliTect.Coalesce.AuditLogging.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Nullable>enable</Nullable>
     

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/IntelliTect.Coalesce.CodeGeneration.Api.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/IntelliTect.Coalesce.CodeGeneration.Api.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>Shared API code generation for IntelliTect.Coalesce</Description>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Knockout/IntelliTect.Coalesce.CodeGeneration.Knockout.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Knockout/IntelliTect.Coalesce.CodeGeneration.Knockout.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>Knockout.js code generation for IntelliTect.Coalesce</Description>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Tests/IntelliTect.Coalesce.CodeGeneration.Tests.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Tests/IntelliTect.Coalesce.CodeGeneration.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Vue/IntelliTect.Coalesce.CodeGeneration.Vue.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Vue/IntelliTect.Coalesce.CodeGeneration.Vue.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>Vue.js code generation for IntelliTect.Coalesce</Description>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/IntelliTect.Coalesce.CodeGeneration/IntelliTect.Coalesce.CodeGeneration.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration/IntelliTect.Coalesce.CodeGeneration.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>Core code generation library for IntelliTect.Coalesce</Description>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/IntelliTect.Coalesce.DotnetCliTool/IntelliTect.Coalesce.DotnetCliTool.csproj
+++ b/src/IntelliTect.Coalesce.DotnetCliTool/IntelliTect.Coalesce.DotnetCliTool.csproj
@@ -1,5 +1,5 @@
 ﻿<Project>
-  
+  <Import Project="../Common.props" />
   <!-- Technique for overriding SDK targets from https://stackoverflow.com/a/47619786/2465631 -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   

--- a/src/IntelliTect.Coalesce.DotnetTool/IntelliTect.Coalesce.DotnetTool.csproj
+++ b/src/IntelliTect.Coalesce.DotnetTool/IntelliTect.Coalesce.DotnetTool.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Common.props" />
   <Import Project="../Cli.Common.props" />
   
   <!--

--- a/src/IntelliTect.Coalesce.Knockout/IntelliTect.Coalesce.Knockout.csproj
+++ b/src/IntelliTect.Coalesce.Knockout/IntelliTect.Coalesce.Knockout.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>Knockout.js shared code for both server and code generation projects for IntelliTect.Coalesce</Description>
   </PropertyGroup>

--- a/src/IntelliTect.Coalesce.Swashbuckle.Tests/IntelliTect.Coalesce.Swashbuckle.Tests.csproj
+++ b/src/IntelliTect.Coalesce.Swashbuckle.Tests/IntelliTect.Coalesce.Swashbuckle.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>

--- a/src/IntelliTect.Coalesce.Swashbuckle/IntelliTect.Coalesce.Swashbuckle.csproj
+++ b/src/IntelliTect.Coalesce.Swashbuckle/IntelliTect.Coalesce.Swashbuckle.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <Description>
       Provides Swashbuckle SwaggerGen filters to enhance definitions of Coalesce APIs in OpenAPI documents.

--- a/src/IntelliTect.Coalesce.Tests/IntelliTect.Coalesce.Tests.csproj
+++ b/src/IntelliTect.Coalesce.Tests/IntelliTect.Coalesce.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>

--- a/src/IntelliTect.Coalesce.Vue/IntelliTect.Coalesce.Vue.csproj
+++ b/src/IntelliTect.Coalesce.Vue/IntelliTect.Coalesce.Vue.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
+  <Import Project="../Common.props" />
 	<PropertyGroup>
 		<Description>Vue.js shared code for server projects for IntelliTect.Coalesce</Description>
 		<Nullable>enable</Nullable>

--- a/src/IntelliTect.Coalesce/IntelliTect.Coalesce.csproj
+++ b/src/IntelliTect.Coalesce/IntelliTect.Coalesce.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Common.props" />
 	<PropertyGroup>
 		<Description>Core framework library for IntelliTect.Coalesce</Description>
 		<PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Did this because I have run into issues with TFM being in Directory.Build.Props file before.
From a dotnet team personnel on the why not to have it in that file: 
- We really dont have well-specified behavior for putting TFM in Directory.Build.props
files - if I recall it messes with the layering of props/project file/targets. I think I can find a blurb about that somewhere.
- there's a step very early on in the SDK targets that determines if we need to do a multi-targeting (crosstargets) build or
not
- this happens before D.B.props is processed so cross-targeting is false