### PR TITLE
Add support for Vue 3.3 generic components to coalesce-vue-vuetify3

### DIFF
--- a/src/coalesce-vue-vuetify3/package-lock.json
+++ b/src/coalesce-vue-vuetify3/package-lock.json
@@ -34,7 +34,7 @@
         "vitest": "0.28.5",
         "vue": "^3.3.11",
         "vue-router": "^4.1.6",
-        "vue-tsc": "1.1.0",
+        "vue-tsc": "^1.6.5",
         "vuetify": "3.4.7"
       },
       "optionalDependencies": {
@@ -1682,109 +1682,31 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-OfbPmmFa4LUA8kJCg77V9ud4NASjJ3VKJ79QCQSfHa5SwXeZ5w7lvQe2yILFBjZ3JDB5EfFnHZUSct6ziK3x5Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "1.2.0-alpha.11"
+        "@volar/source-map": "1.11.1"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-GCRqcq2bn8Gf9N/qbdl8GgfGbmYuuSIB8arhl+gRZfCIWvT5NhIRVlG5GX0lkgpp02lA8ZYWZ0GLGOkwz7+DMQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
       "dev": true,
       "dependencies": {
-        "muggle-string": "^0.2.2"
+        "muggle-string": "^0.3.1"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-tJ20326E/Xi1lvvuWX57boVJtzhStNF3HjBu4orjl9PqCXUbhqWwP+jRYzyb+nLbHqGPmEBvHKYjAO3GsJ/YXg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "1.2.0-alpha.11"
-      }
-    },
-    "node_modules/@volar/vue-language-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.1.0.tgz",
-      "integrity": "sha512-1zTAyeGiyNKYE9s+i3dUpmuvY/Cz1U7LjIh9d5FX3p0NWpaBrzYvSh0gQY+nRaz67or7Y9qYSUCaHLKOmeolzg==",
-      "dev": true,
-      "dependencies": {
-        "@volar/language-core": "1.2.0-alpha.11",
-        "@volar/source-map": "1.2.0-alpha.11",
-        "@vue/compiler-dom": "^3.2.47",
-        "@vue/compiler-sfc": "^3.2.47",
-        "@vue/reactivity": "^3.2.47",
-        "@vue/shared": "^3.2.47",
-        "minimatch": "^6.1.6",
-        "muggle-string": "^0.2.2",
-        "vue-template-compiler": "^2.7.14"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-core": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
-      "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.47",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-dom": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
-      "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.2.47",
-        "@vue/shared": "3.2.47"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/@vue/shared": {
-      "version": "3.2.47",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
-      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
-      "dev": true
-    },
-    "node_modules/@volar/vue-language-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@volar/vue-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.1.0.tgz",
-      "integrity": "sha512-smtfaePuNpVzXEypJayORtl8muvBdtV1FDWjces1WLYbbtcnmfWtdACW9xY0dkVk0LoE/LZTEmLBCQrRJ6hS1w==",
-      "dev": true,
-      "dependencies": {
-        "@volar/typescript": "1.2.0-alpha.11",
-        "@volar/vue-language-core": "1.1.0"
+        "@volar/language-core": "1.11.1",
+        "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@vue/babel-helper-vue-transform-on": {
@@ -1906,6 +1828,55 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.26",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.26.tgz",
+      "integrity": "sha512-9cmza/Y2YTiOnKZ0Mi9zsNn7Irw+aKirP+5LLWVSNaL3fjKJjW1cD3HGBckasY2RuVh4YycvdA9/Q6EBpVd/7Q==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "~1.11.1",
+        "@volar/source-map": "~1.11.1",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "path-browserify": "^1.0.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -2628,6 +2599,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -4358,9 +4335,9 @@
       "dev": true
     },
     "node_modules/muggle-string": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.2.2.tgz",
-      "integrity": "sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -5878,9 +5855,9 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "dependencies": {
         "de-indent": "^1.0.2",
@@ -5888,13 +5865,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.1.0.tgz",
-      "integrity": "sha512-+JqTcuScA6OfyaVH3ezeCh2i2wRgzUScZ6EdTZ3AW69Nb+rmRyOAxmAjL6MPam8YCdwmmdfAUhmN/BNGVp5vQg==",
+      "version": "1.8.26",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.26.tgz",
+      "integrity": "sha512-jMEJ4aqU/l1hdgmeExH5h1TFoN+hbho0A2ZAhHy53/947DGm7Qj/bpB85VpECOCwV00h7JYNVnvoD2ceOorB4Q==",
       "dev": true,
       "dependencies": {
-        "@volar/vue-language-core": "1.1.0",
-        "@volar/vue-typescript": "1.1.0"
+        "@volar/typescript": "~1.11.1",
+        "@vue/language-core": "1.8.26",
+        "semver": "^7.5.4"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -7273,105 +7251,31 @@
       }
     },
     "@volar/language-core": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-OfbPmmFa4LUA8kJCg77V9ud4NASjJ3VKJ79QCQSfHa5SwXeZ5w7lvQe2yILFBjZ3JDB5EfFnHZUSct6ziK3x5Q==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
+      "integrity": "sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==",
       "dev": true,
       "requires": {
-        "@volar/source-map": "1.2.0-alpha.11"
+        "@volar/source-map": "1.11.1"
       }
     },
     "@volar/source-map": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-GCRqcq2bn8Gf9N/qbdl8GgfGbmYuuSIB8arhl+gRZfCIWvT5NhIRVlG5GX0lkgpp02lA8ZYWZ0GLGOkwz7+DMQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.11.1.tgz",
+      "integrity": "sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==",
       "dev": true,
       "requires": {
-        "muggle-string": "^0.2.2"
+        "muggle-string": "^0.3.1"
       }
     },
     "@volar/typescript": {
-      "version": "1.2.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.2.0-alpha.11.tgz",
-      "integrity": "sha512-tJ20326E/Xi1lvvuWX57boVJtzhStNF3HjBu4orjl9PqCXUbhqWwP+jRYzyb+nLbHqGPmEBvHKYjAO3GsJ/YXg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.11.1.tgz",
+      "integrity": "sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==",
       "dev": true,
       "requires": {
-        "@volar/language-core": "1.2.0-alpha.11"
-      }
-    },
-    "@volar/vue-language-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.1.0.tgz",
-      "integrity": "sha512-1zTAyeGiyNKYE9s+i3dUpmuvY/Cz1U7LjIh9d5FX3p0NWpaBrzYvSh0gQY+nRaz67or7Y9qYSUCaHLKOmeolzg==",
-      "dev": true,
-      "requires": {
-        "@volar/language-core": "1.2.0-alpha.11",
-        "@volar/source-map": "1.2.0-alpha.11",
-        "@vue/compiler-dom": "^3.2.47",
-        "@vue/compiler-sfc": "^3.2.47",
-        "@vue/reactivity": "^3.2.47",
-        "@vue/shared": "^3.2.47",
-        "minimatch": "^6.1.6",
-        "muggle-string": "^0.2.2",
-        "vue-template-compiler": "^2.7.14"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.47",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
-          "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
-          "dev": true,
-          "requires": {
-            "@babel/parser": "^7.16.4",
-            "@vue/shared": "3.2.47",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-dom": {
-          "version": "3.2.47",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
-          "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
-          "dev": true,
-          "requires": {
-            "@vue/compiler-core": "3.2.47",
-            "@vue/shared": "3.2.47"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.47",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
-          "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-          "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@volar/vue-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.1.0.tgz",
-      "integrity": "sha512-smtfaePuNpVzXEypJayORtl8muvBdtV1FDWjces1WLYbbtcnmfWtdACW9xY0dkVk0LoE/LZTEmLBCQrRJ6hS1w==",
-      "dev": true,
-      "requires": {
-        "@volar/typescript": "1.2.0-alpha.11",
-        "@volar/vue-language-core": "1.1.0"
+        "@volar/language-core": "1.11.1",
+        "path-browserify": "^1.0.1"
       }
     },
     "@vue/babel-helper-vue-transform-on": {
@@ -7479,6 +7383,43 @@
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "vue-eslint-parser": "^9.0.0"
+      }
+    },
+    "@vue/language-core": {
+      "version": "1.8.26",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.26.tgz",
+      "integrity": "sha512-9cmza/Y2YTiOnKZ0Mi9zsNn7Irw+aKirP+5LLWVSNaL3fjKJjW1cD3HGBckasY2RuVh4YycvdA9/Q6EBpVd/7Q==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "~1.11.1",
+        "@volar/source-map": "~1.11.1",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "computeds": "^0.0.1",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "path-browserify": "^1.0.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@vue/reactivity": {
@@ -8037,6 +7978,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "computeds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
       "dev": true
     },
     "concat-map": {
@@ -9340,9 +9287,9 @@
       "dev": true
     },
     "muggle-string": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.2.2.tgz",
-      "integrity": "sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "nanoid": {
@@ -10383,9 +10330,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
-      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -10393,13 +10340,14 @@
       }
     },
     "vue-tsc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.1.0.tgz",
-      "integrity": "sha512-+JqTcuScA6OfyaVH3ezeCh2i2wRgzUScZ6EdTZ3AW69Nb+rmRyOAxmAjL6MPam8YCdwmmdfAUhmN/BNGVp5vQg==",
+      "version": "1.8.26",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.26.tgz",
+      "integrity": "sha512-jMEJ4aqU/l1hdgmeExH5h1TFoN+hbho0A2ZAhHy53/947DGm7Qj/bpB85VpECOCwV00h7JYNVnvoD2ceOorB4Q==",
       "dev": true,
       "requires": {
-        "@volar/vue-language-core": "1.1.0",
-        "@volar/vue-typescript": "1.1.0"
+        "@volar/typescript": "~1.11.1",
+        "@vue/language-core": "1.8.26",
+        "semver": "^7.5.4"
       }
     },
     "vuetify": {

--- a/src/coalesce-vue-vuetify3/package-lock.json
+++ b/src/coalesce-vue-vuetify3/package-lock.json
@@ -43,7 +43,7 @@
       "peerDependencies": {
         "coalesce-vue": "../coalesce-vue",
         "vue": "^3.3.0",
-        "vuetify": "^3.1.0"
+        "vuetify": "^3.2.0"
       }
     },
     "../coalesce-vue": {

--- a/src/coalesce-vue-vuetify3/package.json
+++ b/src/coalesce-vue-vuetify3/package.json
@@ -69,7 +69,7 @@
     "vitest": "0.28.5",
     "vue": "^3.3.11",
     "vue-router": "^4.1.6",
-    "vue-tsc": "1.1.0",
+    "vue-tsc": "^1.6.5",
     "vuetify": "3.4.7"
   },
   "postcss": {

--- a/src/coalesce-vue-vuetify3/package.json
+++ b/src/coalesce-vue-vuetify3/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "coalesce-vue": "../coalesce-vue",
     "vue": "^3.3.0",
-    "vuetify": "^3.1.0"
+    "vuetify": "^3.2.0"
   },
   "optionalDependencies": {
     "vue-router": "^4.1.6"


### PR DESCRIPTION
## Description

-  Upgrade Vuetify and vue-tsc version in coalesce-vue-vuetify3 to support generic components in Vue 3.3
    - See: https://blog.vuejs.org/posts/vue-3-3#generic-components

Describe your changes here.

Partially solves https://github.com/IntelliTect/Coalesce/issues/348

### Ensure that your pull request has followed all the steps below:
- [ ] Code compilation
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
