### PR TITLE
feat: Accept JSON bodies in all generated endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 5.1.0
 
+- feat: All Coalesce-generated endpoints that accept a formdata body now also accept a JSON body. Existing formdata endpoints remain unchanged.
 - feat: Automatically produce user-friendly response messages in behaviors for Save and Delete operations that fail due to a violation of a SQL Server foreign key or unique constraint. This behavior can be controlled with the `DetailedEfConstraintExceptionMessages` setting in `.AddCoalesce(c => c.Configure(o => { ... }))`, or by overriding `StandardBehaviors.GetExceptionResult`. This is not a substitute for adding proper validation or other handling of related entities - it only exists to provide a better user experience in cases where the developer has forgotten to handle these situations. This behavior does respect Coalesce's security model and won't produce descriptions of types or values that the user is not allowed to see. (#468)
 - feat: Error responses now include inner exception messages when `DetailedExceptionMessages` is enabled. (#468)
 - feat(c-admin-table): Clicking a row takes you to the details page (#465)

--- a/coalesce-vue3.json
+++ b/coalesce-vue3.json
@@ -1,6 +1,6 @@
 {
   "webProject": {
-    "projectFile": "./playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj",
+    "projectFile": "./playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj"
   },
   "dataProject": {
     "projectFile": "./playground/Coalesce.Domain/Coalesce.Domain.csproj",

--- a/coalesce-vue3.json
+++ b/coalesce-vue3.json
@@ -1,7 +1,6 @@
 {
   "webProject": {
     "projectFile": "./playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj",
-    "framework": "net8.0"
   },
   "dataProject": {
     "projectFile": "./playground/Coalesce.Domain/Coalesce.Domain.csproj",

--- a/playground/Coalesce.Web.Vue2/Api/Generated/AuditLogController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/AuditLogController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<AuditLogResponse>> Get(
             long id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<AuditLogResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => CountImplementation(parameters, dataSource);
 

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CaseController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CaseController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [AllowAnonymous]
         public virtual Task<ItemResult<CaseResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [AllowAnonymous]
         public virtual Task<ListResult<CaseResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [AllowAnonymous]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [AllowAnonymous]
         public virtual Task<ItemResult<CaseResponse>> Save(
             [FromForm] CaseParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Case> dataSource,
+            IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [AllowAnonymous]
+        public virtual Task<ItemResult<CaseResponse>> SaveFromJson(
+            [FromBody] CaseParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource,
             IBehaviors<Coalesce.Domain.Case> behaviors)
@@ -88,12 +99,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("GetCaseTitles")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<System.Collections.Generic.ICollection<string>> GetCaseTitles(
             [FromForm(Name = "search")] string search)
         {
             var _params = new
             {
-                search = search
+                Search = search
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -105,7 +117,38 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = Coalesce.Domain.Case.GetCaseTitles(
                 Db,
-                _params.search
+                _params.Search
+            );
+            var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
+            _result.Object = _methodResult?.ToList();
+            return _result;
+        }
+
+        public class GetCaseTitlesParameters
+        {
+            public string Search { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetCaseTitles
+        /// </summary>
+        [HttpPost("GetCaseTitles")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<System.Collections.Generic.ICollection<string>> GetCaseTitles(
+            [FromBody] GetCaseTitlesParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("GetCaseTitles"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<System.Collections.Generic.ICollection<string>>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Case.GetCaseTitles(
+                Db,
+                _params.Search
             );
             var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
             _result.Object = _methodResult?.ToList();
@@ -163,23 +206,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("UploadImage")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadImage(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             Microsoft.AspNetCore.Http.IFormFile file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -189,7 +234,46 @@ namespace Coalesce.Web.Vue2.Api
 
             await item.UploadImage(
                 Db,
-                _params.file
+                _params.File
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadImageParameters
+        {
+            public int Id { get; set; }
+            public IntelliTect.Coalesce.Models.FileParameter File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadImage
+        /// </summary>
+        [HttpPost("UploadImage")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadImage(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadImageParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadImage"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            await item.UploadImage(
+                Db,
+                _params.File
             );
             var _result = new ItemResult();
             return _result;
@@ -202,11 +286,17 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> DownloadImage(
             [FromServices] IDataSourceFactory dataSourceFactory,
-            int id,
-            byte[] etag)
+            [FromQuery] int id,
+            [FromQuery] byte[] etag)
         {
+            var _params = new
+            {
+                Id = id,
+                Etag = etag ?? await ((await Request.ReadFormAsync()).Files[nameof(etag)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
@@ -248,23 +338,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("UploadAndDownload")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> UploadAndDownload(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             Microsoft.AspNetCore.Http.IFormFile file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -274,7 +366,51 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = await item.UploadAndDownload(
                 Db,
-                _params.file
+                _params.File
+            );
+            if (_methodResult.Object != null)
+            {
+                return File(_methodResult.Object);
+            }
+            var _result = new ItemResult<IntelliTect.Coalesce.Models.IFile>(_methodResult);
+            _result.Object = _methodResult.Object;
+            return _result;
+        }
+
+        public class UploadAndDownloadParameters
+        {
+            public int Id { get; set; }
+            public IntelliTect.Coalesce.Models.FileParameter File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadAndDownload
+        /// </summary>
+        [HttpPost("UploadAndDownload")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> UploadAndDownload(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadAndDownloadParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadAndDownload"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<IntelliTect.Coalesce.Models.IFile>(_validationResult);
+            }
+
+            var _methodResult = await item.UploadAndDownload(
+                Db,
+                _params.File
             );
             if (_methodResult.Object != null)
             {
@@ -290,23 +426,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("UploadImages")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadImages(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             System.Collections.Generic.ICollection<Microsoft.AspNetCore.Http.IFormFile> files)
         {
+            var _params = new
+            {
+                Id = id,
+                Files = files == null ? null : files.Select(f => new IntelliTect.Coalesce.Models.File { Name = f.FileName, ContentType = f.ContentType, Length = f.Length, Content = f.OpenReadStream() }).ToList()
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                files = files == null ? null : files.Select(f => (IntelliTect.Coalesce.Models.IFile)new IntelliTect.Coalesce.Models.File { Name = f.FileName, ContentType = f.ContentType, Length = f.Length, Content = f.OpenReadStream() }).ToList()
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -316,7 +454,46 @@ namespace Coalesce.Web.Vue2.Api
 
             await item.UploadImages(
                 Db,
-                _params.files.ToList()
+                _params.Files.Cast<IntelliTect.Coalesce.Models.IFile>().ToList()
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadImagesParameters
+        {
+            public int Id { get; set; }
+            public ICollection<IntelliTect.Coalesce.Models.FileParameter> Files { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadImages
+        /// </summary>
+        [HttpPost("UploadImages")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadImages(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadImagesParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadImages"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            await item.UploadImages(
+                Db,
+                _params.Files.Cast<IntelliTect.Coalesce.Models.IFile>().ToList()
             );
             var _result = new ItemResult();
             return _result;
@@ -327,23 +504,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("UploadByteArray")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadByteArray(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "file")] byte[] file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file ?? await ((await Request.ReadFormAsync()).Files[nameof(file)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file ?? await ((await Request.ReadFormAsync()).Files[nameof(file)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -353,7 +532,46 @@ namespace Coalesce.Web.Vue2.Api
 
             item.UploadByteArray(
                 Db,
-                _params.file
+                _params.File
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadByteArrayParameters
+        {
+            public int Id { get; set; }
+            public byte[] File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadByteArray
+        /// </summary>
+        [HttpPost("UploadByteArray")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadByteArray(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadByteArrayParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadByteArray"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            item.UploadByteArray(
+                Db,
+                _params.File
             );
             var _result = new ItemResult();
             return _result;

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CaseDtoController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CaseDtoController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<Coalesce.Domain.CaseDto>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> Save(
             [FromForm] Coalesce.Domain.CaseDto dto,
+            [FromQuery] DataSourceParameters parameters,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> SaveFromJson(
+            [FromBody] Coalesce.Domain.CaseDto dto,
             [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IBehaviors<Coalesce.Domain.Case> behaviors)
@@ -88,23 +99,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("AsyncMethodOnIClassDto")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<string>> AsyncMethodOnIClassDto(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "input")] string input)
         {
+            var _params = new
+            {
+                Id = id,
+                Input = input
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.CaseDto>("Default");
-            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                input = input
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -113,7 +126,46 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             var _methodResult = await item.AsyncMethodOnIClassDto(
-                _params.input
+                _params.Input
+            );
+            var _result = new ItemResult<string>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class AsyncMethodOnIClassDtoParameters
+        {
+            public int Id { get; set; }
+            public string Input { get; set; }
+        }
+
+        /// <summary>
+        /// Method: AsyncMethodOnIClassDto
+        /// </summary>
+        [HttpPost("AsyncMethodOnIClassDto")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<string>> AsyncMethodOnIClassDto(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] AsyncMethodOnIClassDtoParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.CaseDto>("Default");
+            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<string>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("AsyncMethodOnIClassDto"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<string>(_validationResult);
+            }
+
+            var _methodResult = await item.AsyncMethodOnIClassDto(
+                _params.Input
             );
             var _result = new ItemResult<string>();
             _result.Object = _methodResult;

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CaseDtoStandaloneController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CaseDtoStandaloneController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<Coalesce.Domain.CaseDtoStandalone>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> Save(
             [FromForm] Coalesce.Domain.CaseDtoStandalone dto,
+            [FromQuery] DataSourceParameters parameters,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> SaveFromJson(
+            [FromBody] Coalesce.Domain.CaseDtoStandalone dto,
             [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IBehaviors<Coalesce.Domain.Case> behaviors)

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CaseProductController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CaseProductController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<CaseProductResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<CaseProductResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<CaseProductResponse>> Save(
             [FromForm] CaseProductParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.CaseProduct> dataSource,
+            IBehaviors<Coalesce.Domain.CaseProduct> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<CaseProductResponse>> SaveFromJson(
+            [FromBody] CaseProductParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource,
             IBehaviors<Coalesce.Domain.CaseProduct> behaviors)

--- a/playground/Coalesce.Web.Vue2/Api/Generated/CompanyController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/CompanyController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<CompanyResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Company> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<CompanyResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Company> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Company> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<CompanyResponse>> Save(
             [FromForm] CompanyParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Company> dataSource,
+            IBehaviors<Coalesce.Domain.Company> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<CompanyResponse>> SaveFromJson(
+            [FromBody] CompanyParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Company> dataSource,
             IBehaviors<Coalesce.Domain.Company> behaviors)
@@ -88,25 +99,27 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("ConflictingParameterNames")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> ConflictingParameterNames(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "companyParam")] CompanyParameter companyParam,
             [FromForm(Name = "name")] string name)
         {
+            var _params = new
+            {
+                Id = id,
+                CompanyParam = !Request.Form.HasAnyValue(nameof(companyParam)) ? null : companyParam,
+                Name = name
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Company, Coalesce.Domain.Company>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                companyParam = !Request.Form.HasAnyValue(nameof(companyParam)) ? null : companyParam,
-                name = name
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -116,8 +129,49 @@ namespace Coalesce.Web.Vue2.Api
 
             var _mappingContext = new MappingContext(Context);
             item.ConflictingParameterNames(
-                _params.companyParam?.MapToNew(_mappingContext),
-                _params.name
+                _params.CompanyParam?.MapToNew(_mappingContext),
+                _params.Name
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class ConflictingParameterNamesParameters
+        {
+            public int Id { get; set; }
+            public CompanyParameter CompanyParam { get; set; }
+            public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ConflictingParameterNames
+        /// </summary>
+        [HttpPost("ConflictingParameterNames")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> ConflictingParameterNames(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ConflictingParameterNamesParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Company, Coalesce.Domain.Company>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("ConflictingParameterNames"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            var _mappingContext = new MappingContext(Context);
+            item.ConflictingParameterNames(
+                _params.CompanyParam?.MapToNew(_mappingContext),
+                _params.Name
             );
             var _result = new ItemResult();
             return _result;
@@ -128,12 +182,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("GetCertainItems")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<System.Collections.Generic.ICollection<CompanyResponse>> GetCertainItems(
             [FromForm(Name = "isDeleted")] bool isDeleted = false)
         {
             var _params = new
             {
-                isDeleted = isDeleted
+                IsDeleted = isDeleted
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -147,7 +202,40 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Company.GetCertainItems(
                 Db,
-                _params.isDeleted
+                _params.IsDeleted
+            );
+            var _result = new ItemResult<System.Collections.Generic.ICollection<CompanyResponse>>();
+            _result.Object = _methodResult?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Company, CompanyResponse>(o, _mappingContext, includeTree)).ToList();
+            return _result;
+        }
+
+        public class GetCertainItemsParameters
+        {
+            public bool IsDeleted { get; set; } = false;
+        }
+
+        /// <summary>
+        /// Method: GetCertainItems
+        /// </summary>
+        [HttpPost("GetCertainItems")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<System.Collections.Generic.ICollection<CompanyResponse>> GetCertainItems(
+            [FromBody] GetCertainItemsParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("GetCertainItems"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<System.Collections.Generic.ICollection<CompanyResponse>>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Company.GetCertainItems(
+                Db,
+                _params.IsDeleted
             );
             var _result = new ItemResult<System.Collections.Generic.ICollection<CompanyResponse>>();
             _result.Object = _methodResult?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Company, CompanyResponse>(o, _mappingContext, includeTree)).ToList();

--- a/playground/Coalesce.Web.Vue2/Api/Generated/LogController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/LogController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<LogResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<LogResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => CountImplementation(parameters, dataSource);
 

--- a/playground/Coalesce.Web.Vue2/Api/Generated/PersonController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/PersonController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [AllowAnonymous]
         public virtual Task<ItemResult<PersonResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [AllowAnonymous]
         public virtual Task<ListResult<PersonResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [AllowAnonymous]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [AllowAnonymous]
         public virtual Task<ItemResult<PersonResponse>> Save(
             [FromForm] PersonParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Person> dataSource,
+            IBehaviors<Coalesce.Domain.Person> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [AllowAnonymous]
+        public virtual Task<ItemResult<PersonResponse>> SaveFromJson(
+            [FromBody] PersonParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource,
             IBehaviors<Coalesce.Domain.Person> behaviors)
@@ -88,23 +99,25 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("Rename")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<PersonResponse>> Rename(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "name")] string name)
         {
+            var _params = new
+            {
+                Id = id,
+                Name = name
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<PersonResponse>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                name = name
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -116,7 +129,50 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = item.Rename(
                 Db,
-                _params.name,
+                _params.Name,
+                out includeTree
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class RenameParameters
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// Method: Rename
+        /// </summary>
+        [HttpPost("Rename")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<PersonResponse>> Rename(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] RenameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<PersonResponse>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("Rename"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = item.Rename(
+                Db,
+                _params.Name,
                 out includeTree
             );
             var _result = new ItemResult<PersonResponse>();
@@ -129,12 +185,48 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("ChangeSpacesToDashesInName")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> ChangeSpacesToDashesInName(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("WithoutCases");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.ChangeSpacesToDashesInName(
+                Db
+            );
+            var _result = new ItemResult(_methodResult);
+            return _result;
+        }
+
+        public class ChangeSpacesToDashesInNameParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ChangeSpacesToDashesInName
+        /// </summary>
+        [HttpPost("ChangeSpacesToDashesInName")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> ChangeSpacesToDashesInName(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ChangeSpacesToDashesInNameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("WithoutCases");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
@@ -152,14 +244,15 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("Add")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<int> Add(
             [FromForm(Name = "numberOne")] int numberOne,
             [FromForm(Name = "numberTwo")] int numberTwo = 42)
         {
             var _params = new
             {
-                numberOne = numberOne,
-                numberTwo = numberTwo
+                NumberOne = numberOne,
+                NumberTwo = numberTwo
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -170,8 +263,40 @@ namespace Coalesce.Web.Vue2.Api
             }
 
             var _methodResult = Coalesce.Domain.Person.Add(
-                _params.numberOne,
-                _params.numberTwo
+                _params.NumberOne,
+                _params.NumberTwo
+            );
+            var _result = new ItemResult<int>(_methodResult);
+            _result.Object = _methodResult.Object;
+            return _result;
+        }
+
+        public class AddParameters
+        {
+            public int NumberOne { get; set; }
+            public int NumberTwo { get; set; } = 42;
+        }
+
+        /// <summary>
+        /// Method: Add
+        /// </summary>
+        [HttpPost("Add")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<int> Add(
+            [FromBody] AddParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("Add"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<int>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.Add(
+                _params.NumberOne,
+                _params.NumberTwo
             );
             var _result = new ItemResult<int>(_methodResult);
             _result.Object = _methodResult.Object;
@@ -198,12 +323,47 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("GetBirthdate")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<System.DateTime>> GetBirthdate(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<System.DateTime>(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.GetBirthdate();
+            var _result = new ItemResult<System.DateTime>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class GetBirthdateParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetBirthdate
+        /// </summary>
+        [HttpPost("GetBirthdate")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<System.DateTime>> GetBirthdate(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] GetBirthdateParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<System.DateTime>(itemResult);
@@ -220,25 +380,27 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("SetBirthDate")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> SetBirthDate(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "date")] System.DateOnly date,
             [FromForm(Name = "time")] System.TimeOnly time)
         {
+            var _params = new
+            {
+                Id = id,
+                Date = date,
+                Time = time
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                date = date,
-                time = time
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -248,8 +410,49 @@ namespace Coalesce.Web.Vue2.Api
 
             item.SetBirthDate(
                 Db,
-                _params.date,
-                _params.time
+                _params.Date,
+                _params.Time
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class SetBirthDateParameters
+        {
+            public int Id { get; set; }
+            public System.DateOnly Date { get; set; }
+            public System.TimeOnly Time { get; set; }
+        }
+
+        /// <summary>
+        /// Method: SetBirthDate
+        /// </summary>
+        [HttpPost("SetBirthDate")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> SetBirthDate(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] SetBirthDateParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("SetBirthDate"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            item.SetBirthDate(
+                Db,
+                _params.Date,
+                _params.Time
             );
             var _result = new ItemResult();
             return _result;
@@ -261,11 +464,11 @@ namespace Coalesce.Web.Vue2.Api
         [HttpGet("PersonCount")]
         [Authorize]
         public virtual ItemResult<long> PersonCount(
-            string lastNameStartsWith = "")
+            [FromQuery] string lastNameStartsWith = "")
         {
             var _params = new
             {
-                lastNameStartsWith = lastNameStartsWith
+                LastNameStartsWith = lastNameStartsWith
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -277,7 +480,7 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = Coalesce.Domain.Person.PersonCount(
                 Db,
-                _params.lastNameStartsWith
+                _params.LastNameStartsWith
             );
             var _result = new ItemResult<long>();
             _result.Object = _methodResult;
@@ -291,10 +494,15 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual async Task<ItemResult<string>> FullNameAndAge(
             [FromServices] IDataSourceFactory dataSourceFactory,
-            int id)
+            [FromQuery] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
@@ -314,11 +522,11 @@ namespace Coalesce.Web.Vue2.Api
         [HttpDelete("RemovePersonById")]
         [Authorize]
         public virtual ItemResult<bool> RemovePersonById(
-            int id)
+            [FromQuery] int id)
         {
             var _params = new
             {
-                id = id
+                Id = id
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -330,7 +538,7 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = Coalesce.Domain.Person.RemovePersonById(
                 Db,
-                _params.id
+                _params.Id
             );
             var _result = new ItemResult<bool>();
             _result.Object = _methodResult;
@@ -342,12 +550,49 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPut("ObfuscateEmail")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<string>> ObfuscateEmail(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<string>(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.ObfuscateEmail(
+                Db
+            );
+            var _result = new ItemResult<string>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class ObfuscateEmailParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ObfuscateEmail
+        /// </summary>
+        [HttpPut("ObfuscateEmail")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<string>> ObfuscateEmail(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ObfuscateEmailParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
@@ -366,25 +611,27 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPatch("ChangeFirstName")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<PersonResponse>> ChangeFirstName(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "firstName")] string firstName,
             [FromForm(Name = "title")] Coalesce.Domain.Person.Titles? title)
         {
+            var _params = new
+            {
+                Id = id,
+                FirstName = firstName,
+                Title = title
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<PersonResponse>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                firstName = firstName,
-                title = title
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -396,8 +643,52 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = item.ChangeFirstName(
                 Db,
-                _params.firstName,
-                _params.title
+                _params.FirstName,
+                _params.Title
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class ChangeFirstNameParameters
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public Coalesce.Domain.Person.Titles? Title { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ChangeFirstName
+        /// </summary>
+        [HttpPatch("ChangeFirstName")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<PersonResponse>> ChangeFirstName(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ChangeFirstNameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<PersonResponse>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("ChangeFirstName"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = item.ChangeFirstName(
+                Db,
+                _params.FirstName,
+                _params.Title
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -424,12 +715,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("NamesStartingWith")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<System.Collections.Generic.ICollection<string>> NamesStartingWith(
             [FromForm(Name = "characters")] string characters)
         {
             var _params = new
             {
-                characters = characters
+                Characters = characters
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -441,7 +733,38 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = Coalesce.Domain.Person.NamesStartingWith(
                 Db,
-                _params.characters
+                _params.Characters
+            );
+            var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
+            _result.Object = _methodResult?.ToList();
+            return _result;
+        }
+
+        public class NamesStartingWithParameters
+        {
+            public string Characters { get; set; }
+        }
+
+        /// <summary>
+        /// Method: NamesStartingWith
+        /// </summary>
+        [HttpPost("NamesStartingWith")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<System.Collections.Generic.ICollection<string>> NamesStartingWith(
+            [FromBody] NamesStartingWithParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("NamesStartingWith"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<System.Collections.Generic.ICollection<string>>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.NamesStartingWith(
+                Db,
+                _params.Characters
             );
             var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
             _result.Object = _methodResult?.ToList();
@@ -453,12 +776,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("MethodWithStringArrayParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<string[]> MethodWithStringArrayParameter(
             [FromForm(Name = "strings")] string[] strings)
         {
             var _params = new
             {
-                strings = strings.ToList()
+                Strings = strings.ToList()
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -470,7 +794,38 @@ namespace Coalesce.Web.Vue2.Api
 
             var _methodResult = Coalesce.Domain.Person.MethodWithStringArrayParameter(
                 Db,
-                _params.strings.ToArray()
+                _params.Strings.ToArray()
+            );
+            var _result = new ItemResult<string[]>();
+            _result.Object = _methodResult?.ToArray();
+            return _result;
+        }
+
+        public class MethodWithStringArrayParameterParameters
+        {
+            public string[] Strings { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithStringArrayParameter
+        /// </summary>
+        [HttpPost("MethodWithStringArrayParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<string[]> MethodWithStringArrayParameter(
+            [FromBody] MethodWithStringArrayParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithStringArrayParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<string[]>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.MethodWithStringArrayParameter(
+                Db,
+                _params.Strings.ToArray()
             );
             var _result = new ItemResult<string[]>();
             _result.Object = _methodResult?.ToArray();
@@ -482,12 +837,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("MethodWithEntityParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<PersonResponse> MethodWithEntityParameter(
             [FromForm(Name = "person")] PersonParameter person)
         {
             var _params = new
             {
-                person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
+                Person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -501,7 +857,40 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
                 Db,
-                _params.person?.MapToNew(_mappingContext)
+                _params.Person?.MapToNew(_mappingContext)
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class MethodWithEntityParameterParameters
+        {
+            public PersonParameter Person { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithEntityParameter
+        /// </summary>
+        [HttpPost("MethodWithEntityParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<PersonResponse> MethodWithEntityParameter(
+            [FromBody] MethodWithEntityParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithEntityParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
+                Db,
+                _params.Person?.MapToNew(_mappingContext)
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -513,12 +902,13 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("MethodWithOptionalEntityParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<PersonResponse> MethodWithOptionalEntityParameter(
             [FromForm(Name = "person")] PersonParameter person)
         {
             var _params = new
             {
-                person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
+                Person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -532,7 +922,40 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithOptionalEntityParameter(
                 Db,
-                _params.person?.MapToNew(_mappingContext)
+                _params.Person?.MapToNew(_mappingContext)
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class MethodWithOptionalEntityParameterParameters
+        {
+            public PersonParameter Person { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithOptionalEntityParameter
+        /// </summary>
+        [HttpPost("MethodWithOptionalEntityParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<PersonResponse> MethodWithOptionalEntityParameter(
+            [FromBody] MethodWithOptionalEntityParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithOptionalEntityParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.MethodWithOptionalEntityParameter(
+                Db,
+                _params.Person?.MapToNew(_mappingContext)
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -544,14 +967,15 @@ namespace Coalesce.Web.Vue2.Api
         /// </summary>
         [HttpPost("SearchPeople")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ListResult<PersonResponse> SearchPeople(
             [FromForm(Name = "criteria")] PersonCriteriaParameter criteria,
             [FromForm(Name = "page")] int page)
         {
             var _params = new
             {
-                criteria = !Request.Form.HasAnyValue(nameof(criteria)) ? null : criteria,
-                page = page
+                Criteria = !Request.Form.HasAnyValue(nameof(criteria)) ? null : criteria,
+                Page = page
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -565,8 +989,43 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.SearchPeople(
                 Db,
-                _params.criteria?.MapToNew(_mappingContext),
-                _params.page
+                _params.Criteria?.MapToNew(_mappingContext),
+                _params.Page
+            );
+            var _result = new ListResult<PersonResponse>(_methodResult);
+            _result.List = _methodResult.List?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(o, _mappingContext, includeTree ?? _methodResult.IncludeTree)).ToList();
+            return _result;
+        }
+
+        public class SearchPeopleParameters
+        {
+            public PersonCriteriaParameter Criteria { get; set; }
+            public int Page { get; set; }
+        }
+
+        /// <summary>
+        /// Method: SearchPeople
+        /// </summary>
+        [HttpPost("SearchPeople")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ListResult<PersonResponse> SearchPeople(
+            [FromBody] SearchPeopleParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("SearchPeople"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ListResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.SearchPeople(
+                Db,
+                _params.Criteria?.MapToNew(_mappingContext),
+                _params.Page
             );
             var _result = new ListResult<PersonResponse>(_methodResult);
             _result.List = _methodResult.List?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(o, _mappingContext, includeTree ?? _methodResult.IncludeTree)).ToList();

--- a/playground/Coalesce.Web.Vue2/Api/Generated/ProductController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/ProductController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<ProductResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<ProductResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize(Roles = "Admin")]
         public virtual Task<ItemResult<ProductResponse>> Save(
             [FromForm] ProductParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Product> dataSource,
+            IBehaviors<Coalesce.Domain.Product> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize(Roles = "Admin")]
+        public virtual Task<ItemResult<ProductResponse>> SaveFromJson(
+            [FromBody] ProductParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource,
             IBehaviors<Coalesce.Domain.Product> behaviors)

--- a/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadCreateController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadCreateController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadCreateResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadCreateResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadCreateResponse>> Save(
             [FromForm] StandaloneReadCreateParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource,
+            IBehaviors<Coalesce.Domain.StandaloneReadCreate> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<StandaloneReadCreateResponse>> SaveFromJson(
+            [FromBody] StandaloneReadCreateParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource,
             IBehaviors<Coalesce.Domain.StandaloneReadCreate> behaviors)

--- a/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadWriteController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadWriteController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadWriteResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadWriteResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadWriteResponse>> Save(
             [FromForm] StandaloneReadWriteParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource,
+            IBehaviors<Coalesce.Domain.StandaloneReadWrite> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<StandaloneReadWriteResponse>> SaveFromJson(
+            [FromBody] StandaloneReadWriteParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource,
             IBehaviors<Coalesce.Domain.StandaloneReadWrite> behaviors)

--- a/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadonlyController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/StandaloneReadonlyController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadonlyResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadonlyResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => CountImplementation(parameters, dataSource);
     }

--- a/playground/Coalesce.Web.Vue2/Api/Generated/WeatherServiceController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/WeatherServiceController.g.cs
@@ -39,6 +39,7 @@ namespace Coalesce.Web.Vue2.Api
         [HttpPost("GetWeather")]
         [HttpPost("GetWeatherAsync")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<WeatherDataResponse>> GetWeather(
             [FromServices] Coalesce.Domain.AppDbContext parameterDbContext,
             [FromForm(Name = "location")] LocationParameter location,
@@ -47,9 +48,9 @@ namespace Coalesce.Web.Vue2.Api
         {
             var _params = new
             {
-                location = !Request.Form.HasAnyValue(nameof(location)) ? null : location,
-                dateTime = dateTime,
-                conditions = conditions
+                Location = !Request.Form.HasAnyValue(nameof(location)) ? null : location,
+                DateTime = dateTime,
+                Conditions = conditions
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -63,9 +64,48 @@ namespace Coalesce.Web.Vue2.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = await Service.GetWeatherAsync(
                 parameterDbContext,
-                _params.location?.MapToNew(_mappingContext),
-                _params.dateTime,
-                _params.conditions
+                _params.Location?.MapToNew(_mappingContext),
+                _params.DateTime,
+                _params.Conditions
+            );
+            var _result = new ItemResult<WeatherDataResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Services.WeatherData, WeatherDataResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class GetWeatherParameters
+        {
+            public LocationParameter Location { get; set; }
+            public System.DateTimeOffset? DateTime { get; set; }
+            public Coalesce.Domain.Services.SkyConditions? Conditions { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetWeatherAsync
+        /// </summary>
+        [HttpPost("GetWeather")]
+        [HttpPost("GetWeatherAsync")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<WeatherDataResponse>> GetWeather(
+            [FromServices] Coalesce.Domain.AppDbContext parameterDbContext,
+            [FromBody] GetWeatherParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("GetWeatherAsync"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<WeatherDataResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = await Service.GetWeatherAsync(
+                parameterDbContext,
+                _params.Location?.MapToNew(_mappingContext),
+                _params.DateTime,
+                _params.Conditions
             );
             var _result = new ItemResult<WeatherDataResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Services.WeatherData, WeatherDataResponse>(_methodResult, _mappingContext, includeTree);

--- a/playground/Coalesce.Web.Vue2/Api/Generated/ZipCodeController.g.cs
+++ b/playground/Coalesce.Web.Vue2/Api/Generated/ZipCodeController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue2.Api
         [Authorize]
         public virtual Task<ItemResult<ZipCodeResponse>> Get(
             string id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<ZipCodeResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<ZipCodeResponse>> Save(
             [FromForm] ZipCodeParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.ZipCode> dataSource,
+            IBehaviors<Coalesce.Domain.ZipCode> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<ZipCodeResponse>> SaveFromJson(
+            [FromBody] ZipCodeParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource,
             IBehaviors<Coalesce.Domain.ZipCode> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/AuditLogController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/AuditLogController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<AuditLogResponse>> Get(
             long id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<AuditLogResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.AuditLog> dataSource)
             => CountImplementation(parameters, dataSource);
 

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CaseController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CaseController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [AllowAnonymous]
         public virtual Task<ItemResult<CaseResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [AllowAnonymous]
         public virtual Task<ListResult<CaseResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [AllowAnonymous]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [AllowAnonymous]
         public virtual Task<ItemResult<CaseResponse>> Save(
             [FromForm] CaseParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Case> dataSource,
+            IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [AllowAnonymous]
+        public virtual Task<ItemResult<CaseResponse>> SaveFromJson(
+            [FromBody] CaseParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Case> dataSource,
             IBehaviors<Coalesce.Domain.Case> behaviors)
@@ -88,12 +99,13 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("GetCaseTitles")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<System.Collections.Generic.ICollection<string>> GetCaseTitles(
             [FromForm(Name = "search")] string search)
         {
             var _params = new
             {
-                search = search
+                Search = search
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -105,7 +117,38 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = Coalesce.Domain.Case.GetCaseTitles(
                 Db,
-                _params.search
+                _params.Search
+            );
+            var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
+            _result.Object = _methodResult?.ToList();
+            return _result;
+        }
+
+        public class GetCaseTitlesParameters
+        {
+            public string Search { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetCaseTitles
+        /// </summary>
+        [HttpPost("GetCaseTitles")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<System.Collections.Generic.ICollection<string>> GetCaseTitles(
+            [FromBody] GetCaseTitlesParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("GetCaseTitles"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<System.Collections.Generic.ICollection<string>>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Case.GetCaseTitles(
+                Db,
+                _params.Search
             );
             var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
             _result.Object = _methodResult?.ToList();
@@ -163,23 +206,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("UploadImage")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadImage(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             Microsoft.AspNetCore.Http.IFormFile file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -189,7 +234,46 @@ namespace Coalesce.Web.Vue3.Api
 
             await item.UploadImage(
                 Db,
-                _params.file
+                _params.File
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadImageParameters
+        {
+            public int Id { get; set; }
+            public IntelliTect.Coalesce.Models.FileParameter File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadImage
+        /// </summary>
+        [HttpPost("UploadImage")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadImage(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadImageParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadImage"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            await item.UploadImage(
+                Db,
+                _params.File
             );
             var _result = new ItemResult();
             return _result;
@@ -202,11 +286,17 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> DownloadImage(
             [FromServices] IDataSourceFactory dataSourceFactory,
-            int id,
-            byte[] etag)
+            [FromQuery] int id,
+            [FromQuery] byte[] etag)
         {
+            var _params = new
+            {
+                Id = id,
+                Etag = etag ?? await ((await Request.ReadFormAsync()).Files[nameof(etag)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
@@ -248,23 +338,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("UploadAndDownload")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> UploadAndDownload(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             Microsoft.AspNetCore.Http.IFormFile file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file == null ? null : new IntelliTect.Coalesce.Models.File { Name = file.FileName, ContentType = file.ContentType, Length = file.Length, Content = file.OpenReadStream() }
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -274,7 +366,51 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = await item.UploadAndDownload(
                 Db,
-                _params.file
+                _params.File
+            );
+            if (_methodResult.Object != null)
+            {
+                return File(_methodResult.Object);
+            }
+            var _result = new ItemResult<IntelliTect.Coalesce.Models.IFile>(_methodResult);
+            _result.Object = _methodResult.Object;
+            return _result;
+        }
+
+        public class UploadAndDownloadParameters
+        {
+            public int Id { get; set; }
+            public IntelliTect.Coalesce.Models.FileParameter File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadAndDownload
+        /// </summary>
+        [HttpPost("UploadAndDownload")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ActionResult<ItemResult<IntelliTect.Coalesce.Models.IFile>>> UploadAndDownload(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadAndDownloadParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<IntelliTect.Coalesce.Models.IFile>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadAndDownload"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<IntelliTect.Coalesce.Models.IFile>(_validationResult);
+            }
+
+            var _methodResult = await item.UploadAndDownload(
+                Db,
+                _params.File
             );
             if (_methodResult.Object != null)
             {
@@ -290,23 +426,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("UploadImages")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadImages(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             System.Collections.Generic.ICollection<Microsoft.AspNetCore.Http.IFormFile> files)
         {
+            var _params = new
+            {
+                Id = id,
+                Files = files == null ? null : files.Select(f => new IntelliTect.Coalesce.Models.File { Name = f.FileName, ContentType = f.ContentType, Length = f.Length, Content = f.OpenReadStream() }).ToList()
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                files = files == null ? null : files.Select(f => (IntelliTect.Coalesce.Models.IFile)new IntelliTect.Coalesce.Models.File { Name = f.FileName, ContentType = f.ContentType, Length = f.Length, Content = f.OpenReadStream() }).ToList()
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -316,7 +454,46 @@ namespace Coalesce.Web.Vue3.Api
 
             await item.UploadImages(
                 Db,
-                _params.files.ToList()
+                _params.Files.Cast<IntelliTect.Coalesce.Models.IFile>().ToList()
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadImagesParameters
+        {
+            public int Id { get; set; }
+            public ICollection<IntelliTect.Coalesce.Models.FileParameter> Files { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadImages
+        /// </summary>
+        [HttpPost("UploadImages")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadImages(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadImagesParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadImages"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            await item.UploadImages(
+                Db,
+                _params.Files.Cast<IntelliTect.Coalesce.Models.IFile>().ToList()
             );
             var _result = new ItemResult();
             return _result;
@@ -327,23 +504,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("UploadByteArray")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> UploadByteArray(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "file")] byte[] file)
         {
+            var _params = new
+            {
+                Id = id,
+                File = file ?? await ((await Request.ReadFormAsync()).Files[nameof(file)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                file = file ?? await ((await Request.ReadFormAsync()).Files[nameof(file)]?.OpenReadStream().ReadAllBytesAsync(true) ?? Task.FromResult<byte[]>(null))
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -353,7 +532,46 @@ namespace Coalesce.Web.Vue3.Api
 
             item.UploadByteArray(
                 Db,
-                _params.file
+                _params.File
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class UploadByteArrayParameters
+        {
+            public int Id { get; set; }
+            public byte[] File { get; set; }
+        }
+
+        /// <summary>
+        /// Method: UploadByteArray
+        /// </summary>
+        [HttpPost("UploadByteArray")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> UploadByteArray(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] UploadByteArrayParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.Case>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("UploadByteArray"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            item.UploadByteArray(
+                Db,
+                _params.File
             );
             var _result = new ItemResult();
             return _result;

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CaseDtoController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CaseDtoController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<Coalesce.Domain.CaseDto>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> Save(
             [FromForm] Coalesce.Domain.CaseDto dto,
+            [FromQuery] DataSourceParameters parameters,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<Coalesce.Domain.CaseDto>> SaveFromJson(
+            [FromBody] Coalesce.Domain.CaseDto dto,
             [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IDataSource<Coalesce.Domain.Case> dataSource,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDto))] IBehaviors<Coalesce.Domain.Case> behaviors)
@@ -88,23 +99,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("AsyncMethodOnIClassDto")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<string>> AsyncMethodOnIClassDto(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "input")] string input)
         {
+            var _params = new
+            {
+                Id = id,
+                Input = input
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.CaseDto>("Default");
-            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                input = input
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -113,7 +126,46 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             var _methodResult = await item.AsyncMethodOnIClassDto(
-                _params.input
+                _params.Input
+            );
+            var _result = new ItemResult<string>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class AsyncMethodOnIClassDtoParameters
+        {
+            public int Id { get; set; }
+            public string Input { get; set; }
+        }
+
+        /// <summary>
+        /// Method: AsyncMethodOnIClassDto
+        /// </summary>
+        [HttpPost("AsyncMethodOnIClassDto")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<string>> AsyncMethodOnIClassDto(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] AsyncMethodOnIClassDtoParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Case, Coalesce.Domain.CaseDto>("Default");
+            var itemResult = await dataSource.GetMappedItemAsync<Coalesce.Domain.CaseDto>(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<string>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("AsyncMethodOnIClassDto"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<string>(_validationResult);
+            }
+
+            var _methodResult = await item.AsyncMethodOnIClassDto(
+                _params.Input
             );
             var _result = new ItemResult<string>();
             _result.Object = _methodResult;

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CaseDtoStandaloneController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CaseDtoStandaloneController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<Coalesce.Domain.CaseDtoStandalone>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> Save(
             [FromForm] Coalesce.Domain.CaseDtoStandalone dto,
+            [FromQuery] DataSourceParameters parameters,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource,
+            [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IBehaviors<Coalesce.Domain.Case> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<Coalesce.Domain.CaseDtoStandalone>> SaveFromJson(
+            [FromBody] Coalesce.Domain.CaseDtoStandalone dto,
             [FromQuery] DataSourceParameters parameters,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IDataSource<Coalesce.Domain.Case> dataSource,
             [DeclaredFor(typeof(Coalesce.Domain.CaseDtoStandalone))] IBehaviors<Coalesce.Domain.Case> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/CaseProductController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/CaseProductController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<CaseProductResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<CaseProductResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<CaseProductResponse>> Save(
             [FromForm] CaseProductParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.CaseProduct> dataSource,
+            IBehaviors<Coalesce.Domain.CaseProduct> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<CaseProductResponse>> SaveFromJson(
+            [FromBody] CaseProductParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.CaseProduct> dataSource,
             IBehaviors<Coalesce.Domain.CaseProduct> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/LogController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/LogController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<LogResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<LogResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Log> dataSource)
             => CountImplementation(parameters, dataSource);
 

--- a/playground/Coalesce.Web.Vue3/Api/Generated/PersonController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/PersonController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [AllowAnonymous]
         public virtual Task<ItemResult<PersonResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [AllowAnonymous]
         public virtual Task<ListResult<PersonResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [AllowAnonymous]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [AllowAnonymous]
         public virtual Task<ItemResult<PersonResponse>> Save(
             [FromForm] PersonParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Person> dataSource,
+            IBehaviors<Coalesce.Domain.Person> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [AllowAnonymous]
+        public virtual Task<ItemResult<PersonResponse>> SaveFromJson(
+            [FromBody] PersonParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Person> dataSource,
             IBehaviors<Coalesce.Domain.Person> behaviors)
@@ -88,23 +99,25 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("Rename")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<PersonResponse>> Rename(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "name")] string name)
         {
+            var _params = new
+            {
+                Id = id,
+                Name = name
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<PersonResponse>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                name = name
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -116,7 +129,50 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = item.Rename(
                 Db,
-                _params.name,
+                _params.Name,
+                out includeTree
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class RenameParameters
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// Method: Rename
+        /// </summary>
+        [HttpPost("Rename")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<PersonResponse>> Rename(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] RenameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<PersonResponse>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("Rename"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = item.Rename(
+                Db,
+                _params.Name,
                 out includeTree
             );
             var _result = new ItemResult<PersonResponse>();
@@ -129,12 +185,48 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("ChangeSpacesToDashesInName")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> ChangeSpacesToDashesInName(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("WithoutCases");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.ChangeSpacesToDashesInName(
+                Db
+            );
+            var _result = new ItemResult(_methodResult);
+            return _result;
+        }
+
+        public class ChangeSpacesToDashesInNameParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ChangeSpacesToDashesInName
+        /// </summary>
+        [HttpPost("ChangeSpacesToDashesInName")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> ChangeSpacesToDashesInName(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ChangeSpacesToDashesInNameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("WithoutCases");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
@@ -152,14 +244,15 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("Add")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<int> Add(
             [FromForm(Name = "numberOne")] int numberOne,
             [FromForm(Name = "numberTwo")] int numberTwo = 42)
         {
             var _params = new
             {
-                numberOne = numberOne,
-                numberTwo = numberTwo
+                NumberOne = numberOne,
+                NumberTwo = numberTwo
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -170,8 +263,40 @@ namespace Coalesce.Web.Vue3.Api
             }
 
             var _methodResult = Coalesce.Domain.Person.Add(
-                _params.numberOne,
-                _params.numberTwo
+                _params.NumberOne,
+                _params.NumberTwo
+            );
+            var _result = new ItemResult<int>(_methodResult);
+            _result.Object = _methodResult.Object;
+            return _result;
+        }
+
+        public class AddParameters
+        {
+            public int NumberOne { get; set; }
+            public int NumberTwo { get; set; } = 42;
+        }
+
+        /// <summary>
+        /// Method: Add
+        /// </summary>
+        [HttpPost("Add")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<int> Add(
+            [FromBody] AddParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("Add"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<int>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.Add(
+                _params.NumberOne,
+                _params.NumberTwo
             );
             var _result = new ItemResult<int>(_methodResult);
             _result.Object = _methodResult.Object;
@@ -198,12 +323,47 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("GetBirthdate")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<System.DateTime>> GetBirthdate(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<System.DateTime>(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.GetBirthdate();
+            var _result = new ItemResult<System.DateTime>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class GetBirthdateParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetBirthdate
+        /// </summary>
+        [HttpPost("GetBirthdate")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<System.DateTime>> GetBirthdate(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] GetBirthdateParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<System.DateTime>(itemResult);
@@ -220,25 +380,27 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("SetBirthDate")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult> SetBirthDate(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "date")] System.DateOnly date,
             [FromForm(Name = "time")] System.TimeOnly time)
         {
+            var _params = new
+            {
+                Id = id,
+                Date = date,
+                Time = time
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                date = date,
-                time = time
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -248,8 +410,49 @@ namespace Coalesce.Web.Vue3.Api
 
             item.SetBirthDate(
                 Db,
-                _params.date,
-                _params.time
+                _params.Date,
+                _params.Time
+            );
+            var _result = new ItemResult();
+            return _result;
+        }
+
+        public class SetBirthDateParameters
+        {
+            public int Id { get; set; }
+            public System.DateOnly Date { get; set; }
+            public System.TimeOnly Time { get; set; }
+        }
+
+        /// <summary>
+        /// Method: SetBirthDate
+        /// </summary>
+        [HttpPost("SetBirthDate")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult> SetBirthDate(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] SetBirthDateParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("SetBirthDate"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return _validationResult;
+            }
+
+            item.SetBirthDate(
+                Db,
+                _params.Date,
+                _params.Time
             );
             var _result = new ItemResult();
             return _result;
@@ -261,11 +464,11 @@ namespace Coalesce.Web.Vue3.Api
         [HttpGet("PersonCount")]
         [Authorize]
         public virtual ItemResult<long> PersonCount(
-            string lastNameStartsWith = "")
+            [FromQuery] string lastNameStartsWith = "")
         {
             var _params = new
             {
-                lastNameStartsWith = lastNameStartsWith
+                LastNameStartsWith = lastNameStartsWith
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -277,7 +480,7 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = Coalesce.Domain.Person.PersonCount(
                 Db,
-                _params.lastNameStartsWith
+                _params.LastNameStartsWith
             );
             var _result = new ItemResult<long>();
             _result.Object = _methodResult;
@@ -291,10 +494,15 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual async Task<ItemResult<string>> FullNameAndAge(
             [FromServices] IDataSourceFactory dataSourceFactory,
-            int id)
+            [FromQuery] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
@@ -314,11 +522,11 @@ namespace Coalesce.Web.Vue3.Api
         [HttpDelete("RemovePersonById")]
         [Authorize]
         public virtual ItemResult<bool> RemovePersonById(
-            int id)
+            [FromQuery] int id)
         {
             var _params = new
             {
-                id = id
+                Id = id
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -330,7 +538,7 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = Coalesce.Domain.Person.RemovePersonById(
                 Db,
-                _params.id
+                _params.Id
             );
             var _result = new ItemResult<bool>();
             _result.Object = _methodResult;
@@ -342,12 +550,49 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPut("ObfuscateEmail")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<string>> ObfuscateEmail(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id)
         {
+            var _params = new
+            {
+                Id = id
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<string>(itemResult);
+            }
+            var item = itemResult.Object;
+            var _methodResult = item.ObfuscateEmail(
+                Db
+            );
+            var _result = new ItemResult<string>();
+            _result.Object = _methodResult;
+            return _result;
+        }
+
+        public class ObfuscateEmailParameters
+        {
+            public int Id { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ObfuscateEmail
+        /// </summary>
+        [HttpPut("ObfuscateEmail")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<string>> ObfuscateEmail(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ObfuscateEmailParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<string>(itemResult);
@@ -366,25 +611,27 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPatch("ChangeFirstName")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<PersonResponse>> ChangeFirstName(
             [FromServices] IDataSourceFactory dataSourceFactory,
             [FromForm(Name = "id")] int id,
             [FromForm(Name = "firstName")] string firstName,
             [FromForm(Name = "title")] Coalesce.Domain.Person.Titles? title)
         {
+            var _params = new
+            {
+                Id = id,
+                FirstName = firstName,
+                Title = title
+            };
+
             var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
-            var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
             if (!itemResult.WasSuccessful)
             {
                 return new ItemResult<PersonResponse>(itemResult);
             }
             var item = itemResult.Object;
-            var _params = new
-            {
-                firstName = firstName,
-                title = title
-            };
-
             if (Context.Options.ValidateAttributesForMethods)
             {
                 var _validationResult = ItemResult.FromParameterValidation(
@@ -396,8 +643,52 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = item.ChangeFirstName(
                 Db,
-                _params.firstName,
-                _params.title
+                _params.FirstName,
+                _params.Title
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class ChangeFirstNameParameters
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public Coalesce.Domain.Person.Titles? Title { get; set; }
+        }
+
+        /// <summary>
+        /// Method: ChangeFirstName
+        /// </summary>
+        [HttpPatch("ChangeFirstName")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<PersonResponse>> ChangeFirstName(
+            [FromServices] IDataSourceFactory dataSourceFactory,
+            [FromBody] ChangeFirstNameParameters _params
+        )
+        {
+            var dataSource = dataSourceFactory.GetDataSource<Coalesce.Domain.Person, Coalesce.Domain.Person>("Default");
+            var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());
+            if (!itemResult.WasSuccessful)
+            {
+                return new ItemResult<PersonResponse>(itemResult);
+            }
+            var item = itemResult.Object;
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("ChangeFirstName"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = item.ChangeFirstName(
+                Db,
+                _params.FirstName,
+                _params.Title
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -424,12 +715,13 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("NamesStartingWith")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<System.Collections.Generic.ICollection<string>> NamesStartingWith(
             [FromForm(Name = "characters")] string characters)
         {
             var _params = new
             {
-                characters = characters
+                Characters = characters
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -441,7 +733,38 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = Coalesce.Domain.Person.NamesStartingWith(
                 Db,
-                _params.characters
+                _params.Characters
+            );
+            var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
+            _result.Object = _methodResult?.ToList();
+            return _result;
+        }
+
+        public class NamesStartingWithParameters
+        {
+            public string Characters { get; set; }
+        }
+
+        /// <summary>
+        /// Method: NamesStartingWith
+        /// </summary>
+        [HttpPost("NamesStartingWith")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<System.Collections.Generic.ICollection<string>> NamesStartingWith(
+            [FromBody] NamesStartingWithParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("NamesStartingWith"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<System.Collections.Generic.ICollection<string>>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.NamesStartingWith(
+                Db,
+                _params.Characters
             );
             var _result = new ItemResult<System.Collections.Generic.ICollection<string>>();
             _result.Object = _methodResult?.ToList();
@@ -453,12 +776,13 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("MethodWithStringArrayParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<string[]> MethodWithStringArrayParameter(
             [FromForm(Name = "strings")] string[] strings)
         {
             var _params = new
             {
-                strings = strings.ToList()
+                Strings = strings.ToList()
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -470,7 +794,38 @@ namespace Coalesce.Web.Vue3.Api
 
             var _methodResult = Coalesce.Domain.Person.MethodWithStringArrayParameter(
                 Db,
-                _params.strings.ToArray()
+                _params.Strings.ToArray()
+            );
+            var _result = new ItemResult<string[]>();
+            _result.Object = _methodResult?.ToArray();
+            return _result;
+        }
+
+        public class MethodWithStringArrayParameterParameters
+        {
+            public string[] Strings { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithStringArrayParameter
+        /// </summary>
+        [HttpPost("MethodWithStringArrayParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<string[]> MethodWithStringArrayParameter(
+            [FromBody] MethodWithStringArrayParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithStringArrayParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<string[]>(_validationResult);
+            }
+
+            var _methodResult = Coalesce.Domain.Person.MethodWithStringArrayParameter(
+                Db,
+                _params.Strings.ToArray()
             );
             var _result = new ItemResult<string[]>();
             _result.Object = _methodResult?.ToArray();
@@ -482,12 +837,13 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("MethodWithEntityParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<PersonResponse> MethodWithEntityParameter(
             [FromForm(Name = "person")] PersonParameter person)
         {
             var _params = new
             {
-                person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
+                Person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -501,7 +857,40 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
                 Db,
-                _params.person?.MapToNew(_mappingContext)
+                _params.Person?.MapToNew(_mappingContext)
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class MethodWithEntityParameterParameters
+        {
+            public PersonParameter Person { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithEntityParameter
+        /// </summary>
+        [HttpPost("MethodWithEntityParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<PersonResponse> MethodWithEntityParameter(
+            [FromBody] MethodWithEntityParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithEntityParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.MethodWithEntityParameter(
+                Db,
+                _params.Person?.MapToNew(_mappingContext)
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -513,12 +902,13 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("MethodWithOptionalEntityParameter")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ItemResult<PersonResponse> MethodWithOptionalEntityParameter(
             [FromForm(Name = "person")] PersonParameter person)
         {
             var _params = new
             {
-                person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
+                Person = !Request.Form.HasAnyValue(nameof(person)) ? null : person
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -532,7 +922,40 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.MethodWithOptionalEntityParameter(
                 Db,
-                _params.person?.MapToNew(_mappingContext)
+                _params.Person?.MapToNew(_mappingContext)
+            );
+            var _result = new ItemResult<PersonResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class MethodWithOptionalEntityParameterParameters
+        {
+            public PersonParameter Person { get; set; }
+        }
+
+        /// <summary>
+        /// Method: MethodWithOptionalEntityParameter
+        /// </summary>
+        [HttpPost("MethodWithOptionalEntityParameter")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ItemResult<PersonResponse> MethodWithOptionalEntityParameter(
+            [FromBody] MethodWithOptionalEntityParameterParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("MethodWithOptionalEntityParameter"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.MethodWithOptionalEntityParameter(
+                Db,
+                _params.Person?.MapToNew(_mappingContext)
             );
             var _result = new ItemResult<PersonResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(_methodResult, _mappingContext, includeTree);
@@ -544,14 +967,15 @@ namespace Coalesce.Web.Vue3.Api
         /// </summary>
         [HttpPost("SearchPeople")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual ListResult<PersonResponse> SearchPeople(
             [FromForm(Name = "criteria")] PersonCriteriaParameter criteria,
             [FromForm(Name = "page")] int page)
         {
             var _params = new
             {
-                criteria = !Request.Form.HasAnyValue(nameof(criteria)) ? null : criteria,
-                page = page
+                Criteria = !Request.Form.HasAnyValue(nameof(criteria)) ? null : criteria,
+                Page = page
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -565,8 +989,43 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = Coalesce.Domain.Person.SearchPeople(
                 Db,
-                _params.criteria?.MapToNew(_mappingContext),
-                _params.page
+                _params.Criteria?.MapToNew(_mappingContext),
+                _params.Page
+            );
+            var _result = new ListResult<PersonResponse>(_methodResult);
+            _result.List = _methodResult.List?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(o, _mappingContext, includeTree ?? _methodResult.IncludeTree)).ToList();
+            return _result;
+        }
+
+        public class SearchPeopleParameters
+        {
+            public PersonCriteriaParameter Criteria { get; set; }
+            public int Page { get; set; }
+        }
+
+        /// <summary>
+        /// Method: SearchPeople
+        /// </summary>
+        [HttpPost("SearchPeople")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual ListResult<PersonResponse> SearchPeople(
+            [FromBody] SearchPeopleParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("SearchPeople"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ListResult<PersonResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = Coalesce.Domain.Person.SearchPeople(
+                Db,
+                _params.Criteria?.MapToNew(_mappingContext),
+                _params.Page
             );
             var _result = new ListResult<PersonResponse>(_methodResult);
             _result.List = _methodResult.List?.ToList().Select(o => Mapper.MapToDto<Coalesce.Domain.Person, PersonResponse>(o, _mappingContext, includeTree ?? _methodResult.IncludeTree)).ToList();

--- a/playground/Coalesce.Web.Vue3/Api/Generated/ProductController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/ProductController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<ProductResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<ProductResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize(Roles = "Admin")]
         public virtual Task<ItemResult<ProductResponse>> Save(
             [FromForm] ProductParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.Product> dataSource,
+            IBehaviors<Coalesce.Domain.Product> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize(Roles = "Admin")]
+        public virtual Task<ItemResult<ProductResponse>> SaveFromJson(
+            [FromBody] ProductParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.Product> dataSource,
             IBehaviors<Coalesce.Domain.Product> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadCreateController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadCreateController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadCreateResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadCreateResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadCreateResponse>> Save(
             [FromForm] StandaloneReadCreateParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource,
+            IBehaviors<Coalesce.Domain.StandaloneReadCreate> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<StandaloneReadCreateResponse>> SaveFromJson(
+            [FromBody] StandaloneReadCreateParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadCreate> dataSource,
             IBehaviors<Coalesce.Domain.StandaloneReadCreate> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadWriteController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadWriteController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadWriteResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadWriteResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadWriteResponse>> Save(
             [FromForm] StandaloneReadWriteParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource,
+            IBehaviors<Coalesce.Domain.StandaloneReadWrite> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<StandaloneReadWriteResponse>> SaveFromJson(
+            [FromBody] StandaloneReadWriteParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadWrite> dataSource,
             IBehaviors<Coalesce.Domain.StandaloneReadWrite> behaviors)

--- a/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadonlyController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/StandaloneReadonlyController.g.cs
@@ -36,21 +36,21 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<StandaloneReadonlyResponse>> Get(
             int id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<StandaloneReadonlyResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.StandaloneReadonly> dataSource)
             => CountImplementation(parameters, dataSource);
     }

--- a/playground/Coalesce.Web.Vue3/Api/Generated/WeatherServiceController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/WeatherServiceController.g.cs
@@ -39,6 +39,7 @@ namespace Coalesce.Web.Vue3.Api
         [HttpPost("GetWeather")]
         [HttpPost("GetWeatherAsync")]
         [Authorize]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         public virtual async Task<ItemResult<WeatherDataResponse>> GetWeather(
             [FromServices] Coalesce.Domain.AppDbContext parameterDbContext,
             [FromForm(Name = "location")] LocationParameter location,
@@ -47,9 +48,9 @@ namespace Coalesce.Web.Vue3.Api
         {
             var _params = new
             {
-                location = !Request.Form.HasAnyValue(nameof(location)) ? null : location,
-                dateTime = dateTime,
-                conditions = conditions
+                Location = !Request.Form.HasAnyValue(nameof(location)) ? null : location,
+                DateTime = dateTime,
+                Conditions = conditions
             };
 
             if (Context.Options.ValidateAttributesForMethods)
@@ -63,9 +64,48 @@ namespace Coalesce.Web.Vue3.Api
             var _mappingContext = new MappingContext(Context);
             var _methodResult = await Service.GetWeatherAsync(
                 parameterDbContext,
-                _params.location?.MapToNew(_mappingContext),
-                _params.dateTime,
-                _params.conditions
+                _params.Location?.MapToNew(_mappingContext),
+                _params.DateTime,
+                _params.Conditions
+            );
+            var _result = new ItemResult<WeatherDataResponse>();
+            _result.Object = Mapper.MapToDto<Coalesce.Domain.Services.WeatherData, WeatherDataResponse>(_methodResult, _mappingContext, includeTree);
+            return _result;
+        }
+
+        public class GetWeatherParameters
+        {
+            public LocationParameter Location { get; set; }
+            public System.DateTimeOffset? DateTime { get; set; }
+            public Coalesce.Domain.Services.SkyConditions? Conditions { get; set; }
+        }
+
+        /// <summary>
+        /// Method: GetWeatherAsync
+        /// </summary>
+        [HttpPost("GetWeather")]
+        [HttpPost("GetWeatherAsync")]
+        [Authorize]
+        [Consumes("application/json")]
+        public virtual async Task<ItemResult<WeatherDataResponse>> GetWeather(
+            [FromServices] Coalesce.Domain.AppDbContext parameterDbContext,
+            [FromBody] GetWeatherParameters _params
+        )
+        {
+            if (Context.Options.ValidateAttributesForMethods)
+            {
+                var _validationResult = ItemResult.FromParameterValidation(
+                    GeneratedForClassViewModel!.MethodByName("GetWeatherAsync"), _params, HttpContext.RequestServices);
+                if (!_validationResult.WasSuccessful) return new ItemResult<WeatherDataResponse>(_validationResult);
+            }
+
+            IncludeTree includeTree = null;
+            var _mappingContext = new MappingContext(Context);
+            var _methodResult = await Service.GetWeatherAsync(
+                parameterDbContext,
+                _params.Location?.MapToNew(_mappingContext),
+                _params.DateTime,
+                _params.Conditions
             );
             var _result = new ItemResult<WeatherDataResponse>();
             _result.Object = Mapper.MapToDto<Coalesce.Domain.Services.WeatherData, WeatherDataResponse>(_methodResult, _mappingContext, includeTree);

--- a/playground/Coalesce.Web.Vue3/Api/Generated/ZipCodeController.g.cs
+++ b/playground/Coalesce.Web.Vue3/Api/Generated/ZipCodeController.g.cs
@@ -36,28 +36,39 @@ namespace Coalesce.Web.Vue3.Api
         [Authorize]
         public virtual Task<ItemResult<ZipCodeResponse>> Get(
             string id,
-            DataSourceParameters parameters,
+            [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => GetImplementation(id, parameters, dataSource);
 
         [HttpGet("list")]
         [Authorize]
         public virtual Task<ListResult<ZipCodeResponse>> List(
-            ListParameters parameters,
+            [FromQuery] ListParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => ListImplementation(parameters, dataSource);
 
         [HttpGet("count")]
         [Authorize]
         public virtual Task<ItemResult<int>> Count(
-            FilterParameters parameters,
+            [FromQuery] FilterParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource)
             => CountImplementation(parameters, dataSource);
 
         [HttpPost("save")]
+        [Consumes("application/x-www-form-urlencoded", "multipart/form-data")]
         [Authorize]
         public virtual Task<ItemResult<ZipCodeResponse>> Save(
             [FromForm] ZipCodeParameter dto,
+            [FromQuery] DataSourceParameters parameters,
+            IDataSource<Coalesce.Domain.ZipCode> dataSource,
+            IBehaviors<Coalesce.Domain.ZipCode> behaviors)
+            => SaveImplementation(dto, parameters, dataSource, behaviors);
+
+        [HttpPost("save")]
+        [Consumes("application/json")]
+        [Authorize]
+        public virtual Task<ItemResult<ZipCodeResponse>> SaveFromJson(
+            [FromBody] ZipCodeParameter dto,
             [FromQuery] DataSourceParameters parameters,
             IDataSource<Coalesce.Domain.ZipCode> dataSource,
             IBehaviors<Coalesce.Domain.ZipCode> behaviors)

--- a/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
+++ b/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
@@ -7,7 +7,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
-
+  
+  <ItemGroup>
+    <!--<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />-->
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Coalesce.Domain\Coalesce.Domain.csproj" />
     <ProjectReference Include="..\..\src\IntelliTect.Coalesce.Vue\IntelliTect.Coalesce.Vue.csproj" />

--- a/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
+++ b/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.1" />-->
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Coalesce.Domain\Coalesce.Domain.csproj" />
     <ProjectReference Include="..\..\src\IntelliTect.Coalesce.Vue\IntelliTect.Coalesce.Vue.csproj" />
     <ProjectReference Include="..\..\src\IntelliTect.Coalesce.Swashbuckle\IntelliTect.Coalesce.Swashbuckle.csproj" />

--- a/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
+++ b/playground/Coalesce.Web.Vue3/Coalesce.Web.Vue3.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />

--- a/playground/Coalesce.Web.Vue3/Program.cs
+++ b/playground/Coalesce.Web.Vue3/Program.cs
@@ -1,7 +1,7 @@
 using Coalesce.Domain;
 using Coalesce.Domain.WebShared;
 using IntelliTect.Coalesce;
-using Microsoft.AspNetCore.Authentication;
+using Microsoft.OpenApi;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Console;
@@ -11,6 +11,8 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {
@@ -57,6 +59,9 @@ services.Configure<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions
 {
     options.Limits.MaxRequestBodySize = int.MaxValue; // testing big file uploads/downloads
 });
+
+
+//services.AddOpenApi(); // net9
 
 services.AddSwaggerGen(c =>
 {
@@ -116,6 +121,7 @@ app.Use(async (context, next) =>
 
 app.UseCors(c => c.AllowAnyOrigin().AllowAnyHeader());
 app.MapControllers();
+//app.MapOpenApi(); // net9
 app.MapSwagger();
 app.UseSwaggerUI(c =>
 {

--- a/playground/Coalesce.Web.Vue3/Program.cs
+++ b/playground/Coalesce.Web.Vue3/Program.cs
@@ -1,7 +1,7 @@
 using Coalesce.Domain;
 using Coalesce.Domain.WebShared;
 using IntelliTect.Coalesce;
-using Microsoft.OpenApi;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Console;
@@ -11,8 +11,6 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/BaseGenerators/ApiController.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/BaseGenerators/ApiController.cs
@@ -81,7 +81,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
             }
         }
 
-        protected static void WriteControllerActionPreamble(CSharpCodeBuilder b, MethodViewModel method)
+        private static void WriteControllerActionPreamble(CSharpCodeBuilder b, MethodViewModel method)
         {
             var methodAnnotationName = $"Http{method.ApiActionHttpMethod}";
 
@@ -96,7 +96,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
             b.Line(method.SecurityInfo.Execute.MvcAnnotation());
         }
 
-        protected static void WriteControllerActionJsonPreamble(CSharpCodeBuilder b, MethodViewModel method)
+        private static void WriteControllerActionJsonPreamble(CSharpCodeBuilder b, MethodViewModel method)
         {
             if (!method.ApiParameters.Any()) return;
 
@@ -162,6 +162,8 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
 
         protected IDisposable WriteControllerActionSignature(CSharpCodeBuilder b, MethodViewModel method)
         {
+            WriteControllerActionPreamble(b, method);
+
             if (method.HasHttpRequestBody)
             {
                 b.Line("""[Consumes("application/x-www-form-urlencoded", "multipart/form-data")]""");
@@ -236,11 +238,17 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
 
             b.TrimWhitespace().TrimEnd(",").Append(")");
             indent.Dispose();
-            return b.Block();
+            var blockRet = b.Block();
+
+            WriteFormDataParamsObject(b, method);
+
+            return blockRet;
         }
 
         protected IDisposable WriteControllerActionJsonSignature(CSharpCodeBuilder b, MethodViewModel method)
         {
+            WriteControllerActionJsonPreamble(b, method);
+
             if (method.ApiParameters.Any())
             {
                 b.Line("[Consumes(\"application/json\")]");
@@ -355,7 +363,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
             b.Line(");");
         }
 
-        protected void WriteFormDataParamsObject(CSharpCodeBuilder b, MethodViewModel method)
+        private void WriteFormDataParamsObject(CSharpCodeBuilder b, MethodViewModel method)
         {
             var clientParameters = method.ApiParameters.ToList();
             if (clientParameters.Count == 0) return;

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/BaseGenerators/ApiController.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/BaseGenerators/ApiController.cs
@@ -99,6 +99,10 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
 
         protected IDisposable WriteControllerActionSignature(CSharpCodeBuilder b, MethodViewModel method)
         {
+            if (method.HasHttpRequestBody)
+            {
+                b.Line("""[Consumes("application/x-www-form-urlencoded", "multipart/form-data")]""");
+            }
             var returnType = method.ApiActionReturnTypeDeclaration;
             if (method.ResultType.IsFile)
             {
@@ -168,6 +172,10 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
                     // File parameters must not be annotated with FromForm, as this will break their model binding.
                     // They have their own special implicit model binder.
                 }
+                else if (!method.HasHttpRequestBody)
+                {
+                    b.Append("[FromQuery] ");
+                }
 
                 b.Append(typeName);
                 b.Append(" ");
@@ -185,6 +193,105 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
             return b.Block();
         }
 
+
+        protected static void WriteControllerActionJsonPreamble(CSharpCodeBuilder b, MethodViewModel method)
+        {
+            if (!method.ApiParameters.Any()) return;
+
+            b.Line();
+            using (b.Block($"public class {method.NameWithoutAsync}Parameters"))
+            {
+                foreach (var param in method.ApiParameters.OrderBy(p => p.HasDefaultValue))
+                {
+                    string typeName;
+                    if (param.PureType.IsFile)
+                    {
+                        typeName = "IntelliTect.Coalesce.Models.FileParameter";
+                        if (param.Type.IsCollection) typeName = $"ICollection<{typeName}>";
+                    }
+                    else
+                    {
+                        typeName = param.Type.NullableTypeForDto(isInput: true, dtoNamespace: null, dontEmitNullable: true);
+                    }
+
+                    b.Append("public ");
+                    b.Append(typeName);
+                    b.Append(" ");
+                    b.Append(param.PascalCaseName);
+                    b.Append(" { get; set; }");
+                    if (param.HasDefaultValue)
+                    {
+                        b.Append(" = ");
+                        b.Append(param.CsDefaultValue);
+                        b.Append(";");
+                    }
+                    b.Line();
+                }
+            }
+
+            WriteControllerActionPreamble(b, method);
+        }
+
+        protected IDisposable WriteControllerActionJsonSignature(CSharpCodeBuilder b, MethodViewModel method)
+        {
+            b.Line("[Consumes(\"application/json\")]");
+
+            var returnType = method.ApiActionReturnTypeDeclaration;
+            if (method.ResultType.IsFile)
+            {
+                // Wrap the signature in ActionResult<> since file-returning methods
+                // have mixed return types due to use of the File() method on controllers.
+                // This is not baked into ApiActionReturnTypeDeclaration because it ONLY affects
+                // the signature, but not the places within the method that we instantiate the return type
+                // due to the implcit conversions from T to ActionResult<T>.
+                returnType = $"ActionResult<{returnType}>";
+            }
+            if (method.IsAwaitable || method.IsModelInstanceMethod || method.Parameters.Any(p => p.Type.IsByteArray))
+            {
+                returnType = $"async Task<{returnType}>";
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            b.Append(Model.ApiActionAccessModifier);
+#pragma warning restore CS0618 // Type or member is obsolete
+            b.Append(" virtual ");
+            b.Append(returnType);
+            b.Append(" ");
+            b.Append(method.NameWithoutAsync);
+            b.Line("(");
+            using var indent = b.Indented();
+
+            if (method.IsModelInstanceMethod)
+            {
+                b.Line("[FromServices] IDataSourceFactory dataSourceFactory,");
+            }
+
+            foreach (var param in method.Parameters
+                .Where(f => f.IsDI && !f.IsNonArgumentDI))
+            {
+                string typeName = param.Type.FullyQualifiedName;
+
+                if (param.ShouldInjectFromServices)
+                {
+                    b.Append("[FromServices] ");
+                }
+
+                b.Append(typeName);
+                b.Append(" ");
+                b.Append(param.CsParameterName);
+                b.Line(",");
+            }
+
+            if (method.ApiParameters.Any())
+            {
+                b.Line($"[FromBody] {method.NameWithoutAsync}Parameters _params");
+            }
+
+            indent.Dispose();
+            b.Line(")");
+            return b.Block();
+        }
+
         public const string MethodResultVar = "_methodResult";
         public const string MappingContextVar = "_mappingContext";
 
@@ -197,27 +304,17 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
         /// The member on which to invoke the method. 
         /// This could be an variable holding an instance of a type, or a class reference if the method is static.
         /// </param>
-        public void WriteMethodInvocation(CSharpCodeBuilder b, MethodViewModel method, string owningMember)
+        public void WriteMethodInvocation(
+            CSharpCodeBuilder b, 
+            MethodViewModel method, 
+            string owningMember
+        )
         {
-
             var clientParameters = method.ClientParameters.ToList();
             if (clientParameters.Count > 0)
             {
-                using (b.Block("var _params = new", ";"))
-                {
-                    for (int i = 0; i < clientParameters.Count; i++)
-                    {
-                        var param = clientParameters[i];
-                        if (i != 0) b.Line(", ");
-                        b.Append(param.CsParameterName);
-                        b.Append(" = ");
-                        b.Append(GetMethodPreMapParameterExpression(clientParameters[i]));
-                    }
-                }
-                b.Line();
-
                 var validateAttributes = method.GetAttributeValue<ExecuteAttribute, bool>(
-                    e => e.ValidateAttributes, 
+                    e => e.ValidateAttributes,
                     e => e.ValidateAttributesHasValue);
                 if (validateAttributes == true)
                 {
@@ -268,6 +365,25 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
             b.Line(");");
         }
 
+        protected void WriteFormDataParamsObject(CSharpCodeBuilder b, MethodViewModel method)
+        {
+            var clientParameters = method.ApiParameters.ToList();
+            if (clientParameters.Count == 0) return;
+
+            using (b.Block("var _params = new", ";"))
+            {
+                for (int i = 0; i < clientParameters.Count; i++)
+                {
+                    var param = clientParameters[i];
+                    if (i != 0) b.Line(", ");
+                    b.Append(param.PascalCaseName);
+                    b.Append(" = ");
+                    b.Append(GetMethodParameterFormDataMappingExpression(clientParameters[i]));
+                }
+            }
+            b.Line();
+        }
+
         private void WriteMethodValidation(CSharpCodeBuilder b, MethodViewModel method)
         {
             // You may be wondering... why don't we just check ModelState?
@@ -300,14 +416,14 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
         /// that maps the controller input to the argument of method being called.
         /// Does not perform DTO mapping, as this method produces the target of validation.
         /// </summary>
-        protected string GetMethodPreMapParameterExpression(ParameterViewModel param)
+        protected string GetMethodParameterFormDataMappingExpression(ParameterViewModel param)
         {
             var ret = param.CsParameterName;
 
             if (param.PureType.IsFile)
             {
                 ret = $"{ret} == null ? null : " + (param.Type.IsCollection
-                    ? $"{ret}.Select(f => ({param.PureType.FullyQualifiedName}){FileCtor("f")})"
+                    ? $"{ret}.Select(f => {FileCtor("f")})"
                     : $"{FileCtor(ret)} ");
 
                 static string FileCtor(string x) =>
@@ -365,7 +481,7 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
                 return param.CsParameterName;
             }
 
-            string ret = $"_params.{param.CsParameterName}";
+            string ret = $"_params.{param.PascalCaseName}";
 
             if (param.Type.PureType.ClassViewModel != null && !param.Type.PureType.ClassViewModel.IsCustomDto)
             {
@@ -381,6 +497,11 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.BaseGenerators
 
             if (param.Type.IsCollection)
             {
+                if (param.PureType.IsFile)
+                {
+                    ret += $".Cast<{param.PureType.FullyQualifiedName}>()";
+                }
+
                 if (param.Type.IsArray)
                     ret += ".ToArray()";
                 else

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ModelApiController.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ModelApiController.cs
@@ -76,29 +76,29 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
             {
                 // ENDPOINT: /get/{id}
                 b.Line();
-                b.Line("[HttpGet(\"get/{id}\")]");
+                b.Line("""[HttpGet("get/{id}")]""");
                 b.Line($"{securityInfo.Read.MvcAnnotation()}");
                 b.Line($"{accessModifier} virtual Task<ItemResult<{Model.ResponseDtoTypeName}>> Get(");
                 b.Indented($"{primaryKeyParameter},");
-                b.Indented($"DataSourceParameters parameters,");
+                b.Indented($"[FromQuery] DataSourceParameters parameters,");
                 b.Indented($"{dataSourceParameter})");
                 b.Indented($"=> GetImplementation(id, parameters, dataSource);");
 
                 // ENDPOINT: /list
                 b.Line();
-                b.Line("[HttpGet(\"list\")]");
+                b.Line("""[HttpGet("list")]""");
                 b.Line($"{securityInfo.Read.MvcAnnotation()}");
                 b.Line($"{accessModifier} virtual Task<ListResult<{Model.ResponseDtoTypeName}>> List(");
-                b.Indented($"ListParameters parameters,");
+                b.Indented($"[FromQuery] ListParameters parameters,");
                 b.Indented($"{dataSourceParameter})");
                 b.Indented($"=> ListImplementation(parameters, dataSource);");
 
                 // ENDPOINT: /count
                 b.Line();
-                b.Line("[HttpGet(\"count\")]");
+                b.Line("""[HttpGet("count")]""");
                 b.Line($"{securityInfo.Read.MvcAnnotation()}");
                 b.Line($"{accessModifier} virtual Task<ItemResult<int>> Count(");
-                b.Indented($"FilterParameters parameters,");
+                b.Indented($"[FromQuery] FilterParameters parameters,");
                 b.Indented($"{dataSourceParameter})");
                 b.Indented($"=> CountImplementation(parameters, dataSource);");
             }
@@ -107,10 +107,22 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
             {
                 // ENDPOINT: /save
                 b.Line();
-                b.Line("[HttpPost(\"save\")]");
+                b.Line("""[HttpPost("save")]""");
+                b.Line("""[Consumes("application/x-www-form-urlencoded", "multipart/form-data")]""");
                 b.Line($"{securityInfo.Save.MvcAnnotation()}");
                 b.Line($"{accessModifier} virtual Task<ItemResult<{Model.ResponseDtoTypeName}>> Save(");
                 b.Indented($"[FromForm] {Model.ParameterDtoTypeName} dto,");
+                b.Indented($"[FromQuery] DataSourceParameters parameters,");
+                b.Indented($"{dataSourceParameter},");
+                b.Indented($"{behaviorsParameter})");
+                b.Indented($"=> SaveImplementation(dto, parameters, dataSource, behaviors);");
+
+                b.Line();
+                b.Line("""[HttpPost("save")]""");
+                b.Line("""[Consumes("application/json")]""");
+                b.Line($"{securityInfo.Save.MvcAnnotation()}");
+                b.Line($"{accessModifier} virtual Task<ItemResult<{Model.ResponseDtoTypeName}>> SaveFromJson(");
+                b.Indented($"[FromBody] {Model.ParameterDtoTypeName} dto,");
                 b.Indented($"[FromQuery] DataSourceParameters parameters,");
                 b.Indented($"{dataSourceParameter},");
                 b.Indented($"{behaviorsParameter})");
@@ -158,32 +170,18 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
             }
             foreach (var method in Model.ClientMethods)
             {
+                // Write the action for parameterless methods and formdata methods
                 WriteControllerActionPreamble(b, method);
                 using (WriteControllerActionSignature(b, method))
                 {
+                    WriteFormDataParamsObject(b, method);
                     if (method.IsStatic)
                     {
                         WriteMethodInvocation(b, method, method.Parent.FullyQualifiedName);
                     }
                     else
                     {
-                        b.Line($"var dataSource = dataSourceFactory.GetDataSource<" +
-                            $"{Model.BaseViewModel.FullyQualifiedName}, {Model.FullyQualifiedName}>" +
-                            $"(\"{method.LoadFromDataSourceName}\");");
-
-                        if (Model.IsCustomDto)
-                        {
-                            b.Line($"var itemResult = await dataSource.GetMappedItemAsync<{Model.FullyQualifiedName}>(id, new DataSourceParameters());");
-                        }
-                        else
-                        {
-                            b.Line("var itemResult = await dataSource.GetItemAsync(id, new DataSourceParameters());");
-                        }
-                        using (b.Block("if (!itemResult.WasSuccessful)"))
-                        {
-                            b.Line($"return new {method.ApiActionReturnTypeDeclaration}(itemResult);");
-                        }
-                        b.Line("var item = itemResult.Object;");
+                        WriteInstanceMethodTargetLoading(b, method);
 
                         var varyByProperty = method.VaryByProperty;
                         if (varyByProperty != null)
@@ -196,7 +194,47 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
 
                     WriteMethodResultProcessBlock(b, method);
                 }
+
+                if (method.HasHttpRequestBody)
+                {
+                    WriteControllerActionJsonPreamble(b, method);
+                    using (WriteControllerActionJsonSignature(b, method))
+                    {
+                        if (method.IsStatic)
+                        {
+                            WriteMethodInvocation(b, method, method.Parent.FullyQualifiedName);
+                        }
+                        else
+                        {
+                            WriteInstanceMethodTargetLoading(b, method);
+                            WriteMethodInvocation(b, method, "item");
+                        }
+
+                        WriteMethodResultProcessBlock(b, method);
+                    }
+                }
             }
+        }
+
+        private void WriteInstanceMethodTargetLoading(CSharpCodeBuilder b, MethodViewModel method)
+        {
+            b.Line($"var dataSource = dataSourceFactory.GetDataSource<" +
+                $"{Model.BaseViewModel.FullyQualifiedName}, {Model.FullyQualifiedName}>" +
+                $"(\"{method.LoadFromDataSourceName}\");");
+
+            if (Model.IsCustomDto)
+            {
+                b.Line($"var itemResult = await dataSource.GetMappedItemAsync<{Model.FullyQualifiedName}>(_params.Id, new DataSourceParameters());");
+            }
+            else
+            {
+                b.Line("var itemResult = await dataSource.GetItemAsync(_params.Id, new DataSourceParameters());");
+            }
+            using (b.Block("if (!itemResult.WasSuccessful)"))
+            {
+                b.Line($"return new {method.ApiActionReturnTypeDeclaration}(itemResult);");
+            }
+            b.Line("var item = itemResult.Object;");
         }
 
         private static void WriteEtagProcessing(CSharpCodeBuilder b, MethodViewModel method, PropertyViewModel varyByProperty)

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ServiceApiController.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ServiceApiController.cs
@@ -46,9 +46,21 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
                 WriteControllerActionPreamble(b, method);
                 using (WriteControllerActionSignature(b, method))
                 {
+                    WriteFormDataParamsObject(b, method);
                     WriteMethodInvocation(b, method, "Service");
 
                     WriteMethodResultProcessBlock(b, method);
+                }
+
+                if (method.HasHttpRequestBody)
+                {
+                    WriteControllerActionJsonPreamble(b, method);
+                    using (WriteControllerActionJsonSignature(b, method))
+                    {
+                        WriteMethodInvocation(b, method, "Service");
+
+                        WriteMethodResultProcessBlock(b, method);
+                    }
                 }
             }
         }

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ServiceApiController.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ServiceApiController.cs
@@ -43,10 +43,8 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
 
             foreach (var method in Model.ClientMethods)
             {
-                WriteControllerActionPreamble(b, method);
                 using (WriteControllerActionSignature(b, method))
                 {
-                    WriteFormDataParamsObject(b, method);
                     WriteMethodInvocation(b, method, "Service");
 
                     WriteMethodResultProcessBlock(b, method);
@@ -54,7 +52,6 @@ namespace IntelliTect.Coalesce.CodeGeneration.Api.Generators
 
                 if (method.HasHttpRequestBody)
                 {
-                    WriteControllerActionJsonPreamble(b, method);
                     using (WriteControllerActionJsonSignature(b, method))
                     {
                         WriteMethodInvocation(b, method, "Service");

--- a/src/IntelliTect.Coalesce.Swashbuckle/CoalesceApiOperationFilter.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle/CoalesceApiOperationFilter.cs
@@ -8,26 +8,10 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace IntelliTect.Coalesce.Swashbuckle
 {
-    public class CoalesceApiSchemaFilter : ISchemaFilter
-    {
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
-        {
-            if (context.Type.IsAssignableTo(typeof(ISparseDto)))
-            {
-                string description = "This type supports partial/surgical modifications. Properties that are entirely omitted/undefined will be left unchanged on the target object.";
-
-                if (!string.IsNullOrWhiteSpace(schema.Description)) schema.Description += " " + description;
-                else schema.Description = description;
-            }
-
-        }
-    }
-
     public class CoalesceApiOperationFilter : IOperationFilter
     {
         private readonly ReflectionRepository reflectionRepository;

--- a/src/IntelliTect.Coalesce.Swashbuckle/CoalesceApiSchemaFilter.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle/CoalesceApiSchemaFilter.cs
@@ -1,0 +1,21 @@
+﻿using IntelliTect.Coalesce.Models;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace IntelliTect.Coalesce.Swashbuckle
+{
+    public class CoalesceApiSchemaFilter : ISchemaFilter
+    {
+        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        {
+            if (context.Type.IsAssignableTo(typeof(ISparseDto)))
+            {
+                string description = "This type supports partial/surgical modifications. Properties that are entirely omitted/undefined will be left unchanged on the target object.";
+
+                if (!string.IsNullOrWhiteSpace(schema.Description)) schema.Description += " " + description;
+                else schema.Description = description;
+            }
+
+        }
+    }
+}

--- a/src/IntelliTect.Coalesce.Swashbuckle/CoalesceDocumentFilter.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle/CoalesceDocumentFilter.cs
@@ -13,9 +13,6 @@ namespace IntelliTect.Coalesce.Swashbuckle
         {
             // Get rid of bad schema definitions that we don't use.
             var defsToRemove = swaggerDoc.Components.Schemas.Keys.Where(d =>
-                // Data sources and behaviors are fixed up by CoalesceApiOperationFilter
-                d.EndsWith(nameof(IDataSource<object>)) ||
-                d.EndsWith(nameof(IBehaviors<object>)) ||
                 // These get incorrectly put here if your API surface has file responses.
                 d.Equals(nameof(IFile)) ||
                 d.Equals("IFileItemResult") ||

--- a/src/IntelliTect.Coalesce.Swashbuckle/CoalesceSwashbuckleExtensions.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle/CoalesceSwashbuckleExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using IntelliTect.Coalesce.Swashbuckle;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mime;
 using System.Text;
 
 // Intentionally namespaced to IntelliTect.Coalesce.
@@ -17,6 +20,15 @@ namespace IntelliTect.Coalesce
         {
             swaggerGenOptions.OperationFilter<CoalesceApiOperationFilter>();
             swaggerGenOptions.DocumentFilter<CoalesceDocumentFilter>();
+
+            var oldResolver = swaggerGenOptions.SwaggerGeneratorOptions.ConflictingActionsResolver;
+            swaggerGenOptions.SwaggerGeneratorOptions.ConflictingActionsResolver = (actions) =>
+            {
+                var ret = actions.FirstOrDefault(a => a.SupportedRequestFormats.Any(f => f.MediaType == MediaTypeNames.Application.Json))
+                    ?? oldResolver?.Invoke(actions);
+
+                return ret;
+            };
         }
     }
 }

--- a/src/IntelliTect.Coalesce.Swashbuckle/CoalesceSwashbuckleExtensions.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle/CoalesceSwashbuckleExtensions.cs
@@ -20,14 +20,15 @@ namespace IntelliTect.Coalesce
         {
             swaggerGenOptions.OperationFilter<CoalesceApiOperationFilter>();
             swaggerGenOptions.DocumentFilter<CoalesceDocumentFilter>();
+            swaggerGenOptions.SchemaFilter<CoalesceApiSchemaFilter>();
 
             var oldResolver = swaggerGenOptions.SwaggerGeneratorOptions.ConflictingActionsResolver;
             swaggerGenOptions.SwaggerGeneratorOptions.ConflictingActionsResolver = (actions) =>
             {
-                var ret = actions.FirstOrDefault(a => a.SupportedRequestFormats.Any(f => f.MediaType == MediaTypeNames.Application.Json))
+                return actions.FirstOrDefault(a => a.SupportedRequestFormats
+                        .Any(f => f.MediaType == MediaTypeNames.Application.Json)
+                    )
                     ?? oldResolver?.Invoke(actions);
-
-                return ret;
             };
         }
     }

--- a/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
+++ b/src/IntelliTect.Coalesce.Tests/TargetClasses/TestDbContext/ComplexModel.cs
@@ -251,6 +251,16 @@ namespace IntelliTect.Coalesce.Tests.TargetClasses.TestDbContext
 
         [Coalesce, Execute]
         public void MethodWithMultiFileParameter(ICollection<IFile> files) { }
+        [Coalesce, Execute]
+        public void MethodWithMultiFileParameterConcrete(ICollection<File> files) { }
+        [Coalesce, Execute]
+        public void MethodWithMultiFileParameterConcreteParam(ICollection<FileParameter> files) { }
+        [Coalesce, Execute]
+        public void MethodWithMultiFileParameterList(List<IFile> files) { }
+        [Coalesce, Execute]
+        public void MethodWithMultiFileParameterListConcrete(List<File> files) { }
+        [Coalesce, Execute]
+        public void MethodWithMultiFileParameterListConcreteParam(List<FileParameter> files) { }
 
         [Coalesce, Execute]
         public static string[] MethodWithStringArrayParameterAndReturn(string[] strings)

--- a/src/IntelliTect.Coalesce.Tests/Tests/Models/ItemResultTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Models/ItemResultTests.cs
@@ -193,7 +193,7 @@ namespace IntelliTect.Coalesce.Tests.Tests.Models
                 .MethodByName(nameof(ValidationTarget.MethodWithMixedParameters));
             var dto = new
             {
-                email = "x@",
+                Email = "x@",
             };
 
             var result = ItemResult.FromParameterValidation(method, dto);
@@ -213,8 +213,8 @@ namespace IntelliTect.Coalesce.Tests.Tests.Models
                 .MethodByName(nameof(ValidationTarget.MethodWithMixedParameters));
             var dto = new
             {
-                email = "x@x.com",
-                target = new ValidationTargetDtoGen { }
+                Email = "x@x.com",
+                Target = new ValidationTargetDtoGen { }
             };
 
             var result = ItemResult.FromParameterValidation(method, dto);
@@ -234,8 +234,8 @@ namespace IntelliTect.Coalesce.Tests.Tests.Models
                 .MethodByName(nameof(ValidationTarget.MethodWithMixedParameters));
             var dto = new
             {
-                email = "x@x.com",
-                target = new ValidationTargetDtoGen
+                Email = "x@x.com",
+                Target = new ValidationTargetDtoGen
                 {
                     Number = 7,
                     RequiredChild = new()

--- a/src/IntelliTect.Coalesce.Tests/Tests/Models/ItemResultTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Models/ItemResultTests.cs
@@ -213,8 +213,8 @@ namespace IntelliTect.Coalesce.Tests.Tests.Models
                 .MethodByName(nameof(ValidationTarget.MethodWithMixedParameters));
             var dto = new
             {
-                Email = "x@x.com",
-                Target = new ValidationTargetDtoGen { }
+                email = "x@x.com",
+                target = new ValidationTargetDtoGen { }
             };
 
             var result = ItemResult.FromParameterValidation(method, dto);

--- a/src/IntelliTect.Coalesce/Api/Controllers/ControllerHelpers.cs
+++ b/src/IntelliTect.Coalesce/Api/Controllers/ControllerHelpers.cs
@@ -25,6 +25,7 @@ namespace IntelliTect.Coalesce.Api.Controllers
                 return memoryStream.ToArray();
             }
         }
+
         public static async Task<byte[]> ReadAllBytesAsync(this Stream stream, bool closeUnderlying = false)
         {
             if (stream is MemoryStream memoryStream)

--- a/src/IntelliTect.Coalesce/Api/Controllers/ControllerHelpers.cs
+++ b/src/IntelliTect.Coalesce/Api/Controllers/ControllerHelpers.cs
@@ -11,6 +11,20 @@ namespace IntelliTect.Coalesce.Api.Controllers
     public static class ControllerHelpers
 
     {
+        public static byte[] ReadAllBytes(this Stream stream, bool closeUnderlying = false)
+        {
+            if (stream is MemoryStream memoryStream)
+            {
+                return memoryStream.ToArray();
+            }
+
+            using (memoryStream = new MemoryStream())
+            {
+                stream.CopyTo(memoryStream);
+                if (closeUnderlying) stream.Dispose();
+                return memoryStream.ToArray();
+            }
+        }
         public static async Task<byte[]> ReadAllBytesAsync(this Stream stream, bool closeUnderlying = false)
         {
             if (stream is MemoryStream memoryStream)

--- a/src/IntelliTect.Coalesce/Api/OpenApi/CoalesceApiDescriptionProvider.cs
+++ b/src/IntelliTect.Coalesce/Api/OpenApi/CoalesceApiDescriptionProvider.cs
@@ -19,8 +19,7 @@ namespace IntelliTect.Coalesce.Api
     /// since these cause the OpenAPI generator to throw exceptions. We re-add these definitions with
     /// CoalesceApiOperationFilter (for Swashbuckle), or CLASS_TBD for the native aspnetcore OpenApi gen.
     /// </summary>
-    /// <param name="reflectionRepository"></param>
-    public class CoalesceApiDescriptionProvider(ReflectionRepository reflectionRepository) : IApiDescriptionProvider
+    internal class CoalesceApiDescriptionProvider(ReflectionRepository reflectionRepository) : IApiDescriptionProvider
     {
         public int Order => 0;
 

--- a/src/IntelliTect.Coalesce/Api/OpenApi/CoalesceApiDescriptionProvider.cs
+++ b/src/IntelliTect.Coalesce/Api/OpenApi/CoalesceApiDescriptionProvider.cs
@@ -1,0 +1,86 @@
+﻿using IntelliTect.Coalesce.Models;
+using IntelliTect.Coalesce.TypeDefinition;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IntelliTect.Coalesce.Api
+{
+    /// <summary>
+    /// Performs adjustments to the API metadata so that it doesn't cause .NET 9's OpenAPI generation to implode.
+    /// In particular, we have to remove the parameters that are bound with Coalesce's custom model binders,
+    /// since these cause the OpenAPI generator to throw exceptions. We re-add these definitions with
+    /// CoalesceApiOperationFilter (for Swashbuckle), or CLASS_TBD for the native aspnetcore OpenApi gen.
+    /// </summary>
+    /// <param name="reflectionRepository"></param>
+    public class CoalesceApiDescriptionProvider(ReflectionRepository reflectionRepository) : IApiDescriptionProvider
+    {
+        public int Order => 0;
+
+        public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+        {
+        }
+
+        public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+        {
+            foreach (var operation in context.Results)
+            {
+                if (operation.ActionDescriptor is not ControllerActionDescriptor cad) continue;
+
+                var methodInfo = cad.MethodInfo;
+                var cvm = reflectionRepository.GetClassViewModel(methodInfo.DeclaringType!)!;
+                var method = new ReflectionMethodViewModel(cvm, methodInfo);
+
+                ProcessStandardParameters(operation, method);
+            }
+        }
+
+        private void ProcessStandardParameters(ApiDescription operation, MethodViewModel method)
+        {
+            var parameters = operation.ParameterDescriptions;
+
+            // Remove crud strategy parameters, which are bound with a custom model binder
+            // and can't meaningfully be represented by the API explorer.
+            // We add them back in in CoalesceApiOperationFilter.
+            // They break the new Microsoft.AspNetCore.OpenApi package in .NET 9
+            // if we leave them present in the API descriptions.
+
+            foreach (var paramVm in method.Parameters.Where(p =>
+                p.Type.IsA(typeof(IBehaviors<>)) || 
+                p.Type.IsA(typeof(IDataSource<>))
+            ))
+            {
+                parameters.Remove(parameters.Single(p => p.Name == paramVm.Name));
+            }
+
+            foreach (var paramVm in method.Parameters.Where(p => p.Type.IsA<IDataSourceParameters>()))
+            {
+                var paramType = paramVm.Type.ClassViewModel!;
+
+                // Join our ParameterViewModels with the ApiParameterDescription parameters.
+                var paramsUnion = paramType.ClientProperties.Join(
+                    parameters, p => p.Name, p => p.Name, (pvm, nbp) => (PropViewModel: pvm, OperationParam: nbp)
+                );
+
+                foreach (var noSetterProp in paramsUnion.Where(p =>
+                    // Remove params that have no setter. 
+                    // Honestly I'm clueless why this isn't default behavior, but OK.
+                    !p.PropViewModel.HasSetter
+
+                    // Remove the string "DataSource" parameter that is redundant with our data source model binding functionality.
+                    || (p.PropViewModel.Name == nameof(IDataSourceParameters.DataSource) && p.OperationParam.Type == typeof(string))
+                ))
+                {
+                    parameters.Remove(noSetterProp.OperationParam);
+                }
+            }
+        }
+    }
+}

--- a/src/IntelliTect.Coalesce/Application/CoalesceServiceCollectionExtensions.cs
+++ b/src/IntelliTect.Coalesce/Application/CoalesceServiceCollectionExtensions.cs
@@ -78,6 +78,10 @@ namespace IntelliTect.Coalesce
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IApiDescriptionProvider, FromFormNameFixingApiDescriptionProvider>());
 
+            // Make adjustments to the API explorer so that it doesn't cause .NET 9's OpenAPI generation to implode.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Transient<IApiDescriptionProvider, IntelliTect.Coalesce.Api.CoalesceApiDescriptionProvider>());
+
             return services;
         }
 

--- a/src/IntelliTect.Coalesce/Models/File.cs
+++ b/src/IntelliTect.Coalesce/Models/File.cs
@@ -73,7 +73,7 @@ namespace IntelliTect.Coalesce.Models
 
         public static implicit operator File(FileParameter param) => new File
         {
-            Content = (param as IFile).Content,
+            Content = ((IFile)param).Content,
             ContentType = param.ContentType,
             Length = param.Length,
             Name = param.Name,

--- a/src/IntelliTect.Coalesce/Models/File.cs
+++ b/src/IntelliTect.Coalesce/Models/File.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using IntelliTect.Coalesce.Api.Controllers;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -55,6 +56,35 @@ namespace IntelliTect.Coalesce.Models
         /// This can also be forced with the `download` attribute on an `a` HTML element.
         /// </summary>
         public bool ForceDownload { get; set; }
+    }
+
+    public class FileParameter : IFile
+    {
+        public required byte[] Content { get; set; }
+
+        public string? ContentType { get; set; }
+
+        public string? Name { get; set; }
+
+        public long Length => Content.Length;
+
+        bool IFile.ForceDownload => false;
+        Stream? IFile.Content => new MemoryStream(Content);
+
+        public static implicit operator File(FileParameter param) => new File
+        {
+            Content = (param as IFile).Content,
+            ContentType = param.ContentType,
+            Length = param.Length,
+            Name = param.Name,
+        };
+
+        public static implicit operator FileParameter(File param) => new FileParameter
+        {
+            Content = param.Content?.ReadAllBytes() ?? [],
+            ContentType = param.ContentType,
+            Name = param.Name,
+        };
     }
 
 }

--- a/src/IntelliTect.Coalesce/Models/File.cs
+++ b/src/IntelliTect.Coalesce/Models/File.cs
@@ -1,13 +1,6 @@
-﻿using IntelliTect.Coalesce.Api.Controllers;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
+﻿using System;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace IntelliTect.Coalesce.Models
 {
@@ -56,35 +49,6 @@ namespace IntelliTect.Coalesce.Models
         /// This can also be forced with the `download` attribute on an `a` HTML element.
         /// </summary>
         public bool ForceDownload { get; set; }
-    }
-
-    public class FileParameter : IFile
-    {
-        public required byte[] Content { get; set; }
-
-        public string? ContentType { get; set; }
-
-        public string? Name { get; set; }
-
-        public long Length => Content.Length;
-
-        bool IFile.ForceDownload => false;
-        Stream? IFile.Content => new MemoryStream(Content);
-
-        public static implicit operator File(FileParameter param) => new File
-        {
-            Content = ((IFile)param).Content,
-            ContentType = param.ContentType,
-            Length = param.Length,
-            Name = param.Name,
-        };
-
-        public static implicit operator FileParameter(File param) => new FileParameter
-        {
-            Content = param.Content?.ReadAllBytes() ?? [],
-            ContentType = param.ContentType,
-            Name = param.Name,
-        };
     }
 
 }

--- a/src/IntelliTect.Coalesce/Models/FileParameter.cs
+++ b/src/IntelliTect.Coalesce/Models/FileParameter.cs
@@ -1,0 +1,35 @@
+﻿using IntelliTect.Coalesce.Api.Controllers;
+using System.IO;
+
+namespace IntelliTect.Coalesce.Models
+{
+    public class FileParameter : IFile
+    {
+        public required byte[] Content { get; set; }
+
+        public string? ContentType { get; set; }
+
+        public string? Name { get; set; }
+
+        public long Length => Content.Length;
+
+        bool IFile.ForceDownload => false;
+        Stream? IFile.Content => new MemoryStream(Content);
+
+        public static implicit operator File(FileParameter param) => new File
+        {
+            Content = ((IFile)param).Content,
+            ContentType = param.ContentType,
+            Length = param.Length,
+            Name = param.Name,
+        };
+
+        public static implicit operator FileParameter(File param) => new FileParameter
+        {
+            Content = param.Content?.ReadAllBytes() ?? [],
+            ContentType = param.ContentType,
+            Name = param.Name,
+        };
+    }
+
+}

--- a/src/IntelliTect.Coalesce/Models/ItemResult.cs
+++ b/src/IntelliTect.Coalesce/Models/ItemResult.cs
@@ -231,7 +231,7 @@ namespace IntelliTect.Coalesce.Models
             foreach (var param in method.ClientParameters.OfType<ReflectionParameterViewModel>())
             {
                 string propName = param.Name;
-                var value = obj.GetType().GetProperty(param.CsParameterName)?.GetValue(obj);
+                var value = obj.GetType().GetProperty(param.PascalCaseName)?.GetValue(obj);
 
                 var validationContext = new ValidationContext(obj, serviceProvider, null)
                 {

--- a/src/IntelliTect.Coalesce/Models/ItemResult.cs
+++ b/src/IntelliTect.Coalesce/Models/ItemResult.cs
@@ -231,7 +231,12 @@ namespace IntelliTect.Coalesce.Models
             foreach (var param in method.ClientParameters.OfType<ReflectionParameterViewModel>())
             {
                 string propName = param.Name;
-                var value = obj.GetType().GetProperty(param.PascalCaseName)?.GetValue(obj);
+                Type type = obj.GetType();
+
+                // Checking CsParameterName is backwards-compat for when we generated parms object with camelCase names.
+                var propertyInfo = type.GetProperty(param.PascalCaseName) ?? type.GetProperty(param.CsParameterName);
+
+                var value = propertyInfo?.GetValue(obj);
 
                 var validationContext = new ValidationContext(obj, serviceProvider, null)
                 {

--- a/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
@@ -135,7 +135,10 @@ namespace IntelliTect.Coalesce.TypeDefinition
             this.GetAttributeValue<ExecuteAttribute, HttpMethod>(a => a.HttpMethod) ??
             HttpMethod.Post;
 
-        public bool HasHttpRequestBody => ApiActionHttpMethod != HttpMethod.Get && ApiActionHttpMethod != HttpMethod.Delete;
+        public bool HasHttpRequestBody =>
+            ApiActionHttpMethod != HttpMethod.Get &&
+            ApiActionHttpMethod != HttpMethod.Delete &&
+            ApiParameters.Any();
 
         public PropertyViewModel? VaryByProperty =>
             !IsModelInstanceMethod ? null :

--- a/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/MethodViewModel.cs
@@ -136,8 +136,7 @@ namespace IntelliTect.Coalesce.TypeDefinition
             HttpMethod.Post;
 
         public bool HasHttpRequestBody =>
-            ApiActionHttpMethod != HttpMethod.Get &&
-            ApiActionHttpMethod != HttpMethod.Delete &&
+            ApiActionHttpMethod is not HttpMethod.Get and not HttpMethod.Delete &&
             ApiParameters.Any();
 
         public PropertyViewModel? VaryByProperty =>

--- a/src/test-targets/api-clients.g.ts
+++ b/src/test-targets/api-clients.g.ts
@@ -141,6 +141,51 @@ export class ComplexModelApiClient extends ModelApiClient<$models.ComplexModel> 
     return this.$invoke($method, $params, $config)
   }
   
+  public methodWithMultiFileParameterConcrete(id: number | null, files?: File[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<void>> {
+    const $method = this.$metadata.methods.methodWithMultiFileParameterConcrete
+    const $params =  {
+      id,
+      files,
+    }
+    return this.$invoke($method, $params, $config)
+  }
+  
+  public methodWithMultiFileParameterConcreteParam(id: number | null, files?: File[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<void>> {
+    const $method = this.$metadata.methods.methodWithMultiFileParameterConcreteParam
+    const $params =  {
+      id,
+      files,
+    }
+    return this.$invoke($method, $params, $config)
+  }
+  
+  public methodWithMultiFileParameterList(id: number | null, files?: File[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<void>> {
+    const $method = this.$metadata.methods.methodWithMultiFileParameterList
+    const $params =  {
+      id,
+      files,
+    }
+    return this.$invoke($method, $params, $config)
+  }
+  
+  public methodWithMultiFileParameterListConcrete(id: number | null, files?: File[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<void>> {
+    const $method = this.$metadata.methods.methodWithMultiFileParameterListConcrete
+    const $params =  {
+      id,
+      files,
+    }
+    return this.$invoke($method, $params, $config)
+  }
+  
+  public methodWithMultiFileParameterListConcreteParam(id: number | null, files?: File[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<void>> {
+    const $method = this.$metadata.methods.methodWithMultiFileParameterListConcreteParam
+    const $params =  {
+      id,
+      files,
+    }
+    return this.$invoke($method, $params, $config)
+  }
+  
   public methodWithStringArrayParameterAndReturn(strings?: string[] | null, $config?: AxiosRequestConfig): AxiosPromise<ItemResult<string[]>> {
     const $method = this.$metadata.methods.methodWithStringArrayParameterAndReturn
     const $params =  {

--- a/src/test-targets/metadata.g.ts
+++ b/src/test-targets/metadata.g.ts
@@ -1497,6 +1497,186 @@ export const ComplexModel = domain.types.ComplexModel = {
         role: "value",
       },
     },
+    methodWithMultiFileParameterConcrete: {
+      name: "methodWithMultiFileParameterConcrete",
+      displayName: "Method With Multi File Parameter Concrete",
+      transportType: "item",
+      httpMethod: "POST",
+      params: {
+        id: {
+          name: "id",
+          displayName: "Primary Key",
+          type: "number",
+          role: "value",
+          get source() { return (domain.types.ComplexModel as ModelType & { name: "ComplexModel" }).props.complexModelId },
+          rules: {
+            required: val => val != null || "Primary Key is required.",
+          }
+        },
+        files: {
+          name: "files",
+          displayName: "Files",
+          type: "collection",
+          itemType: {
+            name: "$collectionItem",
+            displayName: "",
+            role: "value",
+            type: "file",
+          },
+          role: "value",
+        },
+      },
+      return: {
+        name: "$return",
+        displayName: "Result",
+        type: "void",
+        role: "value",
+      },
+    },
+    methodWithMultiFileParameterConcreteParam: {
+      name: "methodWithMultiFileParameterConcreteParam",
+      displayName: "Method With Multi File Parameter Concrete Param",
+      transportType: "item",
+      httpMethod: "POST",
+      params: {
+        id: {
+          name: "id",
+          displayName: "Primary Key",
+          type: "number",
+          role: "value",
+          get source() { return (domain.types.ComplexModel as ModelType & { name: "ComplexModel" }).props.complexModelId },
+          rules: {
+            required: val => val != null || "Primary Key is required.",
+          }
+        },
+        files: {
+          name: "files",
+          displayName: "Files",
+          type: "collection",
+          itemType: {
+            name: "$collectionItem",
+            displayName: "",
+            role: "value",
+            type: "file",
+          },
+          role: "value",
+        },
+      },
+      return: {
+        name: "$return",
+        displayName: "Result",
+        type: "void",
+        role: "value",
+      },
+    },
+    methodWithMultiFileParameterList: {
+      name: "methodWithMultiFileParameterList",
+      displayName: "Method With Multi File Parameter List",
+      transportType: "item",
+      httpMethod: "POST",
+      params: {
+        id: {
+          name: "id",
+          displayName: "Primary Key",
+          type: "number",
+          role: "value",
+          get source() { return (domain.types.ComplexModel as ModelType & { name: "ComplexModel" }).props.complexModelId },
+          rules: {
+            required: val => val != null || "Primary Key is required.",
+          }
+        },
+        files: {
+          name: "files",
+          displayName: "Files",
+          type: "collection",
+          itemType: {
+            name: "$collectionItem",
+            displayName: "",
+            role: "value",
+            type: "file",
+          },
+          role: "value",
+        },
+      },
+      return: {
+        name: "$return",
+        displayName: "Result",
+        type: "void",
+        role: "value",
+      },
+    },
+    methodWithMultiFileParameterListConcrete: {
+      name: "methodWithMultiFileParameterListConcrete",
+      displayName: "Method With Multi File Parameter List Concrete",
+      transportType: "item",
+      httpMethod: "POST",
+      params: {
+        id: {
+          name: "id",
+          displayName: "Primary Key",
+          type: "number",
+          role: "value",
+          get source() { return (domain.types.ComplexModel as ModelType & { name: "ComplexModel" }).props.complexModelId },
+          rules: {
+            required: val => val != null || "Primary Key is required.",
+          }
+        },
+        files: {
+          name: "files",
+          displayName: "Files",
+          type: "collection",
+          itemType: {
+            name: "$collectionItem",
+            displayName: "",
+            role: "value",
+            type: "file",
+          },
+          role: "value",
+        },
+      },
+      return: {
+        name: "$return",
+        displayName: "Result",
+        type: "void",
+        role: "value",
+      },
+    },
+    methodWithMultiFileParameterListConcreteParam: {
+      name: "methodWithMultiFileParameterListConcreteParam",
+      displayName: "Method With Multi File Parameter List Concrete Param",
+      transportType: "item",
+      httpMethod: "POST",
+      params: {
+        id: {
+          name: "id",
+          displayName: "Primary Key",
+          type: "number",
+          role: "value",
+          get source() { return (domain.types.ComplexModel as ModelType & { name: "ComplexModel" }).props.complexModelId },
+          rules: {
+            required: val => val != null || "Primary Key is required.",
+          }
+        },
+        files: {
+          name: "files",
+          displayName: "Files",
+          type: "collection",
+          itemType: {
+            name: "$collectionItem",
+            displayName: "",
+            role: "value",
+            type: "file",
+          },
+          role: "value",
+        },
+      },
+      return: {
+        name: "$return",
+        displayName: "Result",
+        type: "void",
+        role: "value",
+      },
+    },
     methodWithStringArrayParameterAndReturn: {
       name: "methodWithStringArrayParameterAndReturn",
       displayName: "Method With String Array Parameter And Return",

--- a/src/test-targets/viewmodels.g.ts
+++ b/src/test-targets/viewmodels.g.ts
@@ -362,6 +362,61 @@ export class ComplexModelViewModel extends ViewModel<$models.ComplexModel, $apiC
     return methodWithMultiFileParameter
   }
   
+  public get methodWithMultiFileParameterConcrete() {
+    const methodWithMultiFileParameterConcrete = this.$apiClient.$makeCaller(
+      this.$metadata.methods.methodWithMultiFileParameterConcrete,
+      (c, files?: File[] | null) => c.methodWithMultiFileParameterConcrete(this.$primaryKey, files),
+      () => ({files: null as File[] | null, }),
+      (c, args) => c.methodWithMultiFileParameterConcrete(this.$primaryKey, args.files))
+    
+    Object.defineProperty(this, 'methodWithMultiFileParameterConcrete', {value: methodWithMultiFileParameterConcrete});
+    return methodWithMultiFileParameterConcrete
+  }
+  
+  public get methodWithMultiFileParameterConcreteParam() {
+    const methodWithMultiFileParameterConcreteParam = this.$apiClient.$makeCaller(
+      this.$metadata.methods.methodWithMultiFileParameterConcreteParam,
+      (c, files?: File[] | null) => c.methodWithMultiFileParameterConcreteParam(this.$primaryKey, files),
+      () => ({files: null as File[] | null, }),
+      (c, args) => c.methodWithMultiFileParameterConcreteParam(this.$primaryKey, args.files))
+    
+    Object.defineProperty(this, 'methodWithMultiFileParameterConcreteParam', {value: methodWithMultiFileParameterConcreteParam});
+    return methodWithMultiFileParameterConcreteParam
+  }
+  
+  public get methodWithMultiFileParameterList() {
+    const methodWithMultiFileParameterList = this.$apiClient.$makeCaller(
+      this.$metadata.methods.methodWithMultiFileParameterList,
+      (c, files?: File[] | null) => c.methodWithMultiFileParameterList(this.$primaryKey, files),
+      () => ({files: null as File[] | null, }),
+      (c, args) => c.methodWithMultiFileParameterList(this.$primaryKey, args.files))
+    
+    Object.defineProperty(this, 'methodWithMultiFileParameterList', {value: methodWithMultiFileParameterList});
+    return methodWithMultiFileParameterList
+  }
+  
+  public get methodWithMultiFileParameterListConcrete() {
+    const methodWithMultiFileParameterListConcrete = this.$apiClient.$makeCaller(
+      this.$metadata.methods.methodWithMultiFileParameterListConcrete,
+      (c, files?: File[] | null) => c.methodWithMultiFileParameterListConcrete(this.$primaryKey, files),
+      () => ({files: null as File[] | null, }),
+      (c, args) => c.methodWithMultiFileParameterListConcrete(this.$primaryKey, args.files))
+    
+    Object.defineProperty(this, 'methodWithMultiFileParameterListConcrete', {value: methodWithMultiFileParameterListConcrete});
+    return methodWithMultiFileParameterListConcrete
+  }
+  
+  public get methodWithMultiFileParameterListConcreteParam() {
+    const methodWithMultiFileParameterListConcreteParam = this.$apiClient.$makeCaller(
+      this.$metadata.methods.methodWithMultiFileParameterListConcreteParam,
+      (c, files?: File[] | null) => c.methodWithMultiFileParameterListConcreteParam(this.$primaryKey, files),
+      () => ({files: null as File[] | null, }),
+      (c, args) => c.methodWithMultiFileParameterListConcreteParam(this.$primaryKey, args.files))
+    
+    Object.defineProperty(this, 'methodWithMultiFileParameterListConcreteParam', {value: methodWithMultiFileParameterListConcreteParam});
+    return methodWithMultiFileParameterListConcreteParam
+  }
+  
   public get downloadAttachment() {
     const downloadAttachment = this.$apiClient.$makeCaller(
       this.$metadata.methods.downloadAttachment,


### PR DESCRIPTION
JSON-accepting endpoints are generated for all endpoints that have a body. `coalesce-vue` is not yet updated to consume these endpoints. The existing formdata-accepting endpoints are unchanged.