### PR TITLE
template: Constrain generated TenantId SQL field size

### DIFF
--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Auth/UserInfo.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Auth/UserInfo.cs
@@ -14,6 +14,7 @@ public class UserInfo
     public required ICollection<string> Permissions { get; set; }
 #endif
 #if Tenancy
+    [MaxLength(36)]
     public string? TenantId { get; set; }
     public string? TenantName { get; set; }
 #endif

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/GlobalUsings.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/GlobalUsings.cs
@@ -10,7 +10,7 @@ global using System.Security.Claims;
 global using Coalesce.Starter.Vue.Data.Auth;
 global using Coalesce.Starter.Vue.Data.Coalesce;
 global using Coalesce.Starter.Vue.Data.Utilities;
-#if (Identity || ExampleModel)
+#if (Identity || ExampleModel || TrackingBase)
 global using Coalesce.Starter.Vue.Data.Models;
 #endif
 

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/AuditLog.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/AuditLog.cs
@@ -21,7 +21,7 @@ public class AuditLog : DefaultAuditLog
     // NOTE: Audit logs are *optionally* tenanted because they can log changes
     // to non-tenanted entities as well. Read security is implemented in the below datasource.
 
-    [InternalUse]
+    [InternalUse, MaxLength(36)]
     public string? TenantId { get; set; }
     [InternalUse]
     public Tenant? Tenant { get; set; }

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Role.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Role.cs
@@ -18,6 +18,7 @@ public class Role
 #if Tenancy
     [InternalUse]
     [DefaultOrderBy(FieldOrder = 0)]
+    [MaxLength(36)]
     public string TenantId { get; set; } = null!;
     [InternalUse]
     [ForeignKey(nameof(TenantId))]
@@ -62,6 +63,7 @@ public class RoleClaim : IdentityRoleClaim<string>, ITenanted
 
     [InternalUse]
     [DefaultOrderBy(FieldOrder = 0)]
+    [MaxLength(36)]
     public required string TenantId { get; set; }
     [InternalUse]
     [ForeignKey(nameof(TenantId))]

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/Tenant.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/Tenant.cs
@@ -12,6 +12,7 @@ namespace Coalesce.Starter.Vue.Data.Models;
 [Display(Name = "Organization")]
 public class Tenant
 {
+    [MaxLength(36)]
     public string TenantId { get; set; } = Guid.NewGuid().ToString();
 
     public required string Name { get; set; }

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/TenantMembership.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/TenantMembership.cs
@@ -4,6 +4,7 @@
 [InternalUse]
 public class TenantMembership : TenantedBase
 {
+    [MaxLength(36)]
     public string TenantMembershipId { get; set; } = Guid.NewGuid().ToString();
 
     [Required]

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/TenantedBase.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/Tenancy/TenantedBase.cs
@@ -7,7 +7,7 @@ public abstract class TenantedBase
     : ITenanted
 #endif
 {
-    [InternalUse, Required]
+    [InternalUse, Required, MaxLength(36)]
     public string TenantId { get; set; } = null!;
     [InternalUse]
     public Tenant? Tenant { get; set; }

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/UserRole.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Data/Models/UserRole.cs
@@ -27,6 +27,7 @@ public class UserRole : IdentityUserRole<string>
 #if Tenancy
     [InternalUse]
     [DefaultOrderBy(FieldOrder = 0)]
+    [MaxLength(36)]
     public string TenantId { get; set; } = null!;
     [InternalUse]
     public Tenant? Tenant { get; set; }

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Pages/_Layout.cshtml
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Pages/_Layout.cshtml
@@ -1,6 +1,7 @@
-﻿@*#if (AppInsights)
+@*#if (AppInsights)
 @inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 #endif*@
+@namespace Coalesce.Starter.Vue.Web.Pages
 
 <!DOCTYPE html>
 <html lang="en">

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Program.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging.Console;
 #if OpenAPI
 using Microsoft.OpenApi.Models;
 #endif
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
## Description

Change project templates to generate TenantId field with a sensible size in SQL so ReSharper doesn't lose it's mind.

Fixes other small templating bugs I found when generating projects with just the `--TrackingBase` option and no others

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] All tests passing

