### PR TITLE
fix: concurrency issues in AuditInterceptor, which can sometimes be singleton.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 - `CrudContext.User` now has a public setter, allowing the user principal to be overridden (e.g. for testing or non-HttpContext scenarios).
 - `UseViteDevelopmentServer` now exposes a `PackageManagerCommand` option (defaults to "npm") to configure which package manager runs the dev script. Improved error messages when the configured package manager is not installed.
 - Fix: `no-sort-in-computed` eslint rule false positive when sorting a locally-declared array variable inside `computed()`.
+- Fix: Handle the possibility that Audit logging's `AuditInterceptor` can end up singleton under specific EF usage patterns (e.g. `AddDbContextFactory` + not using `OnConfiguring`).
 
 ## Template Changes
 - Added Vuetify 4 CSS layer ordering to `index.html` to work around Vite 8/Rolldown CSS ordering bugs.
 - Replaced deprecated `typeface-roboto` with `@fontsource/roboto/latin.css` and `@fontsource/roboto/latin-italic.css`.
-- The first-party login flow is now two-stage: enter username first, then choose between password, passkey, or a one-time email code. When `Passkeys` is enabled, users who sign in with password or email code are then prompted to create a passkey.
+- The first-party password/passkey login flow is now two-stage: enter username first, then choose between password, passkey, or a one-time email code. When `Passkeys` is enabled, users who sign in with password or email code are then prompted to create a passkey.
 - `Role.Permissions` are no longer EF-mapped as enums. The EF property is now `List<string>`, with a `[NotMapped]` `PermissionEnums` wrapper that silently drops unrecognized values. This prevents `InvalidOperationException` when a `Permission` enum member is removed but old values remain in the database.
 - Added rate limiting to authentication pages (sign-in, register, forgot password, reset password, email confirmation, external login) to mitigate brute-force abuse.
 

--- a/src/IntelliTect.Coalesce.AuditLogging.Tests/AuditTests.cs
+++ b/src/IntelliTect.Coalesce.AuditLogging.Tests/AuditTests.cs
@@ -212,6 +212,88 @@ public class AuditTests : IDisposable
         );
     }
 
+    [Test]
+    [Repeat(3)]
+    public async Task WithFullApp_ConcurrentSavesAndSingletonInterceptor_DoesNotCorruptAuditState()
+    {
+        // Arrange - use a file-based SQLite DB so concurrent connections work
+        var dbPath = Path.Combine(Path.GetTempPath(), $"audit_test_{Guid.NewGuid():N}.db");
+        var connString = $"Data Source={dbPath}";
+
+        var builder = CreateAppBuilder();
+
+        builder.Services.AddSingleton<IAuditOperationContext<TestAuditLog>, TestOperationContext>();
+
+        // IMPORTANT: This configuration MUST:
+        // - Call UseCoalesceAuditLogging in the service registration, not in OnConfiguring.
+        //   OnConfiguring will produce a new AuditInterceptor on each instance, which mitigates the issue.
+        // - Use AddDbContextFactory so that the DbContextOptions end up registered as a singleton,
+        //   which then results in a singleton AuditInterceptor.
+        builder.Services.AddDbContextFactory<TestDbContext>(options => options
+            .UseSqlite(connString)
+            .UseCoalesceAuditLogging<TestAuditLog>(x => x
+                .WithAugmentation<IAuditOperationContext<TestAuditLog>>()
+            )
+        );
+
+        var app = builder.Build();
+        var factory = app.Services.GetRequiredService<IDbContextFactory<TestDbContext>>();
+
+        using (var db = factory.CreateDbContext()) { db.Database.EnsureCreated(); }
+
+        // Act: Use a barrier to force both tasks to call SaveChangesAsync concurrently,
+        // maximizing the chance of the race between SavingChanges and SavedChanges.
+        const int iterations = 50;
+        int count1 = 0, count2 = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            using var barrier = new Barrier(2);
+
+            var task1 = Task.Run(async () =>
+            {
+                using var db = factory.CreateDbContext();
+                db.Add(new AppUser { Name = $"t1-{i}" });
+                barrier.SignalAndWait();
+                await db.SaveChangesAsync();
+                count1++;
+            });
+
+            var task2 = Task.Run(async () =>
+            {
+                using var db = factory.CreateDbContext();
+                db.Add(new AppUser { Name = $"t2-{i}" });
+                barrier.SignalAndWait();
+                await db.SaveChangesAsync();
+                count2++;
+            });
+
+            await Task.WhenAll(task1, task2);
+        }
+
+        // Assert: All saves produced audit logs with expected values
+        using var verifyDb = factory.CreateDbContext();
+        var logs = verifyDb.AuditLogs.Include(l => l.Properties).Where(l => l.Type == nameof(AppUser)).ToList();
+        await Assert.That(logs.Count).IsEqualTo(iterations * 2);
+
+        var t1Logs = logs.Where(l => l.Description!.StartsWith("t1-")).ToList();
+        var t2Logs = logs.Where(l => l.Description!.StartsWith("t2-")).ToList();
+        await Assert.That(t1Logs.Count).IsEqualTo(iterations);
+        await Assert.That(t2Logs.Count).IsEqualTo(iterations);
+
+        // Every audit log should have the augmented field from TestOperationContext
+        foreach (var log in logs)
+        {
+            await Assert.That(log.CustomField1).IsEqualTo("from TestOperationContext");
+            await Assert.That(log.Properties!.Any(p => p.PropertyName == nameof(AppUser.Name) && p.NewValue == log.Description)).IsTrue();
+        }
+
+        // Cleanup
+        verifyDb.Dispose();
+        await app.DisposeAsync();
+        SqliteConnection.ClearAllPools();
+        File.Delete(dbPath);
+    }
+
 
     [Test]
     [Arguments(PropertyDescriptionMode.None, null)]

--- a/src/IntelliTect.Coalesce.AuditLogging/Internal/AuditInterceptor.cs
+++ b/src/IntelliTect.Coalesce.AuditLogging/Internal/AuditInterceptor.cs
@@ -14,6 +14,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,7 +25,7 @@ internal sealed class AuditInterceptor<TAuditLog> : SaveChangesInterceptor
 {
     private readonly AuditOptions _options;
 
-    private CoalesceAudit? _audit;
+    private static readonly ConditionalWeakTable<DbContext, CoalesceAudit> _audits = [];
 
     private IAuditLogDbContext<TAuditLog> GetContext(DbContextEventData data)
         => (IAuditLogDbContext<TAuditLog>)(data.Context ?? throw new InvalidOperationException("DbContext unavailable."));
@@ -36,15 +37,17 @@ internal sealed class AuditInterceptor<TAuditLog> : SaveChangesInterceptor
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
-        _audit = null;
+        var db = eventData.Context!;
+        _audits.Remove(db);
         if (GetContext(eventData).SuppressAudit) return result;
 
-        _audit = new CoalesceAudit(_options.AuditConfiguration ?? new());
-        _audit.PreSaveChanges(eventData.Context!);
+        var audit = new CoalesceAudit(_options.AuditConfiguration ?? new());
+        _audits.AddOrUpdate(db, audit);
+        audit.PreSaveChanges(db);
 
         if (_options.PropertyDescriptions.HasFlag(PropertyDescriptionMode.FkListText))
         {
-            await _audit.PopulateOldDescriptions(eventData.Context!, true);
+            await audit.PopulateOldDescriptions(db, true);
         }
 
         return result;
@@ -54,16 +57,18 @@ internal sealed class AuditInterceptor<TAuditLog> : SaveChangesInterceptor
         DbContextEventData eventData,
         InterceptionResult<int> result)
     {
-        _audit = null;
+        var db = eventData.Context!;
+        _audits.Remove(db);
         if (GetContext(eventData).SuppressAudit) return result;
 
-        _audit = new CoalesceAudit(_options.AuditConfiguration ?? new());
-        _audit.PreSaveChanges(eventData.Context!);
+        var audit = new CoalesceAudit(_options.AuditConfiguration ?? new());
+        _audits.AddOrUpdate(db, audit);
+        audit.PreSaveChanges(db);
 
         if (_options.PropertyDescriptions.HasFlag(PropertyDescriptionMode.FkListText))
         {
 #pragma warning disable CS4014 // Executes synchronously when async: false
-            _audit.PopulateOldDescriptions(eventData.Context!, async: false);
+            audit.PopulateOldDescriptions(db, async: false);
 #pragma warning restore CS4014
         }
 
@@ -75,10 +80,10 @@ internal sealed class AuditInterceptor<TAuditLog> : SaveChangesInterceptor
     #region SavedChanges
     public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
     {
-        if (_audit is null) return result;
+        if (!_audits.TryGetValue(eventData.Context!, out var audit)) return result;
 
 #pragma warning disable CS4014 // Executes synchronously when async: false
-        SaveAudit(eventData.Context!, _audit, async: false);
+        SaveAudit(eventData.Context!, audit, async: false);
 #pragma warning restore CS4014
 
         return result;
@@ -89,9 +94,9 @@ internal sealed class AuditInterceptor<TAuditLog> : SaveChangesInterceptor
         int result,
         CancellationToken cancellationToken = default)
     {
-        if (_audit is null) return result;
+        if (!_audits.TryGetValue(eventData.Context!, out var audit)) return result;
 
-        await SaveAudit(eventData.Context!, _audit, async: true);
+        await SaveAudit(eventData.Context!, audit, async: true);
 
         return result;
     }


### PR DESCRIPTION
## Problem

`AuditInterceptor<TAuditLog>` stored its in-flight `CoalesceAudit` state in a plain instance field (`_audit`). When the interceptor is a singleton (which happens when `UseCoalesceAuditLogging` is called in `AddDbContextFactory` or similar singleton-options registration), concurrent `SaveChangesAsync` calls on different DbContext instances race on this field. One thread can overwrite or null out the other's audit state, causing:

- `InvalidOperationException`: HashSet/List corruption ("Collection was modified during enumeration", "concurrent operations not supported")
- `NullReferenceException`: one thread nulls `_audit` while another is between `SavingChanges` and `SavedChanges`
- Silent audit log loss: ~50% of audit records dropped because both threads end up writing from the same `CoalesceAudit` instance

## Fix

Replaced the instance field with a `static ConditionalWeakTable<DbContext, CoalesceAudit>`, keyed by DbContext instance. Each concurrent save gets its own isolated audit state, and entries are automatically cleaned up when the DbContext is GC'd.

## Test

Added `WithFullApp_ConcurrentSavesAndSingletonInterceptor_DoesNotCorruptAuditState` which uses a `Barrier` to force two tasks to call `SaveChangesAsync` simultaneously across 50 iterations (repeated 3x). Verifies exact audit log counts per thread and correct property values. Confirmed the test fails reliably (4/4) without the fix and passes (4/4) with it.