### PR TITLE
docs: dynamic .NET and Node versions in environment setup

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,13 @@ import path from "path";
 import fs from "fs";
 import url from "url";
 import matter from "gray-matter";
+import templateGlobalJson from "../../templates/Coalesce.Vue.Template/content/global.json";
+import templatePackageJson from "../../templates/Coalesce.Vue.Template/content/package.json";
+
+const dotnetMajorVersion = templateGlobalJson.sdk.version.split(".")[0];
+const nodeMajorVersion = (templatePackageJson.engines as any).node.match(
+  /\d+/,
+)[0];
 
 function autoTitle(link: string) {
   const fullPath = path.join(
@@ -61,11 +68,14 @@ export default defineConfig({
   description: "Documentation for Coalesce by IntelliTect",
   head: [["link", { rel: "shortcut icon", href: "/favicon.ico" }]],
 
+  transformPageData(pageData) {
+    pageData.frontmatter.dotnetVersion ??= dotnetMajorVersion;
+    pageData.frontmatter.nodeVersion ??= nodeMajorVersion;
+  },
+
   transformHtml(html) {
-    return html.replaceAll(
-      "COALESCE_VERSION",
-      process.env.COALESCE_VERSION || "x.y.z",
-    );
+    return html
+      .replaceAll("COALESCE_VERSION", process.env.COALESCE_VERSION || "x.y.z");
   },
 
   markdown: {

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "frontmatter",
     "Airtable",
     "appsettings",
     "ASPNETCORE",
@@ -73,3 +74,4 @@
     }
   ]
 }
+

--- a/docs/stacks/vue/getting-started.md
+++ b/docs/stacks/vue/getting-started.md
@@ -6,8 +6,8 @@ This guide walks you through creating a new Coalesce project, launching it, and 
 
 Before you begin, ensure that you have all the required tools installed:
 
-- Recent version of the [.NET SDK](https://dotnet.microsoft.com/en-us/download).
-- A recent version of [Node.js](https://nodejs.org/) (an LTS version is recommended).
+- [.NET {{ $frontmatter.dotnetVersion }} SDK](https://dotnet.microsoft.com/en-us/download) or newer.
+- [Node.js {{ $frontmatter.nodeVersion }}](https://nodejs.org/) or newer (an LTS version is recommended).
 - [pnpm](https://pnpm.io/) - install with `npm install -g pnpm`
 - An IDE: [VS Code](https://code.visualstudio.com/) with the [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extension is recommended. [JetBrains Rider](https://www.jetbrains.com/rider/) also works.
 

--- a/docs/stacks/vue/getting-started.md
+++ b/docs/stacks/vue/getting-started.md
@@ -6,8 +6,8 @@ This guide walks you through creating a new Coalesce project, launching it, and 
 
 Before you begin, ensure that you have all the required tools installed:
 
-- [.NET {{ $frontmatter.dotnetVersion }} SDK](https://dotnet.microsoft.com/en-us/download) or newer.
-- [Node.js {{ $frontmatter.nodeVersion }}](https://nodejs.org/) or newer (an LTS version is recommended).
+- [.NET {{ $frontmatter.dotnetVersion }} SDK](https://dotnet.microsoft.com/en-us/download).
+- [Node.js {{ $frontmatter.nodeVersion }}](https://nodejs.org/), or newer LTS.
 - [pnpm](https://pnpm.io/) - install with `npm install -g pnpm`
 - An IDE: [VS Code](https://code.visualstudio.com/) with the [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extension is recommended. [JetBrains Rider](https://www.jetbrains.com/rider/) also works.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "pnpm -r run lint",
     "lint:fix": "pnpm -r run lint:fix",
     "coalesce": "pnpm -C playground/Coalesce.Web.Vue3 coalesce",
-    "docs": "pnpm -C docs dev",
+    "doc": "pnpm -C docs dev",
     "play": "dotnet run --project playground/Coalesce.Web.Vue3",
     "template": "pwsh templates/Coalesce.Vue.Template/TestLocal.ps1",
     "test": "pnpm -r --filter=./src/* run test run"

--- a/templates/Coalesce.Vue.Template/content/package.json
+++ b/templates/Coalesce.Vue.Template/content/package.json
@@ -2,6 +2,9 @@
   "name": "coalesce-starter-vue",
   "private": true,
   "packageManager": "pnpm@11.0.8",
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "eslint": "^10.3.0"
   }


### PR DESCRIPTION
## Summary

The "Environment Setup" section in the Getting Started docs previously had generic "recent version" language. This PR makes the .NET and Node.js version requirements dynamic, sourced directly from the template files.

## Changes

- **`templates/.../content/package.json`** — Added `"engines": { "node": ">=22" }` as the source of truth for the minimum Node version
- **`docs/.vitepress/config.mts`** — Import `global.json` and `package.json` from the template; inject `.NET` major version and Node minimum version into every page's frontmatter via `transformPageData` (works in both dev and build)
- **`docs/stacks/vue/getting-started.md`** — Use `{{ $frontmatter.dotnetVersion }}` and `{{ $frontmatter.nodeVersion }}` in the environment setup bullet points
- **`package.json`** — Rename root `docs` script to `doc` to avoid conflict with the pnpm built-in `docs` subcommand