### PR TITLE
fix: c-input using numeric values instead of strings for string-serialized enums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
   "chat.tools.terminal.autoApprove": {
     "npx vitest": true
   },
-  "cSpell.words": ["nodenext", "rolldown"]
+  "cSpell.words": ["nodenext", "rolldown"],
+  "aspire.enableSettingsFileCreationPromptOnStartup": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Broad improvements to accessibility issues identified by axe-core across all components.
 - `vue`, `date-fns`, and `date-fns-tz` are now peer dependencies instead of direct dependencies of `coalesce-vue` and `coalesce-vue-vuetify3`.
 - Fix self-referential foreign key infinite recursion in code generation.
+- Fix `c-input` not correctly matching the selected item in `v-select` for string-serialized enums (enums with `format: "string"`). The component now uses `strValue` instead of `value` as the `item-value` key when the enum has string format.
 - Fix Vuetify 4 issues:
   - Margin issue in `c-admin-audit-log-page` `pre` elements
   - Color issue in `c-time-picker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Broad improvements to accessibility issues identified by axe-core across all components.
 - `vue`, `date-fns`, and `date-fns-tz` are now peer dependencies instead of direct dependencies of `coalesce-vue` and `coalesce-vue-vuetify3`.
 - Fix self-referential foreign key infinite recursion in code generation.
-- Fix `c-input` not correctly matching the selected item in `v-select` for string-serialized enums (enums with `format: "string"`). The component now uses `strValue` instead of `value` as the `item-value` key when the enum has string format.
+- Fix `c-input` failing to match selected items for string-serialized enums (`[JsonStringEnumConverter]`), causing broken display and item slot props.
 - Fix Vuetify 4 issues:
   - Margin issue in `c-admin-audit-log-page` `pre` elements
   - Color issue in `c-time-picker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
+# 6.5.2
+- Fix `c-input` failing to match selected items for string-serialized enums (`[JsonStringEnumConverter]`), causing broken display and item slot props.
+
 # 6.5.1
 - Broad improvements to accessibility issues identified by axe-core across all components.
 - `vue`, `date-fns`, and `date-fns-tz` are now peer dependencies instead of direct dependencies of `coalesce-vue` and `coalesce-vue-vuetify3`.
 - Fix self-referential foreign key infinite recursion in code generation.
-- Fix `c-input` failing to match selected items for string-serialized enums (`[JsonStringEnumConverter]`), causing broken display and item slot props.
 - Fix Vuetify 4 issues:
   - Margin issue in `c-admin-audit-log-page` `pre` elements
   - Color issue in `c-time-picker`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 6.5.2
-- Fix `c-input` failing to match selected items for string-serialized enums (`[JsonStringEnumConverter]`), causing broken display and item slot props.
+- Fix `c-input` using numeric enum values instead of string values for string-serialized enums (`[JsonStringEnumConverter]`), causing the selected item to not be found in the dropdown.
 
 # 6.5.1
 - Broad improvements to accessibility issues identified by axe-core across all components.

--- a/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.tsx
@@ -21,6 +21,7 @@ import {
   ComplexModelViewModel,
 } from "@test-targets/viewmodels.g";
 import { Model } from "coalesce-vue";
+import { h } from "vue";
 import { VueWrapper } from "@vue/test-utils";
 
 describe("CInput", () => {
@@ -258,7 +259,7 @@ describe("CInput", () => {
     });
     const wrapper = mount(() => <CInput model={model} for="stringEnum" />);
 
-    // Assert resting state shows the display name
+    // Assert resting state shows the display name (not the raw strValue "SecondValue")
     expect(wrapper.text()).contains("Second Value");
 
     // Open the dropdown and select the first item (First Value)
@@ -268,6 +269,39 @@ describe("CInput", () => {
     // The model should be set to the string strValue, not a number
     expect(model.stringEnum).toBe(StringSerializedEnum.FirstValue);
     expect(wrapper.text()).contains("First Value");
+  });
+
+  test("enum - string format - item slot receives full EnumMember", async () => {
+    const model = new ComplexModelViewModel({
+      stringEnum: StringSerializedEnum.SecondValue,
+    });
+
+    // Capture items provided to the item slot
+    const slotItems: any[] = [];
+    const wrapper = mount(() => (
+      <CInput model={model} for="stringEnum">
+        {{
+          item: (slotProps: any) => {
+            slotItems.push(slotProps);
+            return h(VListItem, slotProps.props);
+          },
+        }}
+      </CInput>
+    ));
+
+    // Open the dropdown to populate the item slot
+    await wrapper.find(".v-field").trigger("mousedown");
+
+    // Verify item slot received full EnumMember objects (not synthetic string items)
+    expect(slotItems.length).toBeGreaterThan(0);
+    const rawItem = slotItems[0].item.raw;
+    // raw should be the full EnumMember object, not just a string
+    expect(typeof rawItem).toBe("object");
+    expect(rawItem).toHaveProperty("displayName");
+    expect(rawItem).toHaveProperty("strValue");
+    expect(rawItem).toHaveProperty("value");
+    expect(rawItem.displayName).toBe("First Value");
+    expect(rawItem.strValue).toBe("FirstValue");
   });
 
   test("caller model - date value", async () => {

--- a/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.tsx
@@ -13,6 +13,7 @@ import {
   CaseProduct,
   ComplexModel,
   Statuses,
+  StringSerializedEnum,
   Test,
 } from "@test-targets/models.g";
 import {
@@ -249,6 +250,24 @@ describe("CInput", () => {
     ]);
     expect(wrapper.text()).contains("In Progress");
     expect(wrapper.text()).contains("Cancelled");
+  });
+
+  test("enum - string format", async () => {
+    const model = new ComplexModelViewModel({
+      stringEnum: StringSerializedEnum.SecondValue,
+    });
+    const wrapper = mount(() => <CInput model={model} for="stringEnum" />);
+
+    // Assert resting state shows the display name
+    expect(wrapper.text()).contains("Second Value");
+
+    // Open the dropdown and select the first item (First Value)
+    await wrapper.find(".v-field").trigger("mousedown");
+    await wrapper.findAllComponents(VListItem)[0].trigger("click");
+
+    // The model should be set to the string strValue, not a number
+    expect(model.stringEnum).toBe(StringSerializedEnum.FirstValue);
+    expect(wrapper.text()).contains("First Value");
   });
 
   test("caller model - date value", async () => {

--- a/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-input.spec.vue
@@ -15,6 +15,30 @@
       }}</span>
     </template>
   </c-input>
+
+  <!-- Test that item slot is typed correctly for string-format enums -->
+  <c-input :model="vm" for="stringEnum" hide-details="auto">
+    <template #item="slotProps">
+      <span>{{
+        (() => {
+          //@ts-expect-error item.raw is enum metadata, cast to string should be invalid
+          slotProps.item.raw as string;
+
+          return slotProps.item.raw.displayName as string;
+        })()
+      }}</span>
+    </template>
+    <template #selection="slotProps">
+      <span>{{
+        (() => {
+          //@ts-expect-error item.raw is enum metadata, cast to string should be invalid
+          slotProps.item.raw as string;
+
+          return slotProps.item.raw.strValue as string;
+        })()
+      }}</span>
+    </template>
+  </c-input>
 </template>
 
 <script setup lang="ts">

--- a/src/coalesce-vue-vuetify3/src/components/input/c-input.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-input.vue
@@ -461,7 +461,9 @@ function render() {
       }
       data.items = items;
       data["item-title"] = "displayName" satisfies keyof EnumMember;
-      data["item-value"] = "value" satisfies keyof EnumMember;
+      data["item-value"] = (
+        valueMeta.typeDef.format === "string" ? "strValue" : "value"
+      ) satisfies keyof EnumMember;
       // maps to the prop "subtitle" on v-list-item
       data["item-props"] = (item: EnumMember) => ({
         subtitle: item.description,
@@ -503,7 +505,9 @@ function render() {
         data["chips"] = true;
         data["closable-chips"] = true;
         data["item-title"] = "displayName";
-        data["item-value"] = "value";
+        data["item-value"] = (
+          valueMeta.itemType.typeDef.format === "string" ? "strValue" : "value"
+        ) satisfies keyof EnumMember;
         // maps to the prop "subtitle" on v-list-item
         data["item-props"] = (item: any) => ({ subtitle: item.description });
 


### PR DESCRIPTION
When an enum uses `[JsonConverter(typeof(JsonStringEnumConverter))]`, its values are stored and transmitted as strings (e.g. `"Resolved"`). However, `c-input` was always setting `item-value="value"` (the numeric field) on the underlying `VSelect`/`VAutocomplete`. This caused a mismatch: VSelect couldn't find a matching item for the string model value, so it created a synthetic item from the raw string -- meaning `item.raw` was just `"Resolved"` instead of the full `EnumMember` object, breaking display and item slot props.

The fix uses `"strValue"` as the `item-value` key when the enum's `typeDef.format === "string"`, both for single-value enum selects and collection enum autocompletes.