### PR TITLE
fix: suppress vite URL announcement lines from stdout

### DIFF
--- a/src/IntelliTect.Coalesce.Vue/DevMiddleware/EventedStreamReader.cs
+++ b/src/IntelliTect.Coalesce.Vue/DevMiddleware/EventedStreamReader.cs
@@ -82,7 +82,7 @@ internal class EventedStreamReader
 
     internal static readonly Regex AnsiColorRegex = new Regex("\x001b\\[[0-9;]*m", RegexOptions.None, TimeSpan.FromSeconds(1));
 
-    private static string StripAnsiColors(string line)
+    internal static string StripAnsiColors(string line)
         => AnsiColorRegex.Replace(line, string.Empty);
 
     private async Task Run()

--- a/src/IntelliTect.Coalesce.Vue/DevMiddleware/NodeScriptRunner.cs
+++ b/src/IntelliTect.Coalesce.Vue/DevMiddleware/NodeScriptRunner.cs
@@ -88,6 +88,15 @@ internal class NodeScriptRunner : IDisposable
         };
     }
 
+    // Matches vite's URL announcement lines (e.g. "➜  Local:   https://..." and "➜  Network: https://...")
+    // that refer to the internal vite HMR server port, not the actual application URL.
+    // These are confusing to users and can cause tools that auto-launch browsers to open the wrong URL.
+    private static readonly System.Text.RegularExpressions.Regex ViteUrlAnnouncementRegex = new(
+        @"➜\s+(Local|Network):\s+https?://",
+        System.Text.RegularExpressions.RegexOptions.None,
+        TimeSpan.FromSeconds(1)
+    );
+
     public void AttachToLogger(ILogger logger)
     {
         // When the node task emits complete lines, pass them through to the real logger.
@@ -99,6 +108,9 @@ internal class NodeScriptRunner : IDisposable
 
         StdOut.OnReceivedLine += line =>
         {
+            // Suppress vite's URL announcement lines - they point to the internal HMR port,
+            // not the application URL, which confuses users and browser-launching tools.
+            if (ViteUrlAnnouncementRegex.IsMatch(EventedStreamReader.StripAnsiColors(line))) return;
             Console.Write("\u001b[32mvite\u001b[0m: " + line);
         };
 

--- a/src/coalesce-vue-vuetify3/vite.config.ts
+++ b/src/coalesce-vue-vuetify3/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    testTimeout: 30000,
     include: ["**/*.spec.{ts,tsx}"],
     setupFiles: ["./test/setup.ts"],
     server: {


### PR DESCRIPTION
After the vite dev server starts, it prints a block of Local/Network URL lines pointing to its internal HMR port. These URLs are not the application URL, so they confuse developers and -- more importantly -- cause tools that scan stdout for URLs to auto-launch a browser pointed at the wrong address.

This change filters those lines out before they are written to the console. Lines matching `➜  Local:` or `➜  Network:` followed by an HTTP/S URL are silently dropped; all other vite output continues to pass through unchanged.

**Changes:**
- `NodeScriptRunner.cs`: added `ViteUrlAnnouncementRegex` and skips matching lines in the `StdOut.OnReceivedLine` handler (after stripping ANSI color codes, consistent with how `WaitForMatch` processes lines).
- `EventedStreamReader.cs`: widened `StripAnsiColors` from `private` to `internal` so `NodeScriptRunner` can reuse it for the filter check.