### PR TITLE
test: increase axe-core test timeout to 30s

### DIFF
--- a/src/coalesce-vue-vuetify3/vite.config.ts
+++ b/src/coalesce-vue-vuetify3/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    testTimeout: 30000,
     include: ["**/*.spec.{ts,tsx}"],
     setupFiles: ["./test/setup.ts"],
     server: {


### PR DESCRIPTION
The axe-core tests in `coalesce-vue-vuetify3` occasionally time out in CI at the default 5s limit. Setting `testTimeout: 30000` in the Vitest config gives them enough headroom to complete reliably.