### PR TITLE
feat: DataSourceFactory walks base type hierarchy for data source resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 6.6.0
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
+- `DataSourceFactory` now walks the base type hierarchy when resolving a named or default data source, enabling inheritance scenarios where a derived type can use data sources declared on its base types.
 
 # 6.5.2
 - Fix `c-input` using numeric enum values instead of string values for string-serialized enums (`[JsonStringEnumConverter]`), causing the selected item to not be found in the dropdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.6.0
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
-- `DataSourceFactory` now walks the base type hierarchy when resolving a named or default data source, enabling inheritance scenarios where a derived type can use data sources declared on its base types.
+- `DataSourceFactory` now walks the base type hierarchy when resolving a named or default data source, enabling inheritance scenarios where a derived type can use data sources declared on its base types. An adapter automatically wraps the resolved data source so that it properly serves the derived type.
 
 # 6.5.2
 - Fix `c-input` using numeric enum values instead of string values for string-serialized enums (`[JsonStringEnumConverter]`), causing the selected item to not be found in the dropdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.6.0
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
-- `DataSourceFactory` now walks the base type hierarchy when resolving a named or default data source, enabling inheritance scenarios where a derived type can use data sources declared on its base types. An adapter automatically wraps the resolved data source so that it properly serves the derived type.
+- `DataSourceFactory` now walks the base type hierarchy when resolving a named, allowing for the loading of single instances of derived types from their base type's data source. This does not support list operations, which should still always target data sources declared directly on the type being listed.
 
 # 6.5.2
 - Fix `c-input` using numeric enum values instead of string values for string-serialized enums (`[JsonStringEnumConverter]`), causing the selected item to not be found in the dropdown.

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
@@ -1,19 +1,28 @@
 using IntelliTect.Coalesce.Api;
 using IntelliTect.Coalesce.Api.DataSources;
 using IntelliTect.Coalesce.DataAnnotations;
+using IntelliTect.Coalesce.Mapping;
+using IntelliTect.Coalesce.Models;
 using IntelliTect.Coalesce.Testing.TargetClasses.TestDbContext;
 using IntelliTect.Coalesce.TypeDefinition;
 using Microsoft.Extensions.DependencyInjection;
+
+#nullable enable
 
 namespace IntelliTect.Coalesce.Tests.Api.DataSources;
 
 public class DataSourceFactoryTests
 {
-    private (DataSourceFactory Factory, ReflectionRepository Repo) BuildFactory()
+    private (DataSourceFactory Factory, ReflectionRepository Repo) BuildFactory(System.Security.Claims.ClaimsPrincipal? user = null)
     {
+        var testUser = user ?? new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity("test"));
+
         var services = new ServiceCollection();
         services.AddDbContext<AppDbContext>();
         services.AddCoalesce(b => b.AddContext<AppDbContext>());
+        // Override CrudContext with a test-friendly registration (no IHttpContextAccessor needed)
+        services.AddScoped(_ => new CrudContext(() => testUser));
         var sp = services.BuildServiceProvider();
 
         var rr = new ReflectionRepository();
@@ -29,27 +38,35 @@ public class DataSourceFactoryTests
     public class StandaloneBase
     {
         public int Id { get; set; }
+        public string? Name { get; set; }
 
         [DefaultDataSource]
         public class DefaultSource : StandardDataSource<StandaloneBase>
         {
             public DefaultSource(CrudContext ctx) : base(ctx) { }
             public override Task<IQueryable<StandaloneBase>> GetQueryAsync(IDataSourceParameters parameters)
-                => Task.FromResult(Array.Empty<StandaloneBase>().AsQueryable());
+                => Task.FromResult(TestData.AsQueryable());
         }
 
         public class NamedSource : StandardDataSource<StandaloneBase>
         {
             public NamedSource(CrudContext ctx) : base(ctx) { }
             public override Task<IQueryable<StandaloneBase>> GetQueryAsync(IDataSourceParameters parameters)
-                => Task.FromResult(Array.Empty<StandaloneBase>().AsQueryable());
+                => Task.FromResult(TestData.AsQueryable());
         }
+
+        public static IEnumerable<StandaloneBase> TestData =>
+        [
+            new StandaloneDerived { Id = 1, Name = "Derived1", DerivedProp = "D1" },
+            new StandaloneDerived { Id = 2, Name = "Derived2", DerivedProp = "D2" },
+            new StandaloneBase { Id = 3, Name = "Base3" },
+        ];
     }
 
     [Coalesce, StandaloneEntity]
     public class StandaloneDerived : StandaloneBase
     {
-        // No own data sources - should inherit from StandaloneBase
+        public string? DerivedProp { get; set; }
     }
 
     [Coalesce, StandaloneEntity]
@@ -75,7 +92,61 @@ public class DataSourceFactoryTests
         }
     }
 
+    public class StandaloneBaseDto : IResponseDto<StandaloneBase>
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+
+        public void MapFrom(StandaloneBase obj, IMappingContext context, IncludeTree? tree = null)
+        {
+            if (obj == null) return;
+            switch (this)
+            {
+                case StandaloneDerivedDto derived:
+                    derived.MapFrom((StandaloneDerived)obj, context, tree);
+                    return;
+            }
+            Id = obj.Id;
+            Name = obj.Name;
+        }
+    }
+
+    public class StandaloneDerivedDto : StandaloneBaseDto, IResponseDto<StandaloneDerived>
+    {
+        public string? DerivedProp { get; set; }
+
+        public void MapFrom(StandaloneDerived obj, IMappingContext context, IncludeTree? tree = null)
+        {
+            Id = obj.Id;
+            Name = obj.Name;
+            DerivedProp = obj.DerivedProp;
+        }
+    }
+
+    [Coalesce, StandaloneEntity]
+    [Read("Admin")]
+    public class SecuredBase
+    {
+        public int Id { get; set; }
+
+        [DefaultDataSource]
+        public class SecuredBaseSource : StandardDataSource<SecuredBase>
+        {
+            public SecuredBaseSource(CrudContext ctx) : base(ctx) { }
+            public override Task<IQueryable<SecuredBase>> GetQueryAsync(IDataSourceParameters parameters)
+                => Task.FromResult(new SecuredBase[] { new SecuredDerived { Id = 1 } }.AsQueryable());
+        }
+    }
+
+    [Coalesce, StandaloneEntity]
+    public class SecuredDerived : SecuredBase
+    {
+        // No own data sources - inherits from SecuredBase which requires "Admin" role
+    }
+
     #endregion
+
+    #region Type Resolution Tests
 
     [Test]
     public async Task GetDefaultDataSourceType_DerivedTypeWithNoSources_UsesBaseDefaultSource()
@@ -136,9 +207,163 @@ public class DataSourceFactoryTests
         var servedType = rr.GetClassViewModel<StandaloneDerivedWithOwnNamed>()!;
         var declaredFor = rr.GetClassViewModel<StandaloneDerivedWithOwnNamed>()!;
 
-        // NamedSource is on the base type; should still be found for derived type
         var type = factory.GetDataSourceType(servedType, declaredFor, nameof(StandaloneBase.NamedSource));
 
         await Assert.That(type).IsEqualTo(typeof(StandaloneBase.NamedSource));
     }
+
+    #endregion
+
+    #region Adapter Wrapping Tests
+
+    [Test]
+    public async Task GetDataSource_DerivedType_ReturnsAdaptedDataSource()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+
+        await Assert.That(dataSource).IsNotNull();
+        await Assert.That(dataSource).IsTypeOf<InheritedDataSourceAdapter<StandaloneDerived, StandaloneBase>>();
+    }
+
+    [Test]
+    public async Task GetDataSource_DerivedTypeWithOwnSource_DoesNotWrap()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerivedWithOwnDefault>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerivedWithOwnDefault>(declaredFor, null);
+
+        await Assert.That(dataSource).IsTypeOf<StandaloneDerivedWithOwnDefault.DerivedDefaultSource>();
+    }
+
+    #endregion
+
+    #region Adapter GetItemAsync Tests
+
+    [Test]
+    public async Task GetItemAsync_AdaptedSource_ReturnsDerivedItem()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
+
+        await Assert.That(result.WasSuccessful).IsTrue();
+        await Assert.That(result.Object).IsNotNull();
+        await Assert.That(result.Object!.Id).IsEqualTo(1);
+        await Assert.That(result.Object).IsTypeOf<StandaloneDerived>();
+        await Assert.That(((StandaloneDerived)result.Object!).DerivedProp).IsEqualTo("D1");
+    }
+
+    [Test]
+    public async Task GetItemAsync_AdaptedSource_BaseOnlyItemReturnsFailure()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        // Id 3 is a StandaloneBase (not StandaloneDerived)
+        var result = await dataSource.GetItemAsync(3, new DataSourceParameters());
+
+        await Assert.That(result.WasSuccessful).IsFalse();
+        await Assert.That(result.Message).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetMappedItemAsync_AdaptedSource_MapsDerivedItem()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var result = await dataSource.GetMappedItemAsync<StandaloneDerivedDto>(1, new DataSourceParameters());
+
+        await Assert.That(result.WasSuccessful).IsTrue();
+        await Assert.That(result.Object).IsNotNull();
+        await Assert.That(result.Object!.Id).IsEqualTo(1);
+        await Assert.That(result.Object!.Name).IsEqualTo("Derived1");
+        await Assert.That(result.Object!.DerivedProp).IsEqualTo("D1");
+    }
+
+    #endregion
+
+    #region Adapter List/Count Operations Throw
+
+    [Test]
+    public async Task GetListAsync_AdaptedSource_ThrowsNotSupported()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+
+        await Assert.That(() => dataSource.GetListAsync(new ListParameters()))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task GetMappedListAsync_AdaptedSource_ThrowsNotSupported()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+
+        await Assert.That(() => dataSource.GetMappedListAsync<StandaloneDerivedDto>(new ListParameters()))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task GetCountAsync_AdaptedSource_ThrowsNotSupported()
+    {
+        var (factory, rr) = BuildFactory();
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+
+        await Assert.That(() => dataSource.GetCountAsync(new FilterParameters()))
+            .Throws<NotSupportedException>();
+    }
+
+    #endregion
+
+    #region Adapter Security Tests
+
+    [Test]
+    public async Task GetItemAsync_AdaptedSource_UserWithBaseTypeRole_Succeeds()
+    {
+        var user = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity(
+                [new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.Role, "Admin")],
+                "test"));
+        var (factory, rr) = BuildFactory(user);
+        var declaredFor = rr.GetClassViewModel<SecuredDerived>()!;
+
+        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, null);
+        var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
+
+        await Assert.That(result.WasSuccessful).IsTrue();
+    }
+
+    [Test]
+    public async Task GetItemAsync_AdaptedSource_UserWithoutBaseTypeRole_Denied()
+    {
+        // User is authenticated but does NOT have "Admin" role
+        var user = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity("test"));
+        var (factory, rr) = BuildFactory(user);
+        var declaredFor = rr.GetClassViewModel<SecuredDerived>()!;
+
+        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, null);
+        var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
+
+        await Assert.That(result.WasSuccessful).IsFalse();
+        await Assert.That(result.Message).Contains("not authorized");
+    }
+
+    #endregion
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
@@ -129,7 +129,6 @@ public class DataSourceFactoryTests
     {
         public int Id { get; set; }
 
-        [DefaultDataSource]
         public class SecuredBaseSource : StandardDataSource<SecuredBase>
         {
             public SecuredBaseSource(CrudContext ctx) : base(ctx) { }
@@ -149,16 +148,15 @@ public class DataSourceFactoryTests
     #region Type Resolution Tests
 
     [Test]
-    public async Task GetDefaultDataSourceType_DerivedTypeWithNoSources_UsesBaseDefaultSource()
+    public async Task GetDefaultDataSourceType_DerivedTypeWithNoSources_Throws()
     {
         var (factory, rr) = BuildFactory();
 
         var servedType = rr.GetClassViewModel<StandaloneDerived>()!;
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var type = factory.GetDataSourceType(servedType, declaredFor, null);
-
-        await Assert.That(type).IsEqualTo(typeof(StandaloneBase.DefaultSource));
+        await Assert.That(() => factory.GetDataSourceType(servedType, declaredFor, null))
+            .Throws<ArgumentException>();
     }
 
     [Test]
@@ -222,7 +220,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
 
         await Assert.That(dataSource).IsNotNull();
         await Assert.That(dataSource).IsTypeOf<InheritedDataSourceAdapter<StandaloneDerived, StandaloneBase>>();
@@ -249,7 +247,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
         var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
 
         await Assert.That(result.WasSuccessful).IsTrue();
@@ -265,7 +263,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
         // Id 3 is a StandaloneBase (not StandaloneDerived)
         var result = await dataSource.GetItemAsync(3, new DataSourceParameters());
 
@@ -279,7 +277,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
         var result = await dataSource.GetMappedItemAsync<StandaloneDerivedDto>(1, new DataSourceParameters());
 
         await Assert.That(result.WasSuccessful).IsTrue();
@@ -299,10 +297,9 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
 
-        await Assert.That(() => dataSource.GetListAsync(new ListParameters()))
-            .Throws<NotSupportedException>();
+        await Assert.ThrowsAsync<NotSupportedException>(() => dataSource.GetListAsync(new ListParameters()));
     }
 
     [Test]
@@ -311,10 +308,9 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
 
-        await Assert.That(() => dataSource.GetMappedListAsync<StandaloneDerivedDto>(new ListParameters()))
-            .Throws<NotSupportedException>();
+        await Assert.ThrowsAsync<NotSupportedException>(() => dataSource.GetMappedListAsync<StandaloneDerivedDto>(new ListParameters()));
     }
 
     [Test]
@@ -323,10 +319,9 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory();
         var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
 
-        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<StandaloneDerived>(declaredFor, nameof(StandaloneBase.NamedSource));
 
-        await Assert.That(() => dataSource.GetCountAsync(new FilterParameters()))
-            .Throws<NotSupportedException>();
+        await Assert.ThrowsAsync<NotSupportedException>(() => dataSource.GetCountAsync(new FilterParameters()));
     }
 
     #endregion
@@ -343,7 +338,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory(user);
         var declaredFor = rr.GetClassViewModel<SecuredDerived>()!;
 
-        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, nameof(SecuredBase.SecuredBaseSource));
         var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
 
         await Assert.That(result.WasSuccessful).IsTrue();
@@ -358,7 +353,7 @@ public class DataSourceFactoryTests
         var (factory, rr) = BuildFactory(user);
         var declaredFor = rr.GetClassViewModel<SecuredDerived>()!;
 
-        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, null);
+        var dataSource = factory.GetDataSource<SecuredDerived>(declaredFor, nameof(SecuredBase.SecuredBaseSource));
         var result = await dataSource.GetItemAsync(1, new DataSourceParameters());
 
         await Assert.That(result.WasSuccessful).IsFalse();

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
@@ -1,0 +1,144 @@
+using IntelliTect.Coalesce.Api;
+using IntelliTect.Coalesce.Api.DataSources;
+using IntelliTect.Coalesce.DataAnnotations;
+using IntelliTect.Coalesce.Testing.TargetClasses.TestDbContext;
+using IntelliTect.Coalesce.TypeDefinition;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IntelliTect.Coalesce.Tests.Api.DataSources;
+
+public class DataSourceFactoryTests
+{
+    private (DataSourceFactory Factory, ReflectionRepository Repo) BuildFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<AppDbContext>();
+        services.AddCoalesce(b => b.AddContext<AppDbContext>());
+        var sp = services.BuildServiceProvider();
+
+        var rr = new ReflectionRepository();
+        rr.AddAssembly<AppDbContext>();
+        rr.AddAssembly<DataSourceFactoryTests>();
+
+        return (new DataSourceFactory(sp, rr), rr);
+    }
+
+    #region Test Models
+
+    [Coalesce, StandaloneEntity]
+    public class StandaloneBase
+    {
+        public int Id { get; set; }
+
+        [DefaultDataSource]
+        public class DefaultSource : StandardDataSource<StandaloneBase>
+        {
+            public DefaultSource(CrudContext ctx) : base(ctx) { }
+            public override Task<IQueryable<StandaloneBase>> GetQueryAsync(IDataSourceParameters parameters)
+                => Task.FromResult(Array.Empty<StandaloneBase>().AsQueryable());
+        }
+
+        public class NamedSource : StandardDataSource<StandaloneBase>
+        {
+            public NamedSource(CrudContext ctx) : base(ctx) { }
+            public override Task<IQueryable<StandaloneBase>> GetQueryAsync(IDataSourceParameters parameters)
+                => Task.FromResult(Array.Empty<StandaloneBase>().AsQueryable());
+        }
+    }
+
+    [Coalesce, StandaloneEntity]
+    public class StandaloneDerived : StandaloneBase
+    {
+        // No own data sources - should inherit from StandaloneBase
+    }
+
+    [Coalesce, StandaloneEntity]
+    public class StandaloneDerivedWithOwnDefault : StandaloneBase
+    {
+        [DefaultDataSource]
+        public class DerivedDefaultSource : StandardDataSource<StandaloneDerivedWithOwnDefault>
+        {
+            public DerivedDefaultSource(CrudContext ctx) : base(ctx) { }
+            public override Task<IQueryable<StandaloneDerivedWithOwnDefault>> GetQueryAsync(IDataSourceParameters parameters)
+                => Task.FromResult(Array.Empty<StandaloneDerivedWithOwnDefault>().AsQueryable());
+        }
+    }
+
+    [Coalesce, StandaloneEntity]
+    public class StandaloneDerivedWithOwnNamed : StandaloneBase
+    {
+        public class OwnNamedSource : StandardDataSource<StandaloneDerivedWithOwnNamed>
+        {
+            public OwnNamedSource(CrudContext ctx) : base(ctx) { }
+            public override Task<IQueryable<StandaloneDerivedWithOwnNamed>> GetQueryAsync(IDataSourceParameters parameters)
+                => Task.FromResult(Array.Empty<StandaloneDerivedWithOwnNamed>().AsQueryable());
+        }
+    }
+
+    #endregion
+
+    [Test]
+    public async Task GetDefaultDataSourceType_DerivedTypeWithNoSources_UsesBaseDefaultSource()
+    {
+        var (factory, rr) = BuildFactory();
+
+        var servedType = rr.GetClassViewModel<StandaloneDerived>()!;
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var type = factory.GetDataSourceType(servedType, declaredFor, null);
+
+        await Assert.That(type).IsEqualTo(typeof(StandaloneBase.DefaultSource));
+    }
+
+    [Test]
+    public async Task GetDataSourceType_NamedSourceOnBase_FoundForDerivedType()
+    {
+        var (factory, rr) = BuildFactory();
+
+        var servedType = rr.GetClassViewModel<StandaloneDerived>()!;
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        var type = factory.GetDataSourceType(servedType, declaredFor, nameof(StandaloneBase.NamedSource));
+
+        await Assert.That(type).IsEqualTo(typeof(StandaloneBase.NamedSource));
+    }
+
+    [Test]
+    public async Task GetDataSourceType_NamedSourceNotInHierarchy_ThrowsDataSourceNotFoundException()
+    {
+        var (factory, rr) = BuildFactory();
+
+        var servedType = rr.GetClassViewModel<StandaloneDerived>()!;
+        var declaredFor = rr.GetClassViewModel<StandaloneDerived>()!;
+
+        await Assert.That(() => factory.GetDataSourceType(servedType, declaredFor, "NonExistentSource"))
+            .Throws<DataSourceNotFoundException>();
+    }
+
+    [Test]
+    public async Task GetDefaultDataSourceType_DerivedWithOwnDefault_OwnDefaultTakesPriority()
+    {
+        var (factory, rr) = BuildFactory();
+
+        var servedType = rr.GetClassViewModel<StandaloneDerivedWithOwnDefault>()!;
+        var declaredFor = rr.GetClassViewModel<StandaloneDerivedWithOwnDefault>()!;
+
+        var type = factory.GetDataSourceType(servedType, declaredFor, null);
+
+        await Assert.That(type).IsEqualTo(typeof(StandaloneDerivedWithOwnDefault.DerivedDefaultSource));
+    }
+
+    [Test]
+    public async Task GetDataSourceType_DerivedWithOwnNamed_BaseNamedSourceAlsoResolvable()
+    {
+        var (factory, rr) = BuildFactory();
+
+        var servedType = rr.GetClassViewModel<StandaloneDerivedWithOwnNamed>()!;
+        var declaredFor = rr.GetClassViewModel<StandaloneDerivedWithOwnNamed>()!;
+
+        // NamedSource is on the base type; should still be found for derived type
+        var type = factory.GetDataSourceType(servedType, declaredFor, nameof(StandaloneBase.NamedSource));
+
+        await Assert.That(type).IsEqualTo(typeof(StandaloneBase.NamedSource));
+    }
+}

--- a/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
@@ -66,7 +66,42 @@ public class DataSourceFactory : IDataSourceFactory
     public object GetDataSource(ClassViewModel servedType, ClassViewModel declaredFor, string? dataSourceName = null)
     {
         var dataSourceType = GetDataSourceType(servedType, declaredFor, dataSourceName);
-        return ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
+        var dataSource = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
+
+        // If the resolved data source serves a base type rather than the requested type,
+        // wrap it in an adapter so that single-item retrieval works for the derived type.
+        var servedTypeInfo = servedType.Type.TypeInfo;
+        var actualServedType = GetActualServedType(dataSourceType);
+
+        if (actualServedType != null && actualServedType != servedTypeInfo && servedTypeInfo.IsSubclassOf(actualServedType))
+        {
+            var baseClassViewModel = reflectionRepository.GetClassViewModel(actualServedType)!;
+            dataSource = CreateInheritedAdapter(dataSource, actualServedType, servedTypeInfo, baseClassViewModel.SecurityInfo);
+        }
+
+        return dataSource;
+    }
+
+    /// <summary>
+    /// Gets the T from IDataSource&lt;T&gt; that the given data source type implements.
+    /// </summary>
+    private static Type? GetActualServedType(Type dataSourceType)
+    {
+        return dataSourceType.GetInterfaces()
+            .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDataSource<>))
+            .Select(i => i.GetGenericArguments()[0])
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Creates an <see cref="InheritedDataSourceAdapter{TDerived, TBase}"/> wrapping the given data source.
+    /// </summary>
+    private object CreateInheritedAdapter(object innerDataSource, Type baseType, Type derivedType, ClassSecurityInfo baseTypeSecurityInfo)
+    {
+        var adapterType = typeof(InheritedDataSourceAdapter<,>).MakeGenericType(derivedType, baseType);
+        var crudContext = serviceProvider.GetRequiredService<CrudContext>();
+        Func<System.Security.Claims.ClaimsPrincipal> userAccessor = () => crudContext.User;
+        return Activator.CreateInstance(adapterType, innerDataSource, baseTypeSecurityInfo, userAccessor)!;
     }
 
     protected Type GetDefaultDataSourceType(ClassViewModel servedType, ClassViewModel declaredFor)
@@ -142,6 +177,17 @@ public class DataSourceFactory : IDataSourceFactory
     public object GetDefaultDataSource(ClassViewModel servedType, ClassViewModel declaredFor)
     {
         var dataSourceType = GetDefaultDataSourceType(servedType, declaredFor);
-        return ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
+        var dataSource = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
+
+        var servedTypeInfo = servedType.Type.TypeInfo;
+        var actualServedType = GetActualServedType(dataSourceType);
+
+        if (actualServedType != null && actualServedType != servedTypeInfo && servedTypeInfo.IsSubclassOf(actualServedType))
+        {
+            var baseClassViewModel = reflectionRepository.GetClassViewModel(actualServedType)!;
+            dataSource = CreateInheritedAdapter(dataSource, actualServedType, servedTypeInfo, baseClassViewModel.SecurityInfo);
+        }
+
+        return dataSource;
     }
 }

--- a/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
@@ -36,8 +36,7 @@ public class DataSourceFactory : IDataSourceFactory
             return GetDefaultDataSourceType(servedType, declaredFor);
         }
 
-        var dataSourceClassViewModel = declaredFor
-            .ClientDataSources(reflectionRepository)
+        var dataSourceClassViewModel = GetDataSourcesForTypeHierarchy(declaredFor)
             .FirstOrDefault(t => t.ClientTypeName.Equals(dataSourceName, InvariantCultureIgnoreCase))
             ?? throw new DataSourceNotFoundException(servedType, declaredFor, dataSourceName);
 
@@ -72,17 +71,13 @@ public class DataSourceFactory : IDataSourceFactory
 
     protected Type GetDefaultDataSourceType(ClassViewModel servedType, ClassViewModel declaredFor)
     {
-        var dataSources = declaredFor.ClientDataSources(reflectionRepository).ToList();
-        var defaultSource = dataSources.SingleOrDefault(s => s.IsDefaultDataSource);
-
-        if (defaultSource != null)
+        foreach (var (_, dataSources) in GetDataSourcesGroupedByHierarchy(declaredFor))
         {
-            return defaultSource.Type.TypeInfo;
-        }
+            var defaultSource = dataSources.SingleOrDefault(s => s.IsDefaultDataSource);
+            if (defaultSource != null) return defaultSource.Type.TypeInfo;
 
-        if (declaredFor.IsStandaloneEntity && dataSources.Count == 1)
-        {
-            return dataSources[0].Type.TypeInfo;
+            if (declaredFor.IsStandaloneEntity && dataSources.Count == 1)
+                return dataSources[0].Type.TypeInfo;
         }
 
         if (servedType.DbContext is null)
@@ -95,6 +90,34 @@ public class DataSourceFactory : IDataSourceFactory
             servedType.Type.TypeInfo,
             servedType.DbContext.Type.TypeInfo
         );
+    }
+
+    /// <summary>
+    /// Returns all client data sources for <paramref name="declaredFor"/> and then for each of its
+    /// base types in order from most-derived to least-derived.
+    /// Data sources on more-derived types take precedence over those on base types.
+    /// </summary>
+    private IEnumerable<ClassViewModel> GetDataSourcesForTypeHierarchy(ClassViewModel declaredFor)
+    {
+        foreach (var (_, dataSources) in GetDataSourcesGroupedByHierarchy(declaredFor))
+            foreach (var ds in dataSources)
+                yield return ds;
+    }
+
+    /// <summary>
+    /// Returns the data sources for <paramref name="declaredFor"/> and each of its
+    /// base types in order from most-derived to least-derived, grouped by declaring type.
+    /// </summary>
+    private IEnumerable<(ClassViewModel Type, IReadOnlyList<ClassViewModel> DataSources)> GetDataSourcesGroupedByHierarchy(ClassViewModel declaredFor)
+    {
+        var ownSources = declaredFor.ClientDataSources(reflectionRepository).ToList();
+        if (ownSources.Count > 0) yield return (declaredFor, ownSources);
+
+        foreach (var baseType in declaredFor.ClientBaseTypes)
+        {
+            var baseSources = baseType.ClientDataSources(reflectionRepository).ToList();
+            if (baseSources.Count > 0) yield return (baseType, baseSources);
+        }
     }
 
     public IDataSource<TServed> GetDefaultDataSource<TServed, TDeclaredFor>()

--- a/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/DataSourceFactory.cs
@@ -106,14 +106,13 @@ public class DataSourceFactory : IDataSourceFactory
 
     protected Type GetDefaultDataSourceType(ClassViewModel servedType, ClassViewModel declaredFor)
     {
-        foreach (var (_, dataSources) in GetDataSourcesGroupedByHierarchy(declaredFor))
-        {
-            var defaultSource = dataSources.SingleOrDefault(s => s.IsDefaultDataSource);
-            if (defaultSource != null) return defaultSource.Type.TypeInfo;
+        var dataSources = declaredFor.ClientDataSources(reflectionRepository).ToList();
 
-            if (declaredFor.IsStandaloneEntity && dataSources.Count == 1)
-                return dataSources[0].Type.TypeInfo;
-        }
+        var defaultSource = dataSources.SingleOrDefault(s => s.IsDefaultDataSource);
+        if (defaultSource != null) return defaultSource.Type.TypeInfo;
+
+        if (declaredFor.IsStandaloneEntity && dataSources.Count == 1)
+            return dataSources[0].Type.TypeInfo;
 
         if (servedType.DbContext is null)
         {
@@ -177,17 +176,6 @@ public class DataSourceFactory : IDataSourceFactory
     public object GetDefaultDataSource(ClassViewModel servedType, ClassViewModel declaredFor)
     {
         var dataSourceType = GetDefaultDataSourceType(servedType, declaredFor);
-        var dataSource = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
-
-        var servedTypeInfo = servedType.Type.TypeInfo;
-        var actualServedType = GetActualServedType(dataSourceType);
-
-        if (actualServedType != null && actualServedType != servedTypeInfo && servedTypeInfo.IsSubclassOf(actualServedType))
-        {
-            var baseClassViewModel = reflectionRepository.GetClassViewModel(actualServedType)!;
-            dataSource = CreateInheritedAdapter(dataSource, actualServedType, servedTypeInfo, baseClassViewModel.SecurityInfo);
-        }
-
-        return dataSource;
+        return ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, dataSourceType);
     }
 }

--- a/src/IntelliTect.Coalesce/Api/DataSources/InheritedDataSourceAdapter.cs
+++ b/src/IntelliTect.Coalesce/Api/DataSources/InheritedDataSourceAdapter.cs
@@ -1,0 +1,112 @@
+using IntelliTect.Coalesce.Models;
+using IntelliTect.Coalesce.TypeDefinition;
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace IntelliTect.Coalesce;
+
+/// <summary>
+/// Adapts an <see cref="IDataSource{T}"/> that serves a base type
+/// so that it can be used to retrieve individual items of a derived type.
+/// This is used by the <see cref="Api.DataSources.DataSourceFactory"/>
+/// when a data source declared on a base type in the hierarchy is resolved for a derived type.
+/// List and count operations are not supported through inherited data sources
+/// because they cannot correctly apply type-specific filtering.
+/// </summary>
+/// <typeparam name="TDerived">The derived entity type that needs to be served.</typeparam>
+/// <typeparam name="TBase">The base entity type that the inner data source serves.</typeparam>
+internal class InheritedDataSourceAdapter<TDerived, TBase> : IDataSource<TDerived>
+    where TDerived : class, TBase
+    where TBase : class
+{
+    private readonly IDataSource<TBase> _inner;
+    private readonly ClassSecurityInfo _baseTypeSecurityInfo;
+    private readonly Func<ClaimsPrincipal> _userAccessor;
+
+    public InheritedDataSourceAdapter(
+        IDataSource<TBase> inner,
+        ClassSecurityInfo baseTypeSecurityInfo,
+        Func<ClaimsPrincipal> userAccessor)
+    {
+        _inner = inner;
+        _baseTypeSecurityInfo = baseTypeSecurityInfo;
+        _userAccessor = userAccessor;
+    }
+
+    public async Task<ItemResult<TDerived>> GetItemAsync(object id, IDataSourceParameters parameters)
+    {
+        if (!_baseTypeSecurityInfo.IsReadAllowed(_userAccessor()))
+        {
+            return new ItemResult<TDerived>(wasSuccessful: false,
+                message: $"Read access to {typeof(TBase).Name} is not authorized.");
+        }
+
+        var result = await _inner.GetItemAsync(id, parameters);
+
+        if (!result.WasSuccessful || result.Object == null)
+        {
+            return new ItemResult<TDerived>(result);
+        }
+
+        if (result.Object is not TDerived derived)
+        {
+            return new ItemResult<TDerived>(wasSuccessful: false,
+                message: $"Item with ID {id} is not a {typeof(TDerived).Name}.");
+        }
+
+        return new ItemResult<TDerived>(result, derived);
+    }
+
+    public async Task<ItemResult<TDto>> GetMappedItemAsync<TDto>(object id, IDataSourceParameters parameters)
+        where TDto : class, IResponseDto<TDerived>, new()
+    {
+        if (!_baseTypeSecurityInfo.IsReadAllowed(_userAccessor()))
+        {
+            return new ItemResult<TDto>(wasSuccessful: false,
+                message: $"Read access to {typeof(TBase).Name} is not authorized.");
+        }
+
+        // TDto also implements IResponseDto<TBase> due to DTO inheritance hierarchy mirroring entities.
+        // Invoke via reflection since the compiler can't prove this constraint.
+        var method = typeof(IDataSource<TBase>)
+            .GetMethod(nameof(GetMappedItemAsync))!
+            .MakeGenericMethod(typeof(TDto));
+
+        var task = (Task)method.Invoke(_inner, [id, parameters])!;
+        await task;
+
+        var result = (ItemResult<TDto>)task.GetType().GetProperty("Result")!.GetValue(task)!;
+
+        if (!result.WasSuccessful || result.Object == null)
+        {
+            return result;
+        }
+
+        if (result.Object is not TDto dto)
+        {
+            return new ItemResult<TDto>(wasSuccessful: false,
+                message: $"Item with ID {id} is not a {typeof(TDerived).Name}.");
+        }
+
+        return new ItemResult<TDto>(result, dto);
+    }
+
+    public Task<ListResult<TDerived>> GetListAsync(IListParameters parameters)
+        => throw ThrowNotSupported();
+
+    public Task<ListResult<TDto>> GetMappedListAsync<TDto>(IListParameters parameters)
+        where TDto : class, IResponseDto<TDerived>, new()
+        => throw ThrowNotSupported();
+
+    public Task<ItemResult<int>> GetCountAsync(IFilterParameters parameters)
+        => throw ThrowNotSupported();
+
+    private NotSupportedException ThrowNotSupported([System.Runtime.CompilerServices.CallerMemberName] string? caller = null)
+    {
+        return new NotSupportedException(
+            $"{caller} is not supported through an inherited data source. " +
+            $"The data source serves {typeof(TBase).Name} but was resolved for {typeof(TDerived).Name}. " +
+            $"Declare a data source directly on {typeof(TDerived).Name} to support list/count operations.");
+    }
+}


### PR DESCRIPTION
## Summary

`DataSourceFactory` now walks the base type hierarchy of the `declaredFor` type when resolving a named or default data source, enabling inheritance scenarios where a derived type can use data sources declared on its base types.

## Changes

- **`DataSourceFactory.GetDataSourceType`** — when looking up a named data source, searches the declared type's own sources first, then walks up through `ClientBaseTypes` until a match is found.
- **`DataSourceFactory.GetDefaultDataSourceType`** — same hierarchy walk when finding an explicit default source (or the sole source for standalone entities).
- More-derived types always take precedence: data sources declared directly on the requested type are checked before those on base types.
- Added `DataSourceFactoryTests` covering:
  - Derived type with no own sources falls back to base type's `[DefaultDataSource]`
  - Named source on base type is found when requested for a derived type
  - Derived type's own default takes priority over base type's default
  - Named source on base type is still findable even when derived has its own named sources
  - Non-existent source throws `DataSourceNotFoundException`