### PR TITLE
fix: exclude abstract and generic nested datasources from discovery

### DIFF
--- a/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/Case.cs
+++ b/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/Case.cs
@@ -87,4 +87,11 @@ public class Case
             .Where(c => MinDate == null || c.OpenedAt > MinDate)
             .IncludeChildren();
     }
+
+    // Generic base datasource - should NOT be auto-discovered as a nested datasource.
+    public class GenericCaseDataSource<T>(CrudContext<AppDbContext> context) : StandardDataSource<T, AppDbContext>(context)
+        where T : Case;
+
+    // Abstract datasource - should NOT be auto-discovered as a nested datasource.
+    public abstract class AbstractCaseDataSource(CrudContext<AppDbContext> context) : StandardDataSource<Case, AppDbContext>(context);
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
@@ -78,4 +78,22 @@ public class ClassViewModelTests
         // Should be empty - no fallback ordering should be applied
         await Assert.That(orderings).IsEmpty();
     }
+
+    [Test]
+    public async Task ClientDataSources_ExcludesGenericAndAbstractNestedDataSources()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+        var entityVm = repo.GetClassViewModel<Case>()!;
+
+        var dataSources = entityVm.ClientDataSources(repo).ToList();
+
+        // The concrete AllOpenCases should be discovered
+        await Assert.That(dataSources).Contains(ds => ds.Name == nameof(Case.AllOpenCases));
+
+        // The open-generic GenericCaseDataSource<T> should NOT be discovered
+        await Assert.That(dataSources).DoesNotContain(ds => ds.Name == "GenericCaseDataSource");
+
+        // The abstract AbstractCaseDataSource should NOT be discovered
+        await Assert.That(dataSources).DoesNotContain(ds => ds.Name == nameof(Case.AbstractCaseDataSource));
+    }
 }

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -244,7 +244,7 @@ public abstract class ClassViewModel : IAttributeProvider
         Methods.Where(m => m.HasAttribute<SemanticKernelAttribute>());
 
     internal IEnumerable<TypeViewModel> ClientNestedTypes =>
-        RawNestedTypes.Where(t => !t.IsInternalUse);
+        RawNestedTypes.Where(t => !t.IsInternalUse && !t.IsAbstract && !t.IsGeneric);
 
     public IEnumerable<ClassViewModel> ClientDataSources(ReflectionRepository repo) => repo
         .DataSources

--- a/src/test-targets/api-clients.g.ts
+++ b/src/test-targets/api-clients.g.ts
@@ -592,6 +592,11 @@ export class EnumPkApiClient extends ModelApiClient<$models.EnumPk> {
 }
 
 
+export class GenericNestedDsTargetApiClient extends ModelApiClient<$models.GenericNestedDsTarget> {
+  constructor() { super($metadata.GenericNestedDsTarget) }
+}
+
+
 export class MultipleParentsApiClient extends ModelApiClient<$models.MultipleParents> {
   constructor() { super($metadata.MultipleParents) }
 }
@@ -751,6 +756,16 @@ export class RequiredAndInitModelApiClient extends ModelApiClient<$models.Requir
 
 export class RequiredInternalUseModelApiClient extends ModelApiClient<$models.RequiredInternalUseModel> {
   constructor() { super($metadata.RequiredInternalUseModel) }
+}
+
+
+export class SelfOwnedTenantApiClient extends ModelApiClient<$models.SelfOwnedTenant> {
+  constructor() { super($metadata.SelfOwnedTenant) }
+}
+
+
+export class SelfOwnedTenantConsumerApiClient extends ModelApiClient<$models.SelfOwnedTenantConsumer> {
+  constructor() { super($metadata.SelfOwnedTenantConsumer) }
 }
 
 

--- a/src/test-targets/metadata.g.ts
+++ b/src/test-targets/metadata.g.ts
@@ -3367,6 +3367,48 @@ export const EnumPk = domain.types.EnumPk = {
   dataSources: {
   },
 }
+export const GenericNestedDsTarget = domain.types.GenericNestedDsTarget = {
+  name: "GenericNestedDsTarget" as const,
+  displayName: "Generic Nested Ds Target",
+  get displayProp() { return this.props.id }, 
+  type: "model",
+  controllerRoute: "GenericNestedDsTarget",
+  get keyProp() { return this.props.id }, 
+  behaviorFlags: 7 as BehaviorFlags,
+  props: {
+    id: {
+      name: "id",
+      displayName: "Id",
+      type: "number",
+      role: "primaryKey",
+      hidden: 3 as HiddenAreas,
+    },
+    isActive: {
+      name: "isActive",
+      displayName: "Is Active",
+      type: "boolean",
+      role: "value",
+    },
+  },
+  methods: {
+  },
+  dataSources: {
+    defaultDs: {
+      type: "dataSource",
+      name: "DefaultDs" as const,
+      displayName: "Default Ds",
+      isDefault: true,
+      props: {
+        onlyActive: {
+          name: "onlyActive",
+          displayName: "Only Active",
+          type: "boolean",
+          role: "value",
+        },
+      },
+    },
+  },
+}
 export const MultipleParents = domain.types.MultipleParents = {
   name: "MultipleParents" as const,
   displayName: "Multiple Parents",
@@ -4586,6 +4628,78 @@ export const RequiredInternalUseModel = domain.types.RequiredInternalUseModel = 
       type: "number",
       role: "primaryKey",
       hidden: 3 as HiddenAreas,
+    },
+  },
+  methods: {
+  },
+  dataSources: {
+  },
+}
+export const SelfOwnedTenant = domain.types.SelfOwnedTenant = {
+  name: "SelfOwnedTenant" as const,
+  displayName: "Self Owned Tenant",
+  get displayProp() { return this.props.id }, 
+  type: "model",
+  controllerRoute: "SelfOwnedTenant",
+  get keyProp() { return this.props.id }, 
+  behaviorFlags: 7 as BehaviorFlags,
+  props: {
+    id: {
+      name: "id",
+      displayName: "Id",
+      type: "number",
+      role: "primaryKey",
+      hidden: 3 as HiddenAreas,
+    },
+    tenantId: {
+      name: "tenantId",
+      displayName: "Tenant Id",
+      type: "number",
+      role: "value",
+    },
+    ownerTenant: {
+      name: "ownerTenant",
+      displayName: "Owner Tenant",
+      type: "model",
+      get typeDef() { return (domain.types.SelfOwnedTenant as ModelType & { name: "SelfOwnedTenant" }) },
+      role: "value",
+      dontSerialize: true,
+    },
+  },
+  methods: {
+  },
+  dataSources: {
+  },
+}
+export const SelfOwnedTenantConsumer = domain.types.SelfOwnedTenantConsumer = {
+  name: "SelfOwnedTenantConsumer" as const,
+  displayName: "Self Owned Tenant Consumer",
+  get displayProp() { return this.props.id }, 
+  type: "model",
+  controllerRoute: "SelfOwnedTenantConsumer",
+  get keyProp() { return this.props.id }, 
+  behaviorFlags: 7 as BehaviorFlags,
+  props: {
+    id: {
+      name: "id",
+      displayName: "Id",
+      type: "number",
+      role: "primaryKey",
+      hidden: 3 as HiddenAreas,
+    },
+    tenantId: {
+      name: "tenantId",
+      displayName: "Tenant Id",
+      type: "number",
+      role: "value",
+    },
+    ownerTenant: {
+      name: "ownerTenant",
+      displayName: "Owner Tenant",
+      type: "model",
+      get typeDef() { return (domain.types.SelfOwnedTenant as ModelType & { name: "SelfOwnedTenant" }) },
+      role: "value",
+      dontSerialize: true,
     },
   },
   methods: {
@@ -5984,6 +6098,7 @@ interface AppDomain extends Domain {
     ExternalParentAsInputOnly: typeof ExternalParentAsInputOnly
     ExternalParentAsOutputOnly: typeof ExternalParentAsOutputOnly
     ExternalTypeWithDtoProp: typeof ExternalTypeWithDtoProp
+    GenericNestedDsTarget: typeof GenericNestedDsTarget
     InitRecordWithDefaultCtor: typeof InitRecordWithDefaultCtor
     InputOutputOnlyExternalTypeWithRequiredNonscalarProp: typeof InputOutputOnlyExternalTypeWithRequiredNonscalarProp
     Location: typeof Location
@@ -6006,6 +6121,8 @@ interface AppDomain extends Domain {
     RecursiveHierarchy: typeof RecursiveHierarchy
     RequiredAndInitModel: typeof RequiredAndInitModel
     RequiredInternalUseModel: typeof RequiredInternalUseModel
+    SelfOwnedTenant: typeof SelfOwnedTenant
+    SelfOwnedTenantConsumer: typeof SelfOwnedTenantConsumer
     Sibling: typeof Sibling
     SimpleModelTarget: typeof SimpleModelTarget
     StandaloneReadonly: typeof StandaloneReadonly

--- a/src/test-targets/models.g.ts
+++ b/src/test-targets/models.g.ts
@@ -597,6 +597,46 @@ export class EnumPk {
 }
 
 
+export interface GenericNestedDsTarget extends Model<typeof metadata.GenericNestedDsTarget> {
+  id: number | null
+  isActive: boolean | null
+}
+export class GenericNestedDsTarget {
+  
+  /** Mutates the input object and its descendants into a valid GenericNestedDsTarget implementation. */
+  static convert(data?: Partial<GenericNestedDsTarget>): GenericNestedDsTarget {
+    return convertToModel<GenericNestedDsTarget>(data || {}, metadata.GenericNestedDsTarget) 
+  }
+  
+  /** Maps the input object and its descendants to a new, valid GenericNestedDsTarget implementation. */
+  static map(data?: Partial<GenericNestedDsTarget>): GenericNestedDsTarget {
+    return mapToModel<GenericNestedDsTarget>(data || {}, metadata.GenericNestedDsTarget) 
+  }
+  
+  static [Symbol.hasInstance](x: any) { return x?.$metadata === metadata.GenericNestedDsTarget; }
+  
+  /** Instantiate a new GenericNestedDsTarget, optionally basing it on the given data. */
+  constructor(data?: Partial<GenericNestedDsTarget> | {[k: string]: any}) {
+    Object.assign(this, GenericNestedDsTarget.map(data || {}));
+  }
+}
+export namespace GenericNestedDsTarget {
+  export namespace DataSources {
+    
+    /** Concrete datasource - SHOULD be discovered. */
+    export class DefaultDs implements DataSource<typeof metadata.GenericNestedDsTarget.dataSources.defaultDs> {
+      readonly $metadata = metadata.GenericNestedDsTarget.dataSources.defaultDs
+      onlyActive: boolean | null = null
+      
+      constructor(params?: Omit<Partial<DefaultDs>, '$metadata'>) {
+        if (params) Object.assign(this, params);
+        return reactiveDataSource(this);
+      }
+    }
+  }
+}
+
+
 export interface MultipleParents extends Model<typeof metadata.MultipleParents> {
   id: number | null
   parent1Id: number | null
@@ -1059,6 +1099,58 @@ export class RequiredInternalUseModel {
   /** Instantiate a new RequiredInternalUseModel, optionally basing it on the given data. */
   constructor(data?: Partial<RequiredInternalUseModel> | {[k: string]: any}) {
     Object.assign(this, RequiredInternalUseModel.map(data || {}));
+  }
+}
+
+
+export interface SelfOwnedTenant extends Model<typeof metadata.SelfOwnedTenant> {
+  id: number | null
+  tenantId: number | null
+  ownerTenant: SelfOwnedTenant | null
+}
+export class SelfOwnedTenant {
+  
+  /** Mutates the input object and its descendants into a valid SelfOwnedTenant implementation. */
+  static convert(data?: Partial<SelfOwnedTenant>): SelfOwnedTenant {
+    return convertToModel<SelfOwnedTenant>(data || {}, metadata.SelfOwnedTenant) 
+  }
+  
+  /** Maps the input object and its descendants to a new, valid SelfOwnedTenant implementation. */
+  static map(data?: Partial<SelfOwnedTenant>): SelfOwnedTenant {
+    return mapToModel<SelfOwnedTenant>(data || {}, metadata.SelfOwnedTenant) 
+  }
+  
+  static [Symbol.hasInstance](x: any) { return x?.$metadata === metadata.SelfOwnedTenant; }
+  
+  /** Instantiate a new SelfOwnedTenant, optionally basing it on the given data. */
+  constructor(data?: Partial<SelfOwnedTenant> | {[k: string]: any}) {
+    Object.assign(this, SelfOwnedTenant.map(data || {}));
+  }
+}
+
+
+export interface SelfOwnedTenantConsumer extends Model<typeof metadata.SelfOwnedTenantConsumer> {
+  id: number | null
+  tenantId: number | null
+  ownerTenant: SelfOwnedTenant | null
+}
+export class SelfOwnedTenantConsumer {
+  
+  /** Mutates the input object and its descendants into a valid SelfOwnedTenantConsumer implementation. */
+  static convert(data?: Partial<SelfOwnedTenantConsumer>): SelfOwnedTenantConsumer {
+    return convertToModel<SelfOwnedTenantConsumer>(data || {}, metadata.SelfOwnedTenantConsumer) 
+  }
+  
+  /** Maps the input object and its descendants to a new, valid SelfOwnedTenantConsumer implementation. */
+  static map(data?: Partial<SelfOwnedTenantConsumer>): SelfOwnedTenantConsumer {
+    return mapToModel<SelfOwnedTenantConsumer>(data || {}, metadata.SelfOwnedTenantConsumer) 
+  }
+  
+  static [Symbol.hasInstance](x: any) { return x?.$metadata === metadata.SelfOwnedTenantConsumer; }
+  
+  /** Instantiate a new SelfOwnedTenantConsumer, optionally basing it on the given data. */
+  constructor(data?: Partial<SelfOwnedTenantConsumer> | {[k: string]: any}) {
+    Object.assign(this, SelfOwnedTenantConsumer.map(data || {}));
   }
 }
 
@@ -1885,6 +1977,7 @@ declare module "coalesce-vue/lib/model" {
     ExternalParentAsInputOnly: ExternalParentAsInputOnly
     ExternalParentAsOutputOnly: ExternalParentAsOutputOnly
     ExternalTypeWithDtoProp: ExternalTypeWithDtoProp
+    GenericNestedDsTarget: GenericNestedDsTarget
     InitRecordWithDefaultCtor: InitRecordWithDefaultCtor
     InputOutputOnlyExternalTypeWithRequiredNonscalarProp: InputOutputOnlyExternalTypeWithRequiredNonscalarProp
     Location: Location
@@ -1907,6 +2000,8 @@ declare module "coalesce-vue/lib/model" {
     RecursiveHierarchy: RecursiveHierarchy
     RequiredAndInitModel: RequiredAndInitModel
     RequiredInternalUseModel: RequiredInternalUseModel
+    SelfOwnedTenant: SelfOwnedTenant
+    SelfOwnedTenantConsumer: SelfOwnedTenantConsumer
     Sibling: Sibling
     SimpleModelTarget: SimpleModelTarget
     StandaloneReadonly: StandaloneReadonly

--- a/src/test-targets/viewmodels.g.ts
+++ b/src/test-targets/viewmodels.g.ts
@@ -1051,6 +1051,28 @@ export class EnumPkListViewModel extends ListViewModel<$models.EnumPk, $apiClien
 }
 
 
+export interface GenericNestedDsTargetViewModel extends $models.GenericNestedDsTarget {
+  id: number | null;
+  isActive: boolean | null;
+}
+export class GenericNestedDsTargetViewModel extends ViewModel<$models.GenericNestedDsTarget, $apiClients.GenericNestedDsTargetApiClient, number> implements $models.GenericNestedDsTarget  {
+  static DataSources = $models.GenericNestedDsTarget.DataSources;
+  
+  constructor(initialData?: DeepPartial<$models.GenericNestedDsTarget> | null) {
+    super($metadata.GenericNestedDsTarget, new $apiClients.GenericNestedDsTargetApiClient(), initialData)
+  }
+}
+defineProps(GenericNestedDsTargetViewModel, $metadata.GenericNestedDsTarget)
+
+export class GenericNestedDsTargetListViewModel extends ListViewModel<$models.GenericNestedDsTarget, $apiClients.GenericNestedDsTargetApiClient, GenericNestedDsTargetViewModel> {
+  static DataSources = $models.GenericNestedDsTarget.DataSources;
+  
+  constructor() {
+    super($metadata.GenericNestedDsTarget, new $apiClients.GenericNestedDsTargetApiClient())
+  }
+}
+
+
 export interface MultipleParentsViewModel extends $models.MultipleParents {
   id: number | null;
   parent1Id: number | null;
@@ -1557,6 +1579,50 @@ export class RequiredInternalUseModelListViewModel extends ListViewModel<$models
 }
 
 
+export interface SelfOwnedTenantViewModel extends $models.SelfOwnedTenant {
+  id: number | null;
+  tenantId: number | null;
+  get ownerTenant(): SelfOwnedTenantViewModel | null;
+  set ownerTenant(value: SelfOwnedTenantViewModel | $models.SelfOwnedTenant | null);
+}
+export class SelfOwnedTenantViewModel extends ViewModel<$models.SelfOwnedTenant, $apiClients.SelfOwnedTenantApiClient, number> implements $models.SelfOwnedTenant  {
+  
+  constructor(initialData?: DeepPartial<$models.SelfOwnedTenant> | null) {
+    super($metadata.SelfOwnedTenant, new $apiClients.SelfOwnedTenantApiClient(), initialData)
+  }
+}
+defineProps(SelfOwnedTenantViewModel, $metadata.SelfOwnedTenant)
+
+export class SelfOwnedTenantListViewModel extends ListViewModel<$models.SelfOwnedTenant, $apiClients.SelfOwnedTenantApiClient, SelfOwnedTenantViewModel> {
+  
+  constructor() {
+    super($metadata.SelfOwnedTenant, new $apiClients.SelfOwnedTenantApiClient())
+  }
+}
+
+
+export interface SelfOwnedTenantConsumerViewModel extends $models.SelfOwnedTenantConsumer {
+  id: number | null;
+  tenantId: number | null;
+  get ownerTenant(): SelfOwnedTenantViewModel | null;
+  set ownerTenant(value: SelfOwnedTenantViewModel | $models.SelfOwnedTenant | null);
+}
+export class SelfOwnedTenantConsumerViewModel extends ViewModel<$models.SelfOwnedTenantConsumer, $apiClients.SelfOwnedTenantConsumerApiClient, number> implements $models.SelfOwnedTenantConsumer  {
+  
+  constructor(initialData?: DeepPartial<$models.SelfOwnedTenantConsumer> | null) {
+    super($metadata.SelfOwnedTenantConsumer, new $apiClients.SelfOwnedTenantConsumerApiClient(), initialData)
+  }
+}
+defineProps(SelfOwnedTenantConsumerViewModel, $metadata.SelfOwnedTenantConsumer)
+
+export class SelfOwnedTenantConsumerListViewModel extends ListViewModel<$models.SelfOwnedTenantConsumer, $apiClients.SelfOwnedTenantConsumerApiClient, SelfOwnedTenantConsumerViewModel> {
+  
+  constructor() {
+    super($metadata.SelfOwnedTenantConsumer, new $apiClients.SelfOwnedTenantConsumerApiClient())
+  }
+}
+
+
 export interface SiblingViewModel extends $models.Sibling {
   siblingId: number | null;
   personId: number | null;
@@ -1849,6 +1915,7 @@ const viewModelTypeLookup = ViewModel.typeLookup = {
   DateTimeOffsetPk: DateTimeOffsetPkViewModel,
   DateTimePk: DateTimePkViewModel,
   EnumPk: EnumPkViewModel,
+  GenericNestedDsTarget: GenericNestedDsTargetViewModel,
   MultipleParents: MultipleParentsViewModel,
   OneToOneManyChildren: OneToOneManyChildrenViewModel,
   OneToOneParent: OneToOneParentViewModel,
@@ -1863,6 +1930,8 @@ const viewModelTypeLookup = ViewModel.typeLookup = {
   RecursiveHierarchy: RecursiveHierarchyViewModel,
   RequiredAndInitModel: RequiredAndInitModelViewModel,
   RequiredInternalUseModel: RequiredInternalUseModelViewModel,
+  SelfOwnedTenant: SelfOwnedTenantViewModel,
+  SelfOwnedTenantConsumer: SelfOwnedTenantConsumerViewModel,
   Sibling: SiblingViewModel,
   StandaloneReadonly: StandaloneReadonlyViewModel,
   StandaloneReadWrite: StandaloneReadWriteViewModel,
@@ -1890,6 +1959,7 @@ const listViewModelTypeLookup = ListViewModel.typeLookup = {
   DateTimeOffsetPk: DateTimeOffsetPkListViewModel,
   DateTimePk: DateTimePkListViewModel,
   EnumPk: EnumPkListViewModel,
+  GenericNestedDsTarget: GenericNestedDsTargetListViewModel,
   MultipleParents: MultipleParentsListViewModel,
   OneToOneManyChildren: OneToOneManyChildrenListViewModel,
   OneToOneParent: OneToOneParentListViewModel,
@@ -1904,6 +1974,8 @@ const listViewModelTypeLookup = ListViewModel.typeLookup = {
   RecursiveHierarchy: RecursiveHierarchyListViewModel,
   RequiredAndInitModel: RequiredAndInitModelListViewModel,
   RequiredInternalUseModel: RequiredInternalUseModelListViewModel,
+  SelfOwnedTenant: SelfOwnedTenantListViewModel,
+  SelfOwnedTenantConsumer: SelfOwnedTenantConsumerListViewModel,
   Sibling: SiblingListViewModel,
   StandaloneReadonly: StandaloneReadonlyListViewModel,
   StandaloneReadWrite: StandaloneReadWriteListViewModel,


### PR DESCRIPTION
When Coalesce auto-discovers nested datasources on entity classes, it was picking up open-generic and abstract nested types. These are unsupported as standalone datasources and caused a subtle bug: if a generic base datasource carried `[InternalUse]`, that attribute would be inherited by a concrete subclass, suppressing the concrete datasource's metadata from the frontend entirely.

The fix is a one-line change to `ClientNestedTypes` in `ClassViewModel` to additionally filter out abstract and generic types, mirroring how top-level discovery already ignores such types.

- `ClassViewModel.ClientNestedTypes`: added `!t.IsAbstract && !t.IsGeneric` to the filter
- `Case.cs` (test targets): added `GenericCaseDataSource<T>` and `AbstractCaseDataSource` as representative examples of the excluded types
- New test `ClientDataSources_ExcludesGenericAndAbstractNestedDataSources` verifies only concrete, closed datasources are surfaced