### PR TITLE
feat: Open generic datasource inheritance for derived types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 6.6.0
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
 - Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library.
-- Open generic data sources nested in a base class (e.g. `class MyDataSource<T> : StandardDataSource<T, DbCtx> where T : MyBase`) are now automatically available for both the base class and all derived entity types. This works for both default and named data sources.
+- Open generic data sources whose single type parameter is constrained to a base class are now automatically available as data sources for that base class and all derived entity types. This works for both default and named data sources, and applies whether the data source is nested in the base class or declared as a top-level type with `[Coalesce]`.
 
 ## Template Changes
 - Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.6.0
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
 - Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library.
+- Open generic data sources nested in a base class (e.g. `class MyDataSource<T> : StandardDataSource<T, DbCtx> where T : MyBase`) are now automatically available for both the base class and all derived entity types. This works for both default and named data sources.
 
 ## Template Changes
 - Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project:

--- a/docs/modeling/model-components/data-sources.md
+++ b/docs/modeling/model-components/data-sources.md
@@ -53,25 +53,32 @@ If you have a class hierarchy and want a single data source implementation to ap
 This works for both default data sources (via `[DefaultDataSource]`) and additional named data sources. The data source can be either nested in the base class, or declared as a top-level type with `[Coalesce]`.
 
 ```cs
-public abstract class AppEntity
+public abstract class Animal
 {
-    public int Id { get; set; }
-    public int TenantId { get; set; }
+    public int AnimalId { get; set; }
+    public int ShelterId { get; set; }
 
-    // This default data source is shared by AppEntity and all derived types.
-    // The closed T is automatically substituted (e.g. ProductDataSource for Product).
+    // This default data source is shared by Animal and all derived types (Dog, Cat, etc.).
+    // Coalesce closes the generic T for each entity in the hierarchy.
     [DefaultDataSource]
-    public class TenantScopedSource<T>(CrudContext<AppDbContext> context)
+    public class ShelterScopedSource<T>(CrudContext<AppDbContext> context)
         : StandardDataSource<T, AppDbContext>(context)
-        where T : AppEntity
+        where T : Animal
     {
         public override IQueryable<T> GetQuery(IDataSourceParameters parameters)
-            => base.GetQuery(parameters).Where(e => e.TenantId == User.GetTenantId());
+            => base.GetQuery(parameters).Where(a => a.ShelterId == User.GetShelterId());
     }
 }
 
-public class Product : AppEntity { /* ... */ }
-public class Order : AppEntity { /* ... */ }
+public class Dog : Animal
+{
+    public string Breed { get; set; }
+}
+
+public class Cat : Animal
+{
+    public bool IsIndoor { get; set; }
+}
 ```
 
 A derived type can still declare its own data source(s) to override or supplement what it inherits from the base class. A non-generic data source declared on the derived type takes precedence over the inherited open generic one when their names match (or when both are the default).

--- a/docs/modeling/model-components/data-sources.md
+++ b/docs/modeling/model-components/data-sources.md
@@ -46,6 +46,36 @@ If you create a custom data source that has custom logic for securing your data,
 
 All data sources are instantiated using dependency injection and your application's `IServiceProvider`. As a result, you can add whatever constructor parameters you desire to your data sources as long as a value for them can be resolved from your application's services. The single parameter to the `StandardDataSource` is resolved in this way - the `CrudContext<TContext>` contains the common set of objects most commonly used, including the `DbContext` and the `ClaimsPrincipal` representing the current user.
 
+### Sharing Data Sources Across an Inheritance Hierarchy
+
+If you have a class hierarchy and want a single data source implementation to apply to a base class and all of its derived types, declare the data source with an open generic parameter that is constrained to the base class. Coalesce will automatically close the generic for each derived type and use the resulting data source for that type, just as if you had declared it directly on each derived class.
+
+This works for both default data sources (via `[DefaultDataSource]`) and additional named data sources. The data source can be either nested in the base class, or declared as a top-level type with `[Coalesce]`.
+
+```cs
+public abstract class AppEntity
+{
+    public int Id { get; set; }
+    public int TenantId { get; set; }
+
+    // This default data source is shared by AppEntity and all derived types.
+    // The closed T is automatically substituted (e.g. ProductDataSource for Product).
+    [DefaultDataSource]
+    public class TenantScopedSource<T>(CrudContext<AppDbContext> context)
+        : StandardDataSource<T, AppDbContext>(context)
+        where T : AppEntity
+    {
+        public override IQueryable<T> GetQuery(IDataSourceParameters parameters)
+            => base.GetQuery(parameters).Where(e => e.TenantId == User.GetTenantId());
+    }
+}
+
+public class Product : AppEntity { /* ... */ }
+public class Order : AppEntity { /* ... */ }
+```
+
+A derived type can still declare its own data source(s) to override or supplement what it inherits from the base class. A non-generic data source declared on the derived type takes precedence over the inherited open generic one when their names match (or when both are the default).
+
 
 ## Consuming Data Sources
 

--- a/docs/modeling/model-types/entities.md
+++ b/docs/modeling/model-types/entities.md
@@ -81,6 +81,7 @@ Coalesce is compatible with TPH, TPT, and TPCT entity hierarchies. Define your m
 - The generated [TypeScript ViewModel](/stacks/vue/layers/viewmodels.md) for an abstract type is not like a regular ViewModel - it functions as a proxy whose primary purpose is to allow usage of `$load` to load a PK value whose concrete type is not known. After a successful load, it transforms itself into an instance of the concrete type.
 - The generated [Model](/stacks/vue/layers/models.md) types **do** mirror your C# inheritance hierarchy using regular TypeScript class inheritance.
 - If you want to expose the discriminator property to the client, map it to a .NET property on the base type [per EF documentation](https://learn.microsoft.com/en-us/ef/core/modeling/inheritance#table-per-hierarchy-and-discriminator-configuration).
+- [Data Sources](/modeling/model-components/data-sources.md#sharing-data-sources-across-an-inheritance-hierarchy) can be shared across the entire hierarchy using an open generic constrained to the base type, avoiding the need to duplicate data source logic for each derived type.
 
 ## JSON-mapped Properties
 

--- a/playground/Coalesce.Domain/AbstractClass.cs
+++ b/playground/Coalesce.Domain/AbstractClass.cs
@@ -1,4 +1,5 @@
 ﻿using IntelliTect.Coalesce;
+using IntelliTect.Coalesce.Api.DataSources;
 using IntelliTect.Coalesce.DataAnnotations;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,6 +23,22 @@ public abstract class AbstractClass
 
     [Coalesce]
     public static AbstractClass EchoAbstractModel(AbstractClass model) => model;
+
+    /// <summary>
+    /// A default data source declared with an open generic parameter constrained to <see cref="AbstractClass"/>.
+    /// Because <typeparamref name="T"/> is constrained to <see cref="AbstractClass"/>,
+    /// this data source is automatically used as the default for <see cref="AbstractClass"/>
+    /// and every derived type (e.g. <see cref="AbstractClassImpl"/>) without needing to
+    /// declare a separate data source on each derived class.
+    /// </summary>
+    [DefaultDataSource]
+    public class DefaultSource<T>(CrudContext<AppDbContext> context)
+        : StandardDataSource<T, AppDbContext>(context)
+        where T : AbstractClass
+    {
+        public override IQueryable<T> GetQuery(IDataSourceParameters parameters)
+            => base.GetQuery(parameters).OrderByDescending(e => e.Id);
+    }
 }
 
 public class AbstractClassImpl : AbstractClass

--- a/playground/Coalesce.Web.Vue3/src/metadata.g.ts
+++ b/playground/Coalesce.Web.Vue3/src/metadata.g.ts
@@ -232,6 +232,14 @@ export const AbstractClass = domain.types.AbstractClass = {
     },
   },
   dataSources: {
+    defaultSource: {
+      type: "dataSource",
+      name: "DefaultSource" as const,
+      displayName: "Default Source",
+      isDefault: true,
+      props: {
+      },
+    },
   },
 }
 export const AbstractClassImpl = domain.types.AbstractClassImpl = {
@@ -359,6 +367,14 @@ export const AbstractClassImpl = domain.types.AbstractClassImpl = {
     },
   },
   dataSources: {
+    defaultSource: {
+      type: "dataSource",
+      name: "DefaultSource" as const,
+      displayName: "Default Source",
+      isDefault: true,
+      props: {
+      },
+    },
   },
 }
 export const AbstractClassPerson = domain.types.AbstractClassPerson = {

--- a/playground/Coalesce.Web.Vue3/src/models.g.ts
+++ b/playground/Coalesce.Web.Vue3/src/models.g.ts
@@ -62,6 +62,21 @@ export class AbstractClass {
     Object.assign(this, AbstractClass.map(data || {}));
   }
 }
+export namespace AbstractClass {
+  export namespace DataSources {
+    
+    /** 
+      A default data source declared with an open generic parameter constrained to AbstractClass.
+      Because  is constrained to AbstractClass,
+      this data source is automatically used as the default for AbstractClass
+      and every derived type (e.g. AbstractClassImpl) without needing to
+      declare a separate data source on each derived class.
+    */
+    export class DefaultSource implements DataSource<typeof metadata.AbstractClass.dataSources.defaultSource> {
+      readonly $metadata = metadata.AbstractClass.dataSources.defaultSource
+    }
+  }
+}
 
 
 export interface AbstractClassImpl extends Model<typeof metadata.AbstractClassImpl> {
@@ -87,6 +102,21 @@ export class AbstractClassImpl {
   /** Instantiate a new AbstractClassImpl, optionally basing it on the given data. */
   constructor(data?: Partial<AbstractClassImpl> | {[k: string]: any}) {
     Object.assign(this, AbstractClassImpl.map(data || {}));
+  }
+}
+export namespace AbstractClassImpl {
+  export namespace DataSources {
+    
+    /** 
+      A default data source declared with an open generic parameter constrained to AbstractClass.
+      Because  is constrained to AbstractClass,
+      this data source is automatically used as the default for AbstractClass
+      and every derived type (e.g. AbstractClassImpl) without needing to
+      declare a separate data source on each derived class.
+    */
+    export class DefaultSource implements DataSource<typeof metadata.AbstractClassImpl.dataSources.defaultSource> {
+      readonly $metadata = metadata.AbstractClassImpl.dataSources.defaultSource
+    }
   }
 }
 

--- a/playground/Coalesce.Web.Vue3/src/viewmodels.g.ts
+++ b/playground/Coalesce.Web.Vue3/src/viewmodels.g.ts
@@ -7,6 +7,7 @@ export type AbstractClassViewModel = AbstractClassImplViewModel
 export const AbstractClassViewModel = createAbstractProxyViewModelType<$models.AbstractClass, AbstractClassViewModel>($metadata.AbstractClass, $apiClients.AbstractClassApiClient)
 
 export class AbstractClassListViewModel extends ListViewModel<$models.AbstractClass, $apiClients.AbstractClassApiClient, AbstractClassViewModel> {
+  static DataSources = $models.AbstractClass.DataSources;
   
   public get getCount() {
     const getCount = this.$apiClient.$makeCaller(
@@ -44,6 +45,7 @@ export interface AbstractClassImplViewModel extends $models.AbstractClassImpl {
   set abstractModelPeople(value: (AbstractClassPersonViewModel | $models.AbstractClassPerson)[] | null);
 }
 export class AbstractClassImplViewModel extends ViewModel<$models.AbstractClassImpl, $apiClients.AbstractClassImplApiClient, number> implements $models.AbstractClassImpl  {
+  static DataSources = $models.AbstractClassImpl.DataSources;
   
   
   public addToAbstractModelPeople(initialData?: DeepPartial<$models.AbstractClassPerson> | null) {
@@ -72,6 +74,7 @@ export class AbstractClassImplViewModel extends ViewModel<$models.AbstractClassI
 defineProps(AbstractClassImplViewModel, $metadata.AbstractClassImpl)
 
 export class AbstractClassImplListViewModel extends ListViewModel<$models.AbstractClassImpl, $apiClients.AbstractClassImplApiClient, AbstractClassImplViewModel> {
+  static DataSources = $models.AbstractClassImpl.DataSources;
   
   public get getCount() {
     const getCount = this.$apiClient.$makeCaller(

--- a/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
+++ b/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
@@ -1,3 +1,4 @@
+using IntelliTect.Coalesce.Api.DataSources;
 using IntelliTect.Coalesce.DataAnnotations;
 using IntelliTect.Coalesce.Testing.TargetClasses.TestDbContext;
 using System.Collections.Generic;
@@ -26,6 +27,23 @@ public abstract class AbstractModel
 
     [Coalesce]
     public static AbstractModel EchoAbstractModel(AbstractModel model) => model;
+
+    /// <summary>
+    /// An open generic data source constrained to AbstractModel.
+    /// Should be discovered for AbstractModel itself and all derived types (AbstractImpl1, AbstractImpl2).
+    /// </summary>
+    public class AbstractModelDataSource<T>(CrudContext<AppDbContext> context)
+        : StandardDataSource<T, AppDbContext>(context)
+        where T : AbstractModel;
+
+    /// <summary>
+    /// An open generic default data source constrained to AbstractModel.
+    /// Should be the default data source for AbstractModel and all derived types.
+    /// </summary>
+    [DefaultDataSource]
+    public class DefaultAbstractModelDataSource<T>(CrudContext<AppDbContext> context)
+        : StandardDataSource<T, AppDbContext>(context)
+        where T : AbstractModel;
 }
 
 [Edit(PermissionLevel = SecurityPermissionLevels.DenyAll)]

--- a/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
+++ b/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
@@ -61,6 +61,16 @@ public class AbstractImpl2 : AbstractModel
     public string Impl2OnlyField { get; set; }
 }
 
+/// <summary>
+/// A top-level open generic data source constrained to AbstractModel,
+/// discovered via [Coalesce] attribute. Should be available for AbstractModel
+/// itself and all derived types.
+/// </summary>
+[Coalesce]
+public class TopLevelAbstractModelDataSource<T>(CrudContext<AppDbContext> context)
+    : StandardDataSource<T, AppDbContext>(context)
+    where T : AbstractModel;
+
 public class AbstractModelPerson
 {
     public int Id { get; set; }

--- a/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
+++ b/src/IntelliTect.Coalesce.Testing/TargetClasses/TestDbContext/AbstractModel.cs
@@ -53,6 +53,19 @@ public class AbstractImpl1 : AbstractModel
 
     public int? ParentId { get; set; }
     public AbstractModel Parent { get; set; }
+
+    /// <summary>
+    /// Overrides the inherited open generic default data source for AbstractImpl1 only.
+    /// </summary>
+    [DefaultDataSource]
+    public class Impl1DefaultDataSource(CrudContext<AppDbContext> context)
+        : StandardDataSource<AbstractImpl1, AppDbContext>(context);
+
+    /// <summary>
+    /// Overrides the inherited open generic named "AbstractModelDataSource" for AbstractImpl1 only.
+    /// </summary>
+    public class AbstractModelDataSource(CrudContext<AppDbContext> context)
+        : StandardDataSource<AbstractImpl1, AppDbContext>(context);
 }
 
 [Edit(PermissionLevel = SecurityPermissionLevels.DenyAll)]

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
@@ -1,0 +1,63 @@
+using IntelliTect.Coalesce.Api.DataSources;
+using IntelliTect.Coalesce.Testing.TargetClasses;
+using IntelliTect.Coalesce.Testing.TargetClasses.TestDbContext;
+using IntelliTect.Coalesce.Testing.Util;
+using IntelliTect.Coalesce.TypeDefinition;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IntelliTect.Coalesce.Tests.Api.DataSources;
+
+public class DataSourceFactoryTests
+{
+    private DataSourceFactory CreateFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<AppDbContext>();
+        services.AddCoalesce(b => b.AddContext<AppDbContext>());
+        var sp = services.BuildServiceProvider();
+        return new DataSourceFactory(sp, ReflectionRepositoryFactory.Reflection);
+    }
+
+    [Test]
+    public async Task GetDataSource_OpenGenericDefault_ReturnsClosedGenericForDerivedType()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var dataSource = factory.GetDefaultDataSource(impl1Vm, impl1Vm);
+
+        // The resolved data source should be the closed generic DefaultAbstractModelDataSource<AbstractImpl1>,
+        // not some base-type version.
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl1>>();
+        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractImpl1));
+        await Assert.That(dataSource.GetType().GetGenericTypeDefinition()).IsEqualTo(typeof(AbstractModel.DefaultAbstractModelDataSource<AbstractModel>).GetGenericTypeDefinition());
+    }
+
+    [Test]
+    public async Task GetDataSource_OpenGenericNamed_ReturnsClosedGenericForDerivedType()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var dataSource = factory.GetDataSource(impl2Vm, impl2Vm, "AbstractModelDataSource");
+
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl2>>();
+        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractImpl2));
+        await Assert.That(dataSource.GetType().GetGenericTypeDefinition()).IsEqualTo(typeof(AbstractModel.AbstractModelDataSource<AbstractModel>).GetGenericTypeDefinition());
+    }
+
+    [Test]
+    public async Task GetDataSource_OpenGenericForBaseType_ReturnsClosedGenericForBaseType()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var abstractVm = repo.GetClassViewModel<AbstractModel>()!;
+        var dataSource = factory.GetDataSource(abstractVm, abstractVm, "AbstractModelDataSource");
+
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractModel>>();
+        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractModel));
+    }
+}

--- a/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/Api/DataSources/DataSourceFactoryTests.cs
@@ -24,13 +24,12 @@ public class DataSourceFactoryTests
         var factory = CreateFactory();
         var repo = ReflectionRepositoryFactory.Reflection;
 
-        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
-        var dataSource = factory.GetDefaultDataSource(impl1Vm, impl1Vm);
+        // AbstractImpl2 has no overrides, so it inherits the open generic default.
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var dataSource = factory.GetDefaultDataSource(impl2Vm, impl2Vm);
 
-        // The resolved data source should be the closed generic DefaultAbstractModelDataSource<AbstractImpl1>,
-        // not some base-type version.
-        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl1>>();
-        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractImpl1));
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl2>>();
+        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractImpl2));
         await Assert.That(dataSource.GetType().GetGenericTypeDefinition()).IsEqualTo(typeof(AbstractModel.DefaultAbstractModelDataSource<AbstractModel>).GetGenericTypeDefinition());
     }
 
@@ -59,5 +58,51 @@ public class DataSourceFactoryTests
 
         await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractModel>>();
         await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractModel));
+    }
+
+    [Test]
+    public async Task GetDataSource_DerivedTypeDefaultOverride_TakesPrecedenceOverInheritedOpenGeneric()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var dataSource = factory.GetDefaultDataSource(impl1Vm, impl1Vm);
+
+        // AbstractImpl1 declares its own Impl1DefaultDataSource, which should take precedence
+        // over the inherited open generic DefaultAbstractModelDataSource<T>.
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl1>>();
+        await Assert.That(dataSource.GetType()).IsEqualTo(typeof(AbstractImpl1.Impl1DefaultDataSource));
+    }
+
+    [Test]
+    public async Task GetDataSource_DerivedTypeNamedOverride_TakesPrecedenceOverInheritedOpenGeneric()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var dataSource = factory.GetDataSource(impl1Vm, impl1Vm, "AbstractModelDataSource");
+
+        // AbstractImpl1 declares its own non-generic AbstractModelDataSource with the same name,
+        // which should take precedence over the base class's open generic AbstractModelDataSource<T>.
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl1>>();
+        await Assert.That(dataSource.GetType()).IsEqualTo(typeof(AbstractImpl1.AbstractModelDataSource));
+    }
+
+    [Test]
+    public async Task GetDataSource_DerivedTypeWithOverride_StillInheritsOtherNamedDataSources()
+    {
+        var factory = CreateFactory();
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        // AbstractImpl1 overrides "AbstractModelDataSource" and the default,
+        // but should still inherit "TopLevelAbstractModelDataSource" from the base.
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var dataSource = factory.GetDataSource(impl1Vm, impl1Vm, "TopLevelAbstractModelDataSource");
+
+        await Assert.That(dataSource).IsAssignableTo<IDataSource<AbstractImpl1>>();
+        await Assert.That(dataSource.GetType().GetGenericArguments().Single()).IsEqualTo(typeof(AbstractImpl1));
+        await Assert.That(dataSource.GetType().GetGenericTypeDefinition()).IsEqualTo(typeof(TopLevelAbstractModelDataSource<AbstractModel>).GetGenericTypeDefinition());
     }
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
@@ -156,4 +156,24 @@ public class ClassViewModelTests
         var typeArg = ds.Type.GenericArgumentsFor(typeof(IDataSource<>))?.Single();
         await Assert.That(typeArg?.ClassViewModel?.Name).IsEqualTo(nameof(AbstractImpl1));
     }
+
+    [Test]
+    public async Task ClientDataSources_TopLevelOpenGeneric_DiscoveredForConstraintAndDerivedTypes()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        // TopLevelAbstractModelDataSource<T> where T : AbstractModel is decorated with [Coalesce]
+        // and should be discovered for AbstractModel and all derived types.
+        var abstractVm = repo.GetClassViewModel<AbstractModel>()!;
+        var abstractSources = abstractVm.ClientDataSources(repo).ToList();
+        await Assert.That(abstractSources).Contains(ds => ds.Name == "TopLevelAbstractModelDataSource");
+
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var impl1Sources = impl1Vm.ClientDataSources(repo).ToList();
+        await Assert.That(impl1Sources).Contains(ds => ds.Name == "TopLevelAbstractModelDataSource");
+
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var impl2Sources = impl2Vm.ClientDataSources(repo).ToList();
+        await Assert.That(impl2Sources).Contains(ds => ds.Name == "TopLevelAbstractModelDataSource");
+    }
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using IntelliTect.Coalesce.Testing.TargetClasses;
 using IntelliTect.Coalesce.Testing.TargetClasses.TestDbContext;
 using IntelliTect.Coalesce.Testing.Util;
+using IntelliTect.Coalesce.TypeDefinition;
 
 namespace IntelliTect.Coalesce.Tests.TypeDefinition;
 
@@ -80,7 +81,7 @@ public class ClassViewModelTests
     }
 
     [Test]
-    public async Task ClientDataSources_ExcludesGenericAndAbstractNestedDataSources()
+    public async Task ClientDataSources_ExcludesAbstractNestedDataSources()
     {
         var repo = ReflectionRepositoryFactory.Reflection;
         var entityVm = repo.GetClassViewModel<Case>()!;
@@ -90,10 +91,69 @@ public class ClassViewModelTests
         // The concrete AllOpenCases should be discovered
         await Assert.That(dataSources).Contains(ds => ds.Name == nameof(Case.AllOpenCases));
 
-        // The open-generic GenericCaseDataSource<T> should NOT be discovered
-        await Assert.That(dataSources).DoesNotContain(ds => ds.Name == "GenericCaseDataSource");
-
         // The abstract AbstractCaseDataSource should NOT be discovered
         await Assert.That(dataSources).DoesNotContain(ds => ds.Name == nameof(Case.AbstractCaseDataSource));
+    }
+
+    [Test]
+    public async Task ClientDataSources_OpenGenericConstrainedToType_DiscoveredForBaseType()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        // GenericCaseDataSource<T> where T : Case is nested in Case and should appear for Case itself.
+        var caseVm = repo.GetClassViewModel<Case>()!;
+        var dataSources = caseVm.ClientDataSources(repo).ToList();
+        await Assert.That(dataSources).Contains(ds => ds.Name == "GenericCaseDataSource");
+
+        // AbstractModelDataSource<T> where T : AbstractModel should appear for AbstractModel.
+        var abstractVm = repo.GetClassViewModel<AbstractModel>()!;
+        var abstractDs = abstractVm.ClientDataSources(repo).ToList();
+        await Assert.That(abstractDs).Contains(ds => ds.Name == "AbstractModelDataSource");
+        await Assert.That(abstractDs).Contains(ds => ds.Name == "DefaultAbstractModelDataSource");
+    }
+
+    [Test]
+    public async Task ClientDataSources_OpenGenericConstrainedToBase_DiscoveredForDerivedTypes()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        // AbstractModelDataSource<T> and DefaultAbstractModelDataSource<T> are nested in AbstractModel.
+        // They should be available for derived types AbstractImpl1 and AbstractImpl2.
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var impl1Sources = impl1Vm.ClientDataSources(repo).ToList();
+        await Assert.That(impl1Sources).Contains(ds => ds.Name == "AbstractModelDataSource");
+        await Assert.That(impl1Sources).Contains(ds => ds.Name == "DefaultAbstractModelDataSource");
+
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var impl2Sources = impl2Vm.ClientDataSources(repo).ToList();
+        await Assert.That(impl2Sources).Contains(ds => ds.Name == "AbstractModelDataSource");
+        await Assert.That(impl2Sources).Contains(ds => ds.Name == "DefaultAbstractModelDataSource");
+    }
+
+    [Test]
+    public async Task ClientDataSources_OpenGenericDefault_IsDefaultForDerivedType()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var defaultSource = impl1Vm.ClientDataSources(repo).SingleOrDefault(ds => ds.IsDefaultDataSource);
+
+        await Assert.That(defaultSource).IsNotNull();
+        await Assert.That(defaultSource!.Name).IsEqualTo("DefaultAbstractModelDataSource");
+    }
+
+    [Test]
+    public async Task ClientDataSources_OpenGenericDerivedType_ClosedWithDerivedType()
+    {
+        var repo = ReflectionRepositoryFactory.Reflection;
+
+        // The closed generic type should be AbstractModel.AbstractModelDataSource<AbstractImpl1>,
+        // not AbstractModel.AbstractModelDataSource<AbstractModel>.
+        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
+        var impl1Sources = impl1Vm.ClientDataSources(repo).ToList();
+
+        var ds = impl1Sources.First(ds => ds.Name == "AbstractModelDataSource");
+        var typeArg = ds.Type.GenericArgumentsFor(typeof(IDataSource<>))?.Single();
+        await Assert.That(typeArg?.ClassViewModel?.Name).IsEqualTo(nameof(AbstractImpl1));
     }
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
@@ -118,12 +118,8 @@ public class ClassViewModelTests
         var repo = ReflectionRepositoryFactory.Reflection;
 
         // AbstractModelDataSource<T> and DefaultAbstractModelDataSource<T> are nested in AbstractModel.
-        // They should be available for derived types AbstractImpl1 and AbstractImpl2.
-        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
-        var impl1Sources = impl1Vm.ClientDataSources(repo).ToList();
-        await Assert.That(impl1Sources).Contains(ds => ds.Name == "AbstractModelDataSource");
-        await Assert.That(impl1Sources).Contains(ds => ds.Name == "DefaultAbstractModelDataSource");
-
+        // They should be available for derived types that don't override them.
+        // AbstractImpl1 overrides both, so use AbstractImpl2 which has no overrides.
         var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
         var impl2Sources = impl2Vm.ClientDataSources(repo).ToList();
         await Assert.That(impl2Sources).Contains(ds => ds.Name == "AbstractModelDataSource");
@@ -135,8 +131,9 @@ public class ClassViewModelTests
     {
         var repo = ReflectionRepositoryFactory.Reflection;
 
-        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
-        var defaultSource = impl1Vm.ClientDataSources(repo).SingleOrDefault(ds => ds.IsDefaultDataSource);
+        // AbstractImpl2 has no overrides, so it inherits the open generic default.
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var defaultSource = impl2Vm.ClientDataSources(repo).SingleOrDefault(ds => ds.IsDefaultDataSource);
 
         await Assert.That(defaultSource).IsNotNull();
         await Assert.That(defaultSource!.Name).IsEqualTo("DefaultAbstractModelDataSource");
@@ -147,14 +144,14 @@ public class ClassViewModelTests
     {
         var repo = ReflectionRepositoryFactory.Reflection;
 
-        // The closed generic type should be AbstractModel.AbstractModelDataSource<AbstractImpl1>,
+        // The closed generic type should be AbstractModel.AbstractModelDataSource<AbstractImpl2>,
         // not AbstractModel.AbstractModelDataSource<AbstractModel>.
-        var impl1Vm = repo.GetClassViewModel<AbstractImpl1>()!;
-        var impl1Sources = impl1Vm.ClientDataSources(repo).ToList();
+        var impl2Vm = repo.GetClassViewModel<AbstractImpl2>()!;
+        var impl2Sources = impl2Vm.ClientDataSources(repo).ToList();
 
-        var ds = impl1Sources.First(ds => ds.Name == "AbstractModelDataSource");
+        var ds = impl2Sources.First(ds => ds.Name == "AbstractModelDataSource");
         var typeArg = ds.Type.GenericArgumentsFor(typeof(IDataSource<>))?.Single();
-        await Assert.That(typeArg?.ClassViewModel?.Name).IsEqualTo(nameof(AbstractImpl1));
+        await Assert.That(typeArg?.ClassViewModel?.Name).IsEqualTo(nameof(AbstractImpl2));
     }
 
     [Test]

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -248,17 +248,28 @@ public abstract class ClassViewModel : IAttributeProvider
 
     /// <summary>
     /// Open generic nested types that could be inherited data sources.
-    /// Filtered to non-abstract and non-internal-use, but retaining generic types.
+    /// Filtered to non-abstract and non-internal-use, and only open (unconstructed) generics.
     /// </summary>
     internal IEnumerable<TypeViewModel> OpenGenericNestedTypes =>
-        RawNestedTypes.Where(t => !t.IsInternalUse && !t.IsAbstract && t.IsGeneric);
+        RawNestedTypes.Where(t => !t.IsInternalUse && !t.IsAbstract && t.IsGeneric && !t.IsConstructedGenericType);
 
-    public IEnumerable<ClassViewModel> ClientDataSources(ReflectionRepository repo) => repo
-        .DataSources
-        .Where(d => d.DeclaredFor.Equals(this))
-        .Select(d => d.StrategyClass)
-        .Concat(GetInheritedOpenGenericDataSources(repo))
-        .OrderBy(d => d.ClientTypeName);
+    public IEnumerable<ClassViewModel> ClientDataSources(ReflectionRepository repo)
+    {
+        var direct = repo
+            .DataSources
+            .Where(d => d.DeclaredFor.Equals(this))
+            .Select(d => d.StrategyClass)
+            .ToList();
+
+        var directNames = new HashSet<string>(direct.Select(d => d.ClientTypeName), StringComparer.OrdinalIgnoreCase);
+        var hasDirectDefault = direct.Any(d => d.IsDefaultDataSource);
+
+        return direct
+            .Concat(GetInheritedOpenGenericDataSources(repo)
+                .Where(d => !directNames.Contains(d.ClientTypeName)
+                    && !(hasDirectDefault && d.IsDefaultDataSource)))
+            .OrderBy(d => d.ClientTypeName);
+    }
 
     private IEnumerable<ClassViewModel> GetInheritedOpenGenericDataSources(ReflectionRepository repo)
     {

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -35,7 +35,7 @@ public abstract class ClassViewModel : IAttributeProvider
         Type = type;
     }
 
-    public abstract string Name { get; }
+    public virtual string Name => Type.Name;
     public abstract string? Comment { get; }
     public TypeViewModel Type { get; protected set; }
     public abstract bool IsStatic { get; }

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -264,10 +264,16 @@ public abstract class ClassViewModel : IAttributeProvider
         var directNames = new HashSet<string>(direct.Select(d => d.ClientTypeName), StringComparer.OrdinalIgnoreCase);
         var hasDirectDefault = direct.Any(d => d.IsDefaultDataSource);
 
+        var inherited = GetInheritedOpenGenericDataSources(repo)
+            .Where(d => !directNames.Contains(d.ClientTypeName)
+                && !(hasDirectDefault && d.IsDefaultDataSource))
+            // Deduplicate inherited sources by name (e.g. if multiple base classes
+            // in the hierarchy each declare an open generic with the same name,
+            // take only the first match which is the most derived constraint).
+            .DistinctBy(d => d.ClientTypeName);
+
         return direct
-            .Concat(GetInheritedOpenGenericDataSources(repo)
-                .Where(d => !directNames.Contains(d.ClientTypeName)
-                    && !(hasDirectDefault && d.IsDefaultDataSource)))
+            .Concat(inherited)
             .OrderBy(d => d.ClientTypeName);
     }
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -265,26 +265,11 @@ public abstract class ClassViewModel : IAttributeProvider
         foreach (var usage in repo.OpenGenericDataSources)
         {
             // Check if this type is the constraint type or is derived from it.
-            if (!IsAssignableTo(usage.ConstraintType)) continue;
+            if (!Type.IsA(usage.ConstraintType)) continue;
 
             var closed = usage.StrategyClass.Type.CloseWithTypeArgument(Type);
             if (closed?.ClassViewModel is { } cvm) yield return cvm;
         }
-    }
-
-    /// <summary>
-    /// Returns true if this type is the same as <paramref name="other"/> or is derived from it,
-    /// by walking the base type chain.
-    /// </summary>
-    private bool IsAssignableTo(ClassViewModel other)
-    {
-        var current = (TypeViewModel?)Type;
-        while (current is not null)
-        {
-            if (current.ClassViewModel?.Equals(other) == true) return true;
-            current = current.BaseType;
-        }
-        return false;
     }
 
     /// <summary>

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -265,7 +265,7 @@ public abstract class ClassViewModel : IAttributeProvider
         foreach (var usage in repo.OpenGenericDataSources)
         {
             // Check if this type is the constraint type or is derived from it.
-            if (!Type.IsA(usage.ConstraintType)) continue;
+            if (!Type.IsA(usage.ConstraintType.Type)) continue;
 
             var closed = usage.StrategyClass.Type.CloseWithTypeArgument(Type);
             if (closed?.ClassViewModel is { } cvm) yield return cvm;

--- a/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ClassViewModel.cs
@@ -246,11 +246,46 @@ public abstract class ClassViewModel : IAttributeProvider
     internal IEnumerable<TypeViewModel> ClientNestedTypes =>
         RawNestedTypes.Where(t => !t.IsInternalUse && !t.IsAbstract && !t.IsGeneric);
 
+    /// <summary>
+    /// Open generic nested types that could be inherited data sources.
+    /// Filtered to non-abstract and non-internal-use, but retaining generic types.
+    /// </summary>
+    internal IEnumerable<TypeViewModel> OpenGenericNestedTypes =>
+        RawNestedTypes.Where(t => !t.IsInternalUse && !t.IsAbstract && t.IsGeneric);
+
     public IEnumerable<ClassViewModel> ClientDataSources(ReflectionRepository repo) => repo
         .DataSources
         .Where(d => d.DeclaredFor.Equals(this))
         .Select(d => d.StrategyClass)
+        .Concat(GetInheritedOpenGenericDataSources(repo))
         .OrderBy(d => d.ClientTypeName);
+
+    private IEnumerable<ClassViewModel> GetInheritedOpenGenericDataSources(ReflectionRepository repo)
+    {
+        foreach (var usage in repo.OpenGenericDataSources)
+        {
+            // Check if this type is the constraint type or is derived from it.
+            if (!IsAssignableTo(usage.ConstraintType)) continue;
+
+            var closed = usage.StrategyClass.Type.CloseWithTypeArgument(Type);
+            if (closed?.ClassViewModel is { } cvm) yield return cvm;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if this type is the same as <paramref name="other"/> or is derived from it,
+    /// by walking the base type chain.
+    /// </summary>
+    private bool IsAssignableTo(ClassViewModel other)
+    {
+        var current = (TypeViewModel?)Type;
+        while (current is not null)
+        {
+            if (current.ClassViewModel?.Equals(other) == true) return true;
+            current = current.BaseType;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Returns a property matching the name if it exists.

--- a/src/IntelliTect.Coalesce/TypeDefinition/Helpers/SymbolExtensions.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Helpers/SymbolExtensions.cs
@@ -161,6 +161,16 @@ public static class SymbolExtensions
                 value = value.Substring(idx + 1);
                 see.ParentNode!.ReplaceChild(xmlDocumentation.CreateTextNode(value), see);
             }
+            foreach (var typeParamRef in xmlDocumentation.SelectNodes("//typeparamref")!.OfType<XmlNode>())
+            {
+                string value = typeParamRef.Attributes?["name"]?.Value ?? "";
+                typeParamRef.ParentNode!.ReplaceChild(xmlDocumentation.CreateTextNode(value), typeParamRef);
+            }
+            foreach (var paramRef in xmlDocumentation.SelectNodes("//paramref")!.OfType<XmlNode>())
+            {
+                string value = paramRef.Attributes?["name"]?.Value ?? "";
+                paramRef.ParentNode!.ReplaceChild(xmlDocumentation.CreateTextNode(value), paramRef);
+            }
             string summary = xmlDocumentation.SelectSingleNode("/member/summary")?.InnerText.Trim() ?? "";
             return Regex.Replace(summary, "\n( +)", "\n");
         }

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
@@ -25,7 +25,8 @@ public class ReflectionClassViewModel : ClassViewModel
             ?? new ReflectionClassViewModel(type);
     }
 
-    public override string Name => Info.Name;
+    // Strip generic arity suffix (e.g. `1) to match the behavior of ReflectionTypeViewModel.Name.
+    public override string Name => Info.Name.Replace("`1", "");
 
     public override string Comment => "";
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionClassViewModel.cs
@@ -25,9 +25,6 @@ public class ReflectionClassViewModel : ClassViewModel
             ?? new ReflectionClassViewModel(type);
     }
 
-    // Strip generic arity suffix (e.g. `1) to match the behavior of ReflectionTypeViewModel.Name.
-    public override string Name => Info.Name.Replace("`1", "");
-
     public override string Comment => "";
 
     public override bool IsStatic => Info.IsAbstract && Info.IsSealed;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
@@ -258,6 +258,32 @@ public class ReflectionTypeViewModel : TypeViewModel
 
     public override Type TypeInfo => Info;
 
+    public override TypeViewModel? OpenGenericSingleClassConstraint
+    {
+        get
+        {
+            if (!Info.IsGenericTypeDefinition) return null;
+            var typeParams = Info.GetGenericArguments();
+            if (typeParams.Length != 1) return null;
+
+            var classConstraints = typeParams[0].GetGenericParameterConstraints()
+                .Where(c => c.IsClass)
+                .ToList();
+            if (classConstraints.Count != 1) return null;
+
+            return GetOrCreate(ReflectionRepository, classConstraints[0]);
+        }
+    }
+
+    public override TypeViewModel? CloseWithTypeArgument(TypeViewModel typeArg)
+    {
+        if (!Info.IsGenericTypeDefinition || Info.GetGenericArguments().Length != 1) return null;
+        Type closedType;
+        try { closedType = Info.MakeGenericType(typeArg.TypeInfo); }
+        catch { return null; }
+        return GetOrCreate(ReflectionRepository, closedType);
+    }
+
     public override bool Equals(object? obj)
     {
         if (!(obj is ReflectionTypeViewModel that)) return base.Equals(obj);

--- a/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Reflection/ReflectionTypeViewModel.cs
@@ -92,6 +92,8 @@ public class ReflectionTypeViewModel : TypeViewModel
 
     public override bool IsGeneric => Info.IsGenericType;
 
+    public override bool IsConstructedGenericType => Info.IsConstructedGenericType;
+
     public override bool IsAbstract => Info.IsAbstract;
 
     public override bool IsArray => Info.IsArray;

--- a/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
@@ -226,6 +226,10 @@ public class ReflectionRepository
                 DiscoverOnApiBackedClass(entity.TypeViewModel.ClassViewModel!);
             }
         }
+        else if (TryAddOpenGenericDataSource(type))
+        {
+            // Handled by helper
+        }
         else if (AddCrudStrategy(typeof(IDataSource<>), type, _dataSources))
         {
             // Handled by helper
@@ -427,24 +431,25 @@ public class ReflectionRepository
         // These will be usable by this type and all of its derived types.
         foreach (var nestedType in model.OpenGenericNestedTypes)
         {
-            TryAddOpenGenericDataSource(nestedType, model);
+            TryAddOpenGenericDataSource(nestedType, declaredFor: model);
         }
     }
 
-    private void TryAddOpenGenericDataSource(TypeViewModel strategyType, ClassViewModel declaredFor)
+    private bool TryAddOpenGenericDataSource(TypeViewModel strategyType, ClassViewModel? declaredFor = null)
     {
-        if (strategyType.ClassViewModel is null) return;
-        if (!strategyType.IsA(typeof(IDataSource<>))) return;
+        if (strategyType.ClassViewModel is null) return false;
+        if (!strategyType.IsA(typeof(IDataSource<>))) return false;
 
         var constraint = strategyType.OpenGenericSingleClassConstraint;
-        if (constraint?.ClassViewModel is null) return;
+        if (constraint?.ClassViewModel is null) return false;
 
-        // The constraint type must be the same as the class this is nested in.
-        if (!constraint.ClassViewModel.Equals(declaredFor)) return;
+        // For nested types, require the constraint to match the declaring class.
+        // For top-level [Coalesce]-discovered types, the constraint type itself is the declared-for type.
+        if (declaredFor != null && !constraint.ClassViewModel.Equals(declaredFor)) return false;
 
-        _openGenericDataSources.Add(new OpenGenericDataSourceUsage(strategyType.ClassViewModel, declaredFor));
+        _openGenericDataSources.Add(new OpenGenericDataSourceUsage(strategyType.ClassViewModel, constraint.ClassViewModel));
 
-        // Discover any external types used as data source parameters on the constraint-closed version.
+        // Discover any external types used as data source parameters.
         if (strategyType.ClassViewModel.DataSourceParameters is { } parameters)
         {
             foreach (var parameter in parameters)
@@ -452,6 +457,8 @@ public class ReflectionRepository
                 ConditionallyAddAndDiscoverTypesOn(parameter);
             }
         }
+
+        return true;
     }
 
     public ClassViewModel? GetClassViewModel(Type classType) =>

--- a/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
@@ -230,6 +230,14 @@ public class ReflectionRepository
         {
             // Handled by helper
         }
+        else if (type.IsConstructedGenericType && type.IsA(typeof(IDataSource<>)))
+        {
+            // Constructed generic data sources (e.g. MyOpenSource<Foo>) are only ever
+            // produced by closing an open generic data source at query/codegen time.
+            // The open generic is already tracked in _openGenericDataSources and gets
+            // resolved on-demand per derived type, so we must not also register the
+            // constructed version in _dataSources, which would cause duplicates.
+        }
         else if (AddCrudStrategy(typeof(IDataSource<>), type, _dataSources))
         {
             // Handled by helper

--- a/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/ReflectionRepository.cs
@@ -23,6 +23,7 @@ public class ReflectionRepository
 
     private readonly ConcurrentHashSet<CrudStrategyTypeUsage> _behaviors = new();
     private readonly ConcurrentHashSet<CrudStrategyTypeUsage> _dataSources = new();
+    private readonly ConcurrentHashSet<OpenGenericDataSourceUsage> _openGenericDataSources = new();
     private readonly ConcurrentHashSet<ClassViewModel> _externalTypes = new();
     private readonly ConcurrentHashSet<ClassViewModel> _customDtos = new();
     private readonly ConcurrentHashSet<ClassViewModel> _services = new();
@@ -81,6 +82,7 @@ public class ReflectionRepository
     public ReadOnlyHashSet<ClassViewModel> Entities => new(_entities);
     public ReadOnlyHashSet<CrudStrategyTypeUsage> Behaviors => new(_behaviors);
     public ReadOnlyHashSet<CrudStrategyTypeUsage> DataSources => new(_dataSources);
+    public ReadOnlyHashSet<OpenGenericDataSourceUsage> OpenGenericDataSources => new(_openGenericDataSources);
     public ReadOnlyHashSet<ClassViewModel> ExternalTypes => new(_externalTypes);
     public ReadOnlyHashSet<ClassViewModel> CustomDtos => new(_customDtos);
     public ReadOnlyHashSet<ClassViewModel> Services => new(_services);
@@ -419,6 +421,36 @@ public class ReflectionRepository
         {
             AddCrudStrategy(typeof(IDataSource<>), nestedType, _dataSources, model);
             AddCrudStrategy(typeof(IBehaviors<>), nestedType, _behaviors, model);
+        }
+
+        // Also detect open generic data sources whose single type parameter is constrained to this type.
+        // These will be usable by this type and all of its derived types.
+        foreach (var nestedType in model.OpenGenericNestedTypes)
+        {
+            TryAddOpenGenericDataSource(nestedType, model);
+        }
+    }
+
+    private void TryAddOpenGenericDataSource(TypeViewModel strategyType, ClassViewModel declaredFor)
+    {
+        if (strategyType.ClassViewModel is null) return;
+        if (!strategyType.IsA(typeof(IDataSource<>))) return;
+
+        var constraint = strategyType.OpenGenericSingleClassConstraint;
+        if (constraint?.ClassViewModel is null) return;
+
+        // The constraint type must be the same as the class this is nested in.
+        if (!constraint.ClassViewModel.Equals(declaredFor)) return;
+
+        _openGenericDataSources.Add(new OpenGenericDataSourceUsage(strategyType.ClassViewModel, declaredFor));
+
+        // Discover any external types used as data source parameters on the constraint-closed version.
+        if (strategyType.ClassViewModel.DataSourceParameters is { } parameters)
+        {
+            foreach (var parameter in parameters)
+            {
+                ConditionallyAddAndDiscoverTypesOn(parameter);
+            }
         }
     }
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolClassViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolClassViewModel.cs
@@ -22,8 +22,6 @@ public class SymbolClassViewModel : ClassViewModel
         return (reflectionRepository ?? ReflectionRepository.Global).GetClassViewModel(symbol) as SymbolClassViewModel;
     }
 
-    public override string Name => Symbol.Name;
-
     public override string? Comment => Symbol.ExtractXmlComments();
 
     public override bool IsStatic => Symbol.IsStatic;

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
@@ -187,6 +187,29 @@ public class SymbolTypeViewModel : TypeViewModel
         return AssignableToLookup.Contains(type.Name);
     }
 
+    public override TypeViewModel? OpenGenericSingleClassConstraint
+    {
+        get
+        {
+            if (Symbol is not INamedTypeSymbol ns || ns.TypeParameters.Length != 1) return null;
+
+            var classConstraints = ns.TypeParameters[0].ConstraintTypes
+                .Where(c => c.TypeKind == TypeKind.Class)
+                .ToList();
+            if (classConstraints.Count != 1) return null;
+
+            return GetOrCreate(ReflectionRepository, classConstraints[0]);
+        }
+    }
+
+    public override TypeViewModel? CloseWithTypeArgument(TypeViewModel typeArg)
+    {
+        if (Symbol is not INamedTypeSymbol ns || ns.TypeParameters.Length != 1) return null;
+        if (typeArg is not SymbolTypeViewModel symbolTypeArg) return null;
+        var closed = ns.Construct(symbolTypeArg.Symbol);
+        return GetOrCreate(ReflectionRepository, closed);
+    }
+
     public override bool Equals(object? obj)
     {
         if (!(obj is SymbolTypeViewModel that)) return base.Equals(obj);

--- a/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/Symbol/SymbolTypeViewModel.cs
@@ -77,6 +77,10 @@ public class SymbolTypeViewModel : TypeViewModel
     public override bool IsGeneric =>
         Symbol is INamedTypeSymbol { IsGenericType: true, Arity: > 0 };
 
+    public override bool IsConstructedGenericType =>
+        Symbol is INamedTypeSymbol { IsGenericType: true, Arity: > 0 } ns
+        && !SymbolEqualityComparer.Default.Equals(ns, ns.OriginalDefinition);
+
     public override bool IsAbstract => Symbol.IsAbstract;
 
     public override string Name => Symbol.Name;
@@ -192,6 +196,8 @@ public class SymbolTypeViewModel : TypeViewModel
         get
         {
             if (Symbol is not INamedTypeSymbol ns || ns.TypeParameters.Length != 1) return null;
+            // Only consider the unbound generic type definition, not constructed generics.
+            if (!SymbolEqualityComparer.Default.Equals(ns, ns.OriginalDefinition)) return null;
 
             var classConstraints = ns.TypeParameters[0].ConstraintTypes
                 .Where(c => c.TypeKind == TypeKind.Class)
@@ -205,6 +211,7 @@ public class SymbolTypeViewModel : TypeViewModel
     public override TypeViewModel? CloseWithTypeArgument(TypeViewModel typeArg)
     {
         if (Symbol is not INamedTypeSymbol ns || ns.TypeParameters.Length != 1) return null;
+        if (!SymbolEqualityComparer.Default.Equals(ns, ns.OriginalDefinition)) return null;
         if (typeArg is not SymbolTypeViewModel symbolTypeArg) return null;
         var closed = ns.Construct(symbolTypeArg.Symbol);
         return GetOrCreate(ReflectionRepository, closed);

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -126,12 +126,12 @@ public abstract class TypeViewModel : IAttributeProvider
     /// Returns true if this type is the same as, or is derived from, <paramref name="other"/>,
     /// by walking the base type chain.
     /// </summary>
-    public bool IsA(ClassViewModel other)
+    public bool IsA(TypeViewModel other)
     {
         var current = (TypeViewModel?)this;
         while (current is not null)
         {
-            if (current.ClassViewModel?.Equals(other) == true) return true;
+            if (current.Equals(other)) return true;
             current = current.BaseType;
         }
         return false;

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -54,6 +54,13 @@ public abstract class TypeViewModel : IAttributeProvider
 
     public abstract bool IsGeneric { get; }
 
+    /// <summary>
+    /// True if this is a generic type that has been fully closed with concrete type arguments
+    /// (e.g. <c>List&lt;int&gt;</c>), as opposed to an open generic type definition
+    /// (e.g. <c>List&lt;&gt;</c>) or a non-generic type.
+    /// </summary>
+    public virtual bool IsConstructedGenericType => false;
+
     public abstract bool IsAbstract { get; }
 
     /// <summary>

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -123,6 +123,21 @@ public abstract class TypeViewModel : IAttributeProvider
     public bool IsA<T>() => IsA(typeof(T));
 
     /// <summary>
+    /// Returns true if this type is the same as, or is derived from, <paramref name="other"/>,
+    /// by walking the base type chain.
+    /// </summary>
+    public bool IsA(ClassViewModel other)
+    {
+        var current = (TypeViewModel?)this;
+        while (current is not null)
+        {
+            if (current.ClassViewModel?.Equals(other) == true) return true;
+            current = current.BaseType;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// For open generic types with exactly one type parameter that has a single class constraint,
     /// returns the <see cref="TypeViewModel"/> representing that class constraint.
     /// Returns <see langword="null"/> for all other types.

--- a/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/TypeViewModel.cs
@@ -123,6 +123,21 @@ public abstract class TypeViewModel : IAttributeProvider
     public bool IsA<T>() => IsA(typeof(T));
 
     /// <summary>
+    /// For open generic types with exactly one type parameter that has a single class constraint,
+    /// returns the <see cref="TypeViewModel"/> representing that class constraint.
+    /// Returns <see langword="null"/> for all other types.
+    /// </summary>
+    public virtual TypeViewModel? OpenGenericSingleClassConstraint => null;
+
+    /// <summary>
+    /// For open generic types with exactly one type parameter, returns a new closed
+    /// <see cref="TypeViewModel"/> with that parameter bound to <paramref name="typeArg"/>.
+    /// Returns <see langword="null"/> if the type is not a single-parameter open generic, or
+    /// if <paramref name="typeArg"/> is incompatible with the implementation.
+    /// </summary>
+    public virtual TypeViewModel? CloseWithTypeArgument(TypeViewModel typeArg) => null;
+
+    /// <summary>
     /// Convenient accessor for the represented System.Type when in reflection-based contexts.
     /// </summary>
     public virtual Type TypeInfo => throw new InvalidOperationException("TypeInfo not available in the current context");

--- a/src/IntelliTect.Coalesce/TypeUsage/OpenGenericDataSourceUsage.cs
+++ b/src/IntelliTect.Coalesce/TypeUsage/OpenGenericDataSourceUsage.cs
@@ -1,0 +1,21 @@
+using IntelliTect.Coalesce.TypeDefinition;
+
+namespace IntelliTect.Coalesce.TypeUsage;
+
+/// <summary>
+/// Represents an open generic data source class whose single type parameter
+/// is constrained to a specific entity type. The data source is usable for
+/// that entity type and all of its derived types.
+/// </summary>
+/// <param name="StrategyClass">
+/// The open generic <see cref="ClassViewModel"/> for the data source strategy class,
+/// e.g., the ClassViewModel representing <c>MyDataSource&lt;T&gt;</c>.
+/// </param>
+/// <param name="ConstraintType">
+/// The entity type that the data source's type parameter T is constrained to,
+/// e.g., <c>MyBase</c> in <c>where T : MyBase</c>.
+/// </param>
+public record OpenGenericDataSourceUsage(
+    ClassViewModel StrategyClass,
+    ClassViewModel ConstraintType
+);

--- a/src/test-targets/api-clients.g.ts
+++ b/src/test-targets/api-clients.g.ts
@@ -592,11 +592,6 @@ export class EnumPkApiClient extends ModelApiClient<$models.EnumPk> {
 }
 
 
-export class GenericNestedDsTargetApiClient extends ModelApiClient<$models.GenericNestedDsTarget> {
-  constructor() { super($metadata.GenericNestedDsTarget) }
-}
-
-
 export class MultipleParentsApiClient extends ModelApiClient<$models.MultipleParents> {
   constructor() { super($metadata.MultipleParents) }
 }

--- a/src/test-targets/metadata.g.ts
+++ b/src/test-targets/metadata.g.ts
@@ -333,10 +333,10 @@ export const AbstractImpl1 = domain.types.AbstractImpl1 = {
       props: {
       },
     },
-    defaultAbstractModelDataSource: {
+    impl1DefaultDataSource: {
       type: "dataSource",
-      name: "DefaultAbstractModelDataSource" as const,
-      displayName: "Default Abstract Model Data Source",
+      name: "Impl1DefaultDataSource" as const,
+      displayName: "Impl 1 Default Data Source",
       isDefault: true,
       props: {
       },

--- a/src/test-targets/metadata.g.ts
+++ b/src/test-targets/metadata.g.ts
@@ -326,6 +326,28 @@ export const AbstractImpl1 = domain.types.AbstractImpl1 = {
     },
   },
   dataSources: {
+    abstractModelDataSource: {
+      type: "dataSource",
+      name: "AbstractModelDataSource" as const,
+      displayName: "Abstract Model Data Source",
+      props: {
+      },
+    },
+    defaultAbstractModelDataSource: {
+      type: "dataSource",
+      name: "DefaultAbstractModelDataSource" as const,
+      displayName: "Default Abstract Model Data Source",
+      isDefault: true,
+      props: {
+      },
+    },
+    topLevelAbstractModelDataSource: {
+      type: "dataSource",
+      name: "TopLevelAbstractModelDataSource" as const,
+      displayName: "Top Level Abstract Model Data Source",
+      props: {
+      },
+    },
   },
 }
 export const AbstractImpl2 = domain.types.AbstractImpl2 = {
@@ -450,6 +472,28 @@ export const AbstractImpl2 = domain.types.AbstractImpl2 = {
     },
   },
   dataSources: {
+    abstractModelDataSource: {
+      type: "dataSource",
+      name: "AbstractModelDataSource" as const,
+      displayName: "Abstract Model Data Source",
+      props: {
+      },
+    },
+    defaultAbstractModelDataSource: {
+      type: "dataSource",
+      name: "DefaultAbstractModelDataSource" as const,
+      displayName: "Default Abstract Model Data Source",
+      isDefault: true,
+      props: {
+      },
+    },
+    topLevelAbstractModelDataSource: {
+      type: "dataSource",
+      name: "TopLevelAbstractModelDataSource" as const,
+      displayName: "Top Level Abstract Model Data Source",
+      props: {
+      },
+    },
   },
 }
 export const AbstractModel = domain.types.AbstractModel = {
@@ -570,6 +614,28 @@ export const AbstractModel = domain.types.AbstractModel = {
     },
   },
   dataSources: {
+    abstractModelDataSource: {
+      type: "dataSource",
+      name: "AbstractModelDataSource" as const,
+      displayName: "Abstract Model Data Source",
+      props: {
+      },
+    },
+    defaultAbstractModelDataSource: {
+      type: "dataSource",
+      name: "DefaultAbstractModelDataSource" as const,
+      displayName: "Default Abstract Model Data Source",
+      isDefault: true,
+      props: {
+      },
+    },
+    topLevelAbstractModelDataSource: {
+      type: "dataSource",
+      name: "TopLevelAbstractModelDataSource" as const,
+      displayName: "Top Level Abstract Model Data Source",
+      props: {
+      },
+    },
   },
 }
 export const AbstractModelPerson = domain.types.AbstractModelPerson = {
@@ -930,6 +996,13 @@ export const Case = domain.types.Case = {
           dateKind: "datetime",
           role: "value",
         },
+      },
+    },
+    genericCaseDataSource: {
+      type: "dataSource",
+      name: "GenericCaseDataSource" as const,
+      displayName: "Generic Case Data Source",
+      props: {
       },
     },
   },
@@ -3365,48 +3438,6 @@ export const EnumPk = domain.types.EnumPk = {
   methods: {
   },
   dataSources: {
-  },
-}
-export const GenericNestedDsTarget = domain.types.GenericNestedDsTarget = {
-  name: "GenericNestedDsTarget" as const,
-  displayName: "Generic Nested Ds Target",
-  get displayProp() { return this.props.id }, 
-  type: "model",
-  controllerRoute: "GenericNestedDsTarget",
-  get keyProp() { return this.props.id }, 
-  behaviorFlags: 7 as BehaviorFlags,
-  props: {
-    id: {
-      name: "id",
-      displayName: "Id",
-      type: "number",
-      role: "primaryKey",
-      hidden: 3 as HiddenAreas,
-    },
-    isActive: {
-      name: "isActive",
-      displayName: "Is Active",
-      type: "boolean",
-      role: "value",
-    },
-  },
-  methods: {
-  },
-  dataSources: {
-    defaultDs: {
-      type: "dataSource",
-      name: "DefaultDs" as const,
-      displayName: "Default Ds",
-      isDefault: true,
-      props: {
-        onlyActive: {
-          name: "onlyActive",
-          displayName: "Only Active",
-          type: "boolean",
-          role: "value",
-        },
-      },
-    },
   },
 }
 export const MultipleParents = domain.types.MultipleParents = {
@@ -6098,7 +6129,6 @@ interface AppDomain extends Domain {
     ExternalParentAsInputOnly: typeof ExternalParentAsInputOnly
     ExternalParentAsOutputOnly: typeof ExternalParentAsOutputOnly
     ExternalTypeWithDtoProp: typeof ExternalTypeWithDtoProp
-    GenericNestedDsTarget: typeof GenericNestedDsTarget
     InitRecordWithDefaultCtor: typeof InitRecordWithDefaultCtor
     InputOutputOnlyExternalTypeWithRequiredNonscalarProp: typeof InputOutputOnlyExternalTypeWithRequiredNonscalarProp
     Location: typeof Location

--- a/src/test-targets/models.g.ts
+++ b/src/test-targets/models.g.ts
@@ -86,6 +86,35 @@ export class AbstractModel {
     Object.assign(this, AbstractModel.map(data || {}));
   }
 }
+export namespace AbstractModel {
+  export namespace DataSources {
+    
+    /** 
+      An open generic data source constrained to AbstractModel.
+      Should be discovered for AbstractModel itself and all derived types (AbstractImpl1, AbstractImpl2).
+    */
+    export class AbstractModelDataSource implements DataSource<typeof metadata.AbstractModel.dataSources.abstractModelDataSource> {
+      readonly $metadata = metadata.AbstractModel.dataSources.abstractModelDataSource
+    }
+    
+    /** 
+      An open generic default data source constrained to AbstractModel.
+      Should be the default data source for AbstractModel and all derived types.
+    */
+    export class DefaultAbstractModelDataSource implements DataSource<typeof metadata.AbstractModel.dataSources.defaultAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractModel.dataSources.defaultAbstractModelDataSource
+    }
+    
+    /** 
+      A top-level open generic data source constrained to AbstractModel,
+      discovered via [Coalesce] attribute. Should be available for AbstractModel
+      itself and all derived types.
+    */
+    export class TopLevelAbstractModelDataSource implements DataSource<typeof metadata.AbstractModel.dataSources.topLevelAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractModel.dataSources.topLevelAbstractModelDataSource
+    }
+  }
+}
 
 
 export interface AbstractImpl1 extends Model<typeof metadata.AbstractImpl1> {
@@ -115,6 +144,35 @@ export class AbstractImpl1 {
     Object.assign(this, AbstractImpl1.map(data || {}));
   }
 }
+export namespace AbstractImpl1 {
+  export namespace DataSources {
+    
+    /** 
+      An open generic data source constrained to AbstractModel.
+      Should be discovered for AbstractModel itself and all derived types (AbstractImpl1, AbstractImpl2).
+    */
+    export class AbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.abstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl1.dataSources.abstractModelDataSource
+    }
+    
+    /** 
+      An open generic default data source constrained to AbstractModel.
+      Should be the default data source for AbstractModel and all derived types.
+    */
+    export class DefaultAbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.defaultAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl1.dataSources.defaultAbstractModelDataSource
+    }
+    
+    /** 
+      A top-level open generic data source constrained to AbstractModel,
+      discovered via [Coalesce] attribute. Should be available for AbstractModel
+      itself and all derived types.
+    */
+    export class TopLevelAbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.topLevelAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl1.dataSources.topLevelAbstractModelDataSource
+    }
+  }
+}
 
 
 export interface AbstractImpl2 extends Model<typeof metadata.AbstractImpl2> {
@@ -140,6 +198,35 @@ export class AbstractImpl2 {
   /** Instantiate a new AbstractImpl2, optionally basing it on the given data. */
   constructor(data?: Partial<AbstractImpl2> | {[k: string]: any}) {
     Object.assign(this, AbstractImpl2.map(data || {}));
+  }
+}
+export namespace AbstractImpl2 {
+  export namespace DataSources {
+    
+    /** 
+      An open generic data source constrained to AbstractModel.
+      Should be discovered for AbstractModel itself and all derived types (AbstractImpl1, AbstractImpl2).
+    */
+    export class AbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl2.dataSources.abstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl2.dataSources.abstractModelDataSource
+    }
+    
+    /** 
+      An open generic default data source constrained to AbstractModel.
+      Should be the default data source for AbstractModel and all derived types.
+    */
+    export class DefaultAbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl2.dataSources.defaultAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl2.dataSources.defaultAbstractModelDataSource
+    }
+    
+    /** 
+      A top-level open generic data source constrained to AbstractModel,
+      discovered via [Coalesce] attribute. Should be available for AbstractModel
+      itself and all derived types.
+    */
+    export class TopLevelAbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl2.dataSources.topLevelAbstractModelDataSource> {
+      readonly $metadata = metadata.AbstractImpl2.dataSources.topLevelAbstractModelDataSource
+    }
   }
 }
 
@@ -247,6 +334,10 @@ export namespace Case {
         if (params) Object.assign(this, params);
         return reactiveDataSource(this);
       }
+    }
+    
+    export class GenericCaseDataSource implements DataSource<typeof metadata.Case.dataSources.genericCaseDataSource> {
+      readonly $metadata = metadata.Case.dataSources.genericCaseDataSource
     }
   }
 }
@@ -593,46 +684,6 @@ export class EnumPk {
   /** Instantiate a new EnumPk, optionally basing it on the given data. */
   constructor(data?: Partial<EnumPk> | {[k: string]: any}) {
     Object.assign(this, EnumPk.map(data || {}));
-  }
-}
-
-
-export interface GenericNestedDsTarget extends Model<typeof metadata.GenericNestedDsTarget> {
-  id: number | null
-  isActive: boolean | null
-}
-export class GenericNestedDsTarget {
-  
-  /** Mutates the input object and its descendants into a valid GenericNestedDsTarget implementation. */
-  static convert(data?: Partial<GenericNestedDsTarget>): GenericNestedDsTarget {
-    return convertToModel<GenericNestedDsTarget>(data || {}, metadata.GenericNestedDsTarget) 
-  }
-  
-  /** Maps the input object and its descendants to a new, valid GenericNestedDsTarget implementation. */
-  static map(data?: Partial<GenericNestedDsTarget>): GenericNestedDsTarget {
-    return mapToModel<GenericNestedDsTarget>(data || {}, metadata.GenericNestedDsTarget) 
-  }
-  
-  static [Symbol.hasInstance](x: any) { return x?.$metadata === metadata.GenericNestedDsTarget; }
-  
-  /** Instantiate a new GenericNestedDsTarget, optionally basing it on the given data. */
-  constructor(data?: Partial<GenericNestedDsTarget> | {[k: string]: any}) {
-    Object.assign(this, GenericNestedDsTarget.map(data || {}));
-  }
-}
-export namespace GenericNestedDsTarget {
-  export namespace DataSources {
-    
-    /** Concrete datasource - SHOULD be discovered. */
-    export class DefaultDs implements DataSource<typeof metadata.GenericNestedDsTarget.dataSources.defaultDs> {
-      readonly $metadata = metadata.GenericNestedDsTarget.dataSources.defaultDs
-      onlyActive: boolean | null = null
-      
-      constructor(params?: Omit<Partial<DefaultDs>, '$metadata'>) {
-        if (params) Object.assign(this, params);
-        return reactiveDataSource(this);
-      }
-    }
   }
 }
 
@@ -1977,7 +2028,6 @@ declare module "coalesce-vue/lib/model" {
     ExternalParentAsInputOnly: ExternalParentAsInputOnly
     ExternalParentAsOutputOnly: ExternalParentAsOutputOnly
     ExternalTypeWithDtoProp: ExternalTypeWithDtoProp
-    GenericNestedDsTarget: GenericNestedDsTarget
     InitRecordWithDefaultCtor: InitRecordWithDefaultCtor
     InputOutputOnlyExternalTypeWithRequiredNonscalarProp: InputOutputOnlyExternalTypeWithRequiredNonscalarProp
     Location: Location

--- a/src/test-targets/models.g.ts
+++ b/src/test-targets/models.g.ts
@@ -147,20 +147,14 @@ export class AbstractImpl1 {
 export namespace AbstractImpl1 {
   export namespace DataSources {
     
-    /** 
-      An open generic data source constrained to AbstractModel.
-      Should be discovered for AbstractModel itself and all derived types (AbstractImpl1, AbstractImpl2).
-    */
+    /** Overrides the inherited open generic named "AbstractModelDataSource" for AbstractImpl1 only. */
     export class AbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.abstractModelDataSource> {
       readonly $metadata = metadata.AbstractImpl1.dataSources.abstractModelDataSource
     }
     
-    /** 
-      An open generic default data source constrained to AbstractModel.
-      Should be the default data source for AbstractModel and all derived types.
-    */
-    export class DefaultAbstractModelDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.defaultAbstractModelDataSource> {
-      readonly $metadata = metadata.AbstractImpl1.dataSources.defaultAbstractModelDataSource
+    /** Overrides the inherited open generic default data source for AbstractImpl1 only. */
+    export class Impl1DefaultDataSource implements DataSource<typeof metadata.AbstractImpl1.dataSources.impl1DefaultDataSource> {
+      readonly $metadata = metadata.AbstractImpl1.dataSources.impl1DefaultDataSource
     }
     
     /** 

--- a/src/test-targets/viewmodels.g.ts
+++ b/src/test-targets/viewmodels.g.ts
@@ -14,6 +14,7 @@ export interface AbstractImpl1ViewModel extends $models.AbstractImpl1 {
   set abstractModelPeople(value: (AbstractModelPersonViewModel | $models.AbstractModelPerson)[] | null);
 }
 export class AbstractImpl1ViewModel extends ViewModel<$models.AbstractImpl1, $apiClients.AbstractImpl1ApiClient, number> implements $models.AbstractImpl1  {
+  static DataSources = $models.AbstractImpl1.DataSources;
   
   
   public addToAbstractModelPeople(initialData?: DeepPartial<$models.AbstractModelPerson> | null) {
@@ -42,6 +43,7 @@ export class AbstractImpl1ViewModel extends ViewModel<$models.AbstractImpl1, $ap
 defineProps(AbstractImpl1ViewModel, $metadata.AbstractImpl1)
 
 export class AbstractImpl1ListViewModel extends ListViewModel<$models.AbstractImpl1, $apiClients.AbstractImpl1ApiClient, AbstractImpl1ViewModel> {
+  static DataSources = $models.AbstractImpl1.DataSources;
   
   public get getCount() {
     const getCount = this.$apiClient.$makeCaller(
@@ -79,6 +81,7 @@ export interface AbstractImpl2ViewModel extends $models.AbstractImpl2 {
   set abstractModelPeople(value: (AbstractModelPersonViewModel | $models.AbstractModelPerson)[] | null);
 }
 export class AbstractImpl2ViewModel extends ViewModel<$models.AbstractImpl2, $apiClients.AbstractImpl2ApiClient, number> implements $models.AbstractImpl2  {
+  static DataSources = $models.AbstractImpl2.DataSources;
   
   
   public addToAbstractModelPeople(initialData?: DeepPartial<$models.AbstractModelPerson> | null) {
@@ -107,6 +110,7 @@ export class AbstractImpl2ViewModel extends ViewModel<$models.AbstractImpl2, $ap
 defineProps(AbstractImpl2ViewModel, $metadata.AbstractImpl2)
 
 export class AbstractImpl2ListViewModel extends ListViewModel<$models.AbstractImpl2, $apiClients.AbstractImpl2ApiClient, AbstractImpl2ViewModel> {
+  static DataSources = $models.AbstractImpl2.DataSources;
   
   public get getCount() {
     const getCount = this.$apiClient.$makeCaller(
@@ -140,6 +144,7 @@ export type AbstractModelViewModel = AbstractImpl1ViewModel | AbstractImpl2ViewM
 export const AbstractModelViewModel = createAbstractProxyViewModelType<$models.AbstractModel, AbstractModelViewModel>($metadata.AbstractModel, $apiClients.AbstractModelApiClient)
 
 export class AbstractModelListViewModel extends ListViewModel<$models.AbstractModel, $apiClients.AbstractModelApiClient, AbstractModelViewModel> {
+  static DataSources = $models.AbstractModel.DataSources;
   
   public get getCount() {
     const getCount = this.$apiClient.$makeCaller(
@@ -1051,28 +1056,6 @@ export class EnumPkListViewModel extends ListViewModel<$models.EnumPk, $apiClien
 }
 
 
-export interface GenericNestedDsTargetViewModel extends $models.GenericNestedDsTarget {
-  id: number | null;
-  isActive: boolean | null;
-}
-export class GenericNestedDsTargetViewModel extends ViewModel<$models.GenericNestedDsTarget, $apiClients.GenericNestedDsTargetApiClient, number> implements $models.GenericNestedDsTarget  {
-  static DataSources = $models.GenericNestedDsTarget.DataSources;
-  
-  constructor(initialData?: DeepPartial<$models.GenericNestedDsTarget> | null) {
-    super($metadata.GenericNestedDsTarget, new $apiClients.GenericNestedDsTargetApiClient(), initialData)
-  }
-}
-defineProps(GenericNestedDsTargetViewModel, $metadata.GenericNestedDsTarget)
-
-export class GenericNestedDsTargetListViewModel extends ListViewModel<$models.GenericNestedDsTarget, $apiClients.GenericNestedDsTargetApiClient, GenericNestedDsTargetViewModel> {
-  static DataSources = $models.GenericNestedDsTarget.DataSources;
-  
-  constructor() {
-    super($metadata.GenericNestedDsTarget, new $apiClients.GenericNestedDsTargetApiClient())
-  }
-}
-
-
 export interface MultipleParentsViewModel extends $models.MultipleParents {
   id: number | null;
   parent1Id: number | null;
@@ -1915,7 +1898,6 @@ const viewModelTypeLookup = ViewModel.typeLookup = {
   DateTimeOffsetPk: DateTimeOffsetPkViewModel,
   DateTimePk: DateTimePkViewModel,
   EnumPk: EnumPkViewModel,
-  GenericNestedDsTarget: GenericNestedDsTargetViewModel,
   MultipleParents: MultipleParentsViewModel,
   OneToOneManyChildren: OneToOneManyChildrenViewModel,
   OneToOneParent: OneToOneParentViewModel,
@@ -1959,7 +1941,6 @@ const listViewModelTypeLookup = ListViewModel.typeLookup = {
   DateTimeOffsetPk: DateTimeOffsetPkListViewModel,
   DateTimePk: DateTimePkListViewModel,
   EnumPk: EnumPkListViewModel,
-  GenericNestedDsTarget: GenericNestedDsTargetListViewModel,
   MultipleParents: MultipleParentsListViewModel,
   OneToOneManyChildren: OneToOneManyChildrenListViewModel,
   OneToOneParent: OneToOneParentListViewModel,


### PR DESCRIPTION
## Summary

Allows open generic data sources nested in a base class — where the single type parameter is constrained to that base class — to be automatically usable for all derived entity types.

### Example

```csharp
public abstract class MyBase { ... }

// Nested inside MyBase:
public class MySource<T>(CrudContext<AppDbContext> ctx) : StandardDataSource<T, AppDbContext>(ctx)
    where T : MyBase;

[DefaultDataSource]
public class MyDefaultSource<T>(CrudContext<AppDbContext> ctx) : StandardDataSource<T, AppDbContext>(ctx)
    where T : MyBase;
```

`MySource` and `MyDefaultSource` are now automatically available for `MyBase` and all derived types, both as named and default data sources.

## How It Works

- **Discovery**: `ReflectionRepository.DiscoverNestedCrudStrategiesOn` detects open generic nested types whose single type parameter is constrained to the declaring class, and registers them in a new `_openGenericDataSources` collection.
- **Resolution**: `ClassViewModel.ClientDataSources` iterates the registered open generic sources, checks if the queried type is assignable to the constraint type, and closes the generic with the concrete entity type.
- **New abstractions**: `TypeViewModel.OpenGenericSingleClassConstraint` and `CloseWithTypeArgument` virtual methods implemented for both `ReflectionTypeViewModel` (reflection APIs) and `SymbolTypeViewModel` (Roslyn APIs).
- **Bug fix**: `ReflectionClassViewModel.Name` now strips generic arity suffix (`` `1``) consistent with `ReflectionTypeViewModel.Name`, fixing name lookup for generic data source types.

## Changes

- `ReflectionRepository.cs` — discovery of open generic datasources  
- `ClassViewModel.cs` — `ClientDataSources` includes inherited open generic sources  
- `TypeViewModel.cs` / `ReflectionTypeViewModel.cs` / `SymbolTypeViewModel.cs` — new generic closing abstractions  
- `ReflectionClassViewModel.cs` — fix `Name` to strip arity suffix  
- `OpenGenericDataSourceUsage.cs` — new record type  
- Test data in `AbstractModel.cs` and new/updated tests