### PR TITLE
feat: add adminExtensions option with tableToolbarActions extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,19 @@
 
 ## Features
 
-- API callers (`ItemApiState`, `ListApiState`) are now awaitable. `await caller` now resolves to `caller.result` after the current or previous operation is completed.
-  - `await vm.$load(1)` - performs a new load call and waits for completion.
-  - `await vm.$load` - waits for completion of the pending load operation, or immediately resolves with the last result if no operation is pending.
+- Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library to reduce boilerplate duplication in projects.
+- Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type or global extension components to be injected into admin pages. Supported extension points: `tableToolbarActions`, `editorToolbarActions`, `editorActions`, `tableRowActions`, `tablePageHeader`, and `editorPageHeader`. Each corresponding component also exposes a slot for conventional per-instance customization.
+- Open generic data sources whose single type parameter is constrained to a base class are now automatically available as data sources for that base class and all derived entity types.
+- API callers (`ItemApiState`, `ListApiState`) are now awaitable. `await caller` now resolves to `caller.result` after the current operation is complete, or resolves immediately to the previous result if no operation is in progress.
 - `useAppUpdateCheck` now also listens for Vite's `vite:preloadError` event, showing the update notification when dynamic imports fail due to stale chunks after a deployment.
 - `useAppUpdateCheck` now persists the observed build in `sessionStorage` (keyed by a fingerprint of loaded script URLs), enabling detection of server updates after a browser discards and restores a tab from cached HTML.
-- `c-datetime-picker`: Assorted UI and UX improvements and fixes.
-- Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type (or global `"*"`) extension components to be injected into admin pages. Supported extension points: `tableToolbarActions`, `editorToolbarActions`, `editorActions`, `tableRowActions`, `tablePageHeader`, and `editorPageHeader`. Each corresponding component also exposes a slot for conventional per-instance customization.
-
 - Added `returnViewModel` prop to `c-select`, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
-- Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library.
-- Open generic data sources whose single type parameter is constrained to a base class are now automatically available as data sources for that base class and all derived entity types. This works for both default and named data sources, and applies whether the data source is nested in the base class or declared as a top-level type with `[Coalesce]`.
+- `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 - Added `headerComment` generator configuration option to emit custom comments at the start of all generated files. Supports cascading hierarchical configuration—define on a parent generator and child generators automatically inherit the value.
 
 ## Template Changes
-- Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project:
+- Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project that doesn't diverge significantly from the previous out-of-the-box Coalesce template tenancy behavior:
   1. Add the package `IntelliTect.Coalesce.MultiTenancy`
   2. In `OnConfiguring`, replace `.AddInterceptors(new TenantInterceptor())` with:
      ```cs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `useAppUpdateCheck` now also listens for Vite's `vite:preloadError` event, showing the update notification when dynamic imports fail due to stale chunks after a deployment.
 - `useAppUpdateCheck` now persists the observed build in `sessionStorage` (keyed by a fingerprint of loaded script URLs), enabling detection of server updates after a browser discards and restores a tab from cached HTML.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
-- Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type (or global `"*"`) extension components to be injected into admin pages. The first supported extension point is `tableToolbarActions`, which renders a custom component after the built-in buttons in `c-admin-table-toolbar`. Also added a `toolbar-actions` slot to `c-admin-table-toolbar` for conventional per-instance customization.
+- Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type (or global `"*"`) extension components to be injected into admin pages. Supported extension points: `tableToolbarActions`, `editorToolbarActions`, `editorActions`, `tableRowActions`, `tablePageHeader`, and `editorPageHeader`. Each corresponding component also exposes a slot for conventional per-instance customization.
 
 - Added `returnViewModel` prop to `c-select`, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - `await vm.$load(1)` - performs a new load call and waits for completion
   - `await vm.$load` - waits for completion of the pending load operation, or immediately resolves with the last result if no operation is pending.
 - `useAppUpdateCheck` now also listens for Vite's `vite:preloadError` event, showing the update notification when dynamic imports fail due to stale chunks after a deployment.
+- Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type (or global `"*"`) extension components to be injected into admin pages. The first supported extension point is `tableToolbarActions`, which renders a custom component after the built-in buttons in `c-admin-table-toolbar`. Also added a `toolbar-actions` slot to `c-admin-table-toolbar` for conventional per-instance customization.
 
 # 6.6.0
 - Added `returnViewModel` prop to `c-select`, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -124,7 +124,7 @@ const coalesceVuetify = createCoalesceVuetify({
 | [c-admin-method](/stacks/vue/coalesce-vue-vuetify/components/c-admin-method.md) — method return value | — | ✅ Replaces `c-admin-display` |
 | [c-table](/stacks/vue/coalesce-vue-vuetify/components/c-table.md) with `admin` prop — columns | ✅ Replaces `c-input` (editable mode) | ✅ Replaces `c-admin-display` |
 
-### Custom input component
+### Input overrides
 
 A custom input component is rendered in place of `c-input`. It receives `model` and `for` props, plus any extra props that the admin surface passes (e.g. `density`, `variant`). The `for` prop is the resolved metadata value for the overridden surface: for editable model fields this is a `Property`, and for method parameters it is a `Value` metadata object, not a string:
 
@@ -153,7 +153,7 @@ const props = defineProps<{
 </script>
 ```
 
-### Custom display component
+### Display overrides
 
 A custom display component is rendered in place of `c-admin-display` or `c-display`. It always receives a `modelValue` prop containing the property's current value, plus `model` and `for` props when rendering a model property (in `c-admin-editor` and `c-table`).
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -226,16 +226,33 @@ const coalesceVuetify = createCoalesceVuetify({
 
 | Field | Surface | Props | Description |
 |---|---|---|---|
-| `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | `list: ListViewModel` | Component rendered after the built-in buttons (Create, Reload, Edit) |
-| `editorToolbarActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor toolbar, before Save/Delete/Reload |
-| `editorActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor's footer actions area |
-| `tableRowActions` | [c-admin-table](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table.md) | `model: ViewModel`, `list: ListViewModel` | Component rendered in each row's actions column, before the built-in Edit/Delete buttons |
+| `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | `list: ListViewModel`, `editable: boolean \| null` | Component rendered after the built-in buttons (Create, Reload, Edit) |
+| `editorToolbarActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel`, `editable: boolean` | Component rendered in the editor toolbar, before Save/Delete/Reload |
+| `editorActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel`, `editable: boolean` | Component rendered in the editor's footer actions area |
+| `tableRowActions` | [c-admin-table](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table.md) | `model: ViewModel`, `list: ListViewModel`, `editable: boolean` | Component rendered in each row's actions column, before the built-in Edit/Delete buttons |
 | `tablePageHeader` | [c-admin-table-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-page.md) | `list: ListViewModel` | Component rendered before the table |
 | `editorPageHeader` | [c-admin-editor-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor-page.md) | `model: ViewModel` | Component rendered before the editor |
 
 ### Resolution order
 
 When resolving an extension, a type-specific entry (e.g. `$metadata.types.Case`) takes precedence over `"*"`. If neither is found, nothing is rendered.
+
+Extension components can be lazy-loaded with `defineAsyncComponent` to keep the main bundle small:
+
+```ts
+import { defineAsyncComponent } from "vue";
+
+const coalesceVuetify = createCoalesceVuetify({
+  metadata: $metadata,
+  adminExtensions: [
+    [$metadata.types.Case, {
+      tableToolbarActions: defineAsyncComponent(
+        () => import("@/components/CaseToolbarActions.vue")
+      ),
+    }],
+  ],
+});
+```
 
 ## Replacing Admin Pages
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -197,11 +197,9 @@ const statusConfig = computed(() => {
 
 ## Extending Admin Pages
 
-Beyond replacing individual input/display components, you can inject additional content into admin page components on a per-type basis using `adminExtensions`. This follows the same array-of-pairs pattern as `adminOverrides`, but is keyed by model type (or `"*"` for a global default) rather than by individual property.
+You can inject additional content into admin page components on a per-type basis using `adminExtensions`. Pass an array of `[key, extension]` pairs to `createCoalesceVuetify()`, where the key is either a model type from `$metadata` or `"*"` for a global default.
 
 ### Configuration
-
-Pass an `adminExtensions` option to `createCoalesceVuetify()`. It accepts an array of `[key, extension]` pairs, where the key is either a model type from your generated `$metadata` or the string `"*"` for a global default, and the extension is an object with optional component fields for different admin surfaces.
 
 ```ts
 import { createCoalesceVuetify } from 'coalesce-vue-vuetify3';
@@ -237,15 +235,11 @@ const coalesceVuetify = createCoalesceVuetify({
 
 ### Resolution order
 
-When resolving an extension for a model type, the lookup checks:
-1. An exact type match (e.g. `$metadata.types.Case`)
-2. The `"*"` global default
-
-If neither is found, nothing is rendered. A type-specific entry always takes precedence over `"*"`.
+When resolving an extension, a type-specific entry (e.g. `$metadata.types.Case`) takes precedence over `"*"`. If neither is found, nothing is rendered.
 
 ## Replacing Admin Pages
 
-The [Customizing Admin Components](#customizing-admin-components) section above lets you swap individual input/display components within the standard admin pages. If you need to go further — replacing an entire admin page with a fully custom view for a specific model type — you can do so via the router.
+If the above customization and extension options aren't enough, you can replace an entire admin page with a fully custom view for a specific model type via the router.
 
 Because vue-router matches routes in order, placing type-specific routes before the generic `coalesce-admin-list` / `coalesce-admin-item` catch-all routes causes them to be used for that type while all others continue using the default admin pages. You can also use this technique to attach route-level metadata, such as required permissions, to specific types.
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -237,31 +237,6 @@ const coalesceVuetify = createCoalesceVuetify({
 | `tablePageHeader` | [c-admin-table-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-page.md) | `list: ListViewModel` | Component rendered before the table |
 | `editorPageHeader` | [c-admin-editor-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor-page.md) | `model: ViewModel` | Component rendered before the editor |
 
-### Extension component props
-
-A `tableToolbarActions` extension component receives a `list` prop containing the `ListViewModel` for the current admin table:
-
-```vue
-<template>
-  <v-btn variant="text" @click="exportData">
-    <v-icon start>fa fa-download</v-icon>
-    <span class="hidden-sm-and-down">Export</span>
-  </v-btn>
-</template>
-
-<script setup lang="ts">
-import { ListViewModel } from 'coalesce-vue';
-
-const props = defineProps<{
-  list: ListViewModel;
-}>();
-
-function exportData() {
-  // Use props.list.$params, props.list.$items, etc.
-}
-</script>
-```
-
 ### Resolution order
 
 When resolving an extension for a model type, the lookup checks:

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -228,9 +228,14 @@ const coalesceVuetify = createCoalesceVuetify({
 
 ### Extension fields
 
-| Field | Surface | Description |
-|---|---|---|
-| `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | Component rendered after the built-in buttons (Create, Reload, Edit) |
+| Field | Surface | Props | Description |
+|---|---|---|---|
+| `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | `list: ListViewModel` | Component rendered after the built-in buttons (Create, Reload, Edit) |
+| `editorToolbarActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor toolbar, before Save/Delete/Reload |
+| `editorActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor's footer actions area |
+| `tableRowActions` | [c-admin-table](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table.md) | `model: ViewModel`, `list: ListViewModel` | Component rendered in each row's actions column, after the built-in Edit/Delete buttons |
+| `tablePageHeader` | [c-admin-table-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-page.md) | `list: ListViewModel` | Component rendered before the table |
+| `editorPageHeader` | [c-admin-editor-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor-page.md) | `model: ViewModel` | Component rendered before the editor |
 
 ### Extension component props
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -197,7 +197,7 @@ const statusConfig = computed(() => {
 </script>
 ```
 
-## Extending Admin Pages Per Type
+## Extending Admin Pages
 
 Beyond replacing individual input/display components, you can inject additional content into admin page components on a per-type basis using `adminExtensions`. This follows the same array-of-pairs pattern as `adminOverrides`, but is keyed by model type (or `"*"` for a global default) rather than by individual property.
 
@@ -245,7 +245,7 @@ When resolving an extension for a model type, the lookup checks:
 
 If neither is found, nothing is rendered. A type-specific entry always takes precedence over `"*"`.
 
-## Replacing Admin Pages Per Type
+## Replacing Admin Pages
 
 The [Customizing Admin Components](#customizing-admin-components) section above lets you swap individual input/display components within the standard admin pages. If you need to go further — replacing an entire admin page with a fully custom view for a specific model type — you can do so via the router.
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -233,7 +233,7 @@ const coalesceVuetify = createCoalesceVuetify({
 | `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | `list: ListViewModel` | Component rendered after the built-in buttons (Create, Reload, Edit) |
 | `editorToolbarActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor toolbar, before Save/Delete/Reload |
 | `editorActions` | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) | `model: ViewModel` | Component rendered in the editor's footer actions area |
-| `tableRowActions` | [c-admin-table](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table.md) | `model: ViewModel`, `list: ListViewModel` | Component rendered in each row's actions column, after the built-in Edit/Delete buttons |
+| `tableRowActions` | [c-admin-table](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table.md) | `model: ViewModel`, `list: ListViewModel` | Component rendered in each row's actions column, before the built-in Edit/Delete buttons |
 | `tablePageHeader` | [c-admin-table-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-page.md) | `list: ListViewModel` | Component rendered before the table |
 | `editorPageHeader` | [c-admin-editor-page](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor-page.md) | `model: ViewModel` | Component rendered before the editor |
 

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -115,8 +115,6 @@ const coalesceVuetify = createCoalesceVuetify({
 });
 ```
 
-### Where overrides apply
-
 | Surface | Input override | Display override |
 |---|---|---|
 | [c-admin-editor](/stacks/vue/coalesce-vue-vuetify/components/c-admin-editor.md) — editable properties | ✅ Replaces `c-input` | ✅ Replaces `c-admin-display` (read-only mode) |

--- a/docs/stacks/vue/admin-pages.md
+++ b/docs/stacks/vue/admin-pages.md
@@ -197,6 +197,74 @@ const statusConfig = computed(() => {
 </script>
 ```
 
+## Extending Admin Pages Per Type
+
+Beyond replacing individual input/display components, you can inject additional content into admin page components on a per-type basis using `adminExtensions`. This follows the same array-of-pairs pattern as `adminOverrides`, but is keyed by model type (or `"*"` for a global default) rather than by individual property.
+
+### Configuration
+
+Pass an `adminExtensions` option to `createCoalesceVuetify()`. It accepts an array of `[key, extension]` pairs, where the key is either a model type from your generated `$metadata` or the string `"*"` for a global default, and the extension is an object with optional component fields for different admin surfaces.
+
+```ts
+import { createCoalesceVuetify } from 'coalesce-vue-vuetify3';
+import $metadata from '@/metadata.g';
+import MyCaseToolbarActions from '@/components/MyCaseToolbarActions.vue';
+import MyGlobalToolbarActions from '@/components/MyGlobalToolbarActions.vue';
+
+const coalesceVuetify = createCoalesceVuetify({
+  metadata: $metadata,
+  adminExtensions: [
+    // Global default for all types without a specific override
+    ["*", {
+      tableToolbarActions: MyGlobalToolbarActions,
+    }],
+    // Type-specific override (takes precedence over "*")
+    [$metadata.types.Case, {
+      tableToolbarActions: MyCaseToolbarActions,
+    }],
+  ],
+});
+```
+
+### Extension fields
+
+| Field | Surface | Description |
+|---|---|---|
+| `tableToolbarActions` | [c-admin-table-toolbar](/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md) | Component rendered after the built-in buttons (Create, Reload, Edit) |
+
+### Extension component props
+
+A `tableToolbarActions` extension component receives a `list` prop containing the `ListViewModel` for the current admin table:
+
+```vue
+<template>
+  <v-btn variant="text" @click="exportData">
+    <v-icon start>fa fa-download</v-icon>
+    <span class="hidden-sm-and-down">Export</span>
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { ListViewModel } from 'coalesce-vue';
+
+const props = defineProps<{
+  list: ListViewModel;
+}>();
+
+function exportData() {
+  // Use props.list.$params, props.list.$items, etc.
+}
+</script>
+```
+
+### Resolution order
+
+When resolving an extension for a model type, the lookup checks:
+1. An exact type match (e.g. `$metadata.types.Case`)
+2. The `"*"` global default
+
+If neither is found, nothing is rendered. A type-specific entry always takes precedence over `"*"`.
+
 ## Replacing Admin Pages Per Type
 
 The [Customizing Admin Components](#customizing-admin-components) section above lets you swap individual input/display components within the standard admin pages. If you need to go further — replacing an entire admin page with a fully custom view for a specific model type — you can do so via the router.

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
@@ -31,5 +31,22 @@ The [color](https://vuetifyjs.com/en/styles/colors/) of the toolbar.
 
 If provided, adds a button to toggle editing state. Should be two-way bound with v-model.
 
+## Slots
+
+<Prop def="#toolbar-actions" lang="ts" />
+
+Slot for injecting custom content after the built-in toolbar buttons (Create, Reload, Edit). Receives `{ list: ListViewModel }` as scoped slot props. When provided, this slot replaces any component configured via [`adminExtensions`](/stacks/vue/admin-pages.md#extending-admin-pages-per-type).
+
+``` vue-html
+<c-admin-table-toolbar :list="personList">
+  <template #toolbar-actions="{ list }">
+    <v-btn variant="text" @click="doSomething(list)">
+      <v-icon start>fa fa-download</v-icon>
+      Export
+    </v-btn>
+  </template>
+</c-admin-table-toolbar>
+```
+
 
 

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
@@ -35,7 +35,7 @@ If provided, adds a button to toggle editing state. Should be two-way bound with
 
 <Prop def="#toolbar-actions" lang="ts" />
 
-Slot for injecting custom content after the built-in toolbar buttons (Create, Reload, Edit). Receives `{ list: ListViewModel }` as scoped slot props. When provided, this slot replaces any component configured via [`adminExtensions`](/stacks/vue/admin-pages.md#extending-admin-pages-per-type).
+Slot for injecting custom content after the built-in toolbar buttons (Create, Reload, Edit). Receives `{ list: ListViewModel }` as scoped slot props. When provided, this slot replaces any component configured via [`adminExtensions`](/stacks/vue/admin-pages.md#extending-admin-pages).
 
 ``` vue-html
 <c-admin-table-toolbar :list="personList">

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-admin-table-toolbar.md
@@ -35,7 +35,7 @@ If provided, adds a button to toggle editing state. Should be two-way bound with
 
 <Prop def="#toolbar-actions" lang="ts" />
 
-Slot for injecting custom content after the built-in toolbar buttons (Create, Reload, Edit). Receives `{ list: ListViewModel }` as scoped slot props. When provided, this slot replaces any component configured via [`adminExtensions`](/stacks/vue/admin-pages.md#extending-admin-pages).
+Slot for injecting custom content after the built-in toolbar buttons (Create, Reload, Edit). Receives `{ list: ListViewModel, editable: boolean | null }` as scoped slot props. When provided, this slot replaces any component configured via [`adminExtensions`](/stacks/vue/admin-pages.md#extending-admin-pages).
 
 ``` vue-html
 <c-admin-table-toolbar :list="personList">

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorActions.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-btn variant="tonal" color="info" @click="onClick">
+    <v-icon start>fa fa-envelope</v-icon>
+    Send Email
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { ViewModel } from "coalesce-vue";
+
+const props = defineProps<{ model: ViewModel }>();
+
+function onClick() {
+  alert(`Send email to ${props.model.$display}`);
+}
+</script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorActions.vue
@@ -1,16 +1,15 @@
 <template>
-  <v-btn variant="tonal" color="info" @click="onClick">
-    <v-icon start>fa fa-envelope</v-icon>
-    Send Email
+  <v-btn variant="text" prepend-icon="fa fa-envelope" @click="onClick">
+    <span class="hidden-sm-and-down">Send Email</span>
   </v-btn>
 </template>
 
 <script setup lang="ts">
 import { ViewModel } from "coalesce-vue";
 
-const props = defineProps<{ model: ViewModel }>();
+const props = defineProps<{ model: ViewModel; editable: boolean }>();
 
 function onClick() {
-  alert(`Send email to ${props.model.$display}`);
+  alert(`Send email to ${props.model.$display()}`);
 }
 </script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorPageHeader.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorPageHeader.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-alert type="warning" variant="tonal" density="compact" class="mb-4">
+    Editing person record. Changes are auto-saved.
+  </v-alert>
+</template>
+
+<script setup lang="ts">
+import { ViewModel } from "coalesce-vue";
+
+defineProps<{ model: ViewModel }>();
+</script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorToolbarActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorToolbarActions.vue
@@ -1,16 +1,15 @@
 <template>
-  <v-btn size="small" variant="outlined" color="warning" @click="onClick">
-    <v-icon start>fa fa-archive</v-icon>
-    Archive
+  <v-btn variant="text" prepend-icon="fa fa-archive" @click="onClick">
+    <span class="hidden-sm-and-down">Archive</span>
   </v-btn>
 </template>
 
 <script setup lang="ts">
 import { ViewModel } from "coalesce-vue";
 
-const props = defineProps<{ model: ViewModel }>();
+const props = defineProps<{ model: ViewModel; editable: boolean }>();
 
 function onClick() {
-  alert(`Archive ${props.model.$display}`);
+  alert(`Archive ${props.model.$display()}`);
 }
 </script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorToolbarActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonEditorToolbarActions.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-btn size="small" variant="outlined" color="warning" @click="onClick">
+    <v-icon start>fa fa-archive</v-icon>
+    Archive
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { ViewModel } from "coalesce-vue";
+
+const props = defineProps<{ model: ViewModel }>();
+
+function onClick() {
+  alert(`Archive ${props.model.$display}`);
+}
+</script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTablePageHeader.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTablePageHeader.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+    Manage all people in the system. Use the toolbar actions to export or filter.
+  </v-alert>
+</template>
+
+<script setup lang="ts">
+import { ListViewModel } from "coalesce-vue";
+
+defineProps<{ list: ListViewModel }>();
+</script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTablePageHeader.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTablePageHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <v-alert type="info" variant="tonal" density="compact" class="mb-4">
-    Manage all people in the system. Use the toolbar actions to export or filter.
+    Manage all people in the system. Use the toolbar to export or filter.
   </v-alert>
 </template>
 

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableRowActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableRowActions.vue
@@ -1,15 +1,19 @@
 <template>
-  <v-btn size="x-small" variant="text" color="info" @click="onClick">
-    <v-icon>fa fa-eye</v-icon>
+  <v-btn variant="text" icon title="Quick View" @click="onClick">
+    <i aria-hidden="true" class="v-icon notranslate fa fa-eye"></i>
   </v-btn>
 </template>
 
 <script setup lang="ts">
 import { ViewModel, ListViewModel } from "coalesce-vue";
 
-const props = defineProps<{ model: ViewModel; list: ListViewModel }>();
+const props = defineProps<{
+  model: ViewModel;
+  list: ListViewModel;
+  editable: boolean;
+}>();
 
 function onClick() {
-  alert(`Quick view: ${props.model.$display}`);
+  alert(`Quick view: ${props.model.$display()}`);
 }
 </script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableRowActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableRowActions.vue
@@ -1,0 +1,15 @@
+<template>
+  <v-btn size="x-small" variant="text" color="info" @click="onClick">
+    <v-icon>fa fa-eye</v-icon>
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { ViewModel, ListViewModel } from "coalesce-vue";
+
+const props = defineProps<{ model: ViewModel; list: ListViewModel }>();
+
+function onClick() {
+  alert(`Quick view: ${props.model.$display}`);
+}
+</script>

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableToolbarActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableToolbarActions.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-btn size="small" variant="outlined" color="secondary" @click="onClick">
+  <v-btn variant="text" @click="onClick">
     <v-icon start>fa fa-download</v-icon>
-    Export
+    <span class="hidden-sm-and-down">Export</span>
   </v-btn>
 </template>
 
 <script setup lang="ts">
 import { ListViewModel } from "coalesce-vue";
 
-const props = defineProps<{ list: ListViewModel }>();
+const props = defineProps<{ list: ListViewModel; editable: boolean | null }>();
 
 function onClick() {
   alert(`Export ${props.list.$items.length} items`);

--- a/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableToolbarActions.vue
+++ b/playground/Coalesce.Web.Vue3/src/admin-extensions/PersonTableToolbarActions.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-btn size="small" variant="outlined" color="secondary" @click="onClick">
+    <v-icon start>fa fa-download</v-icon>
+    Export
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { ListViewModel } from "coalesce-vue";
+
+const props = defineProps<{ list: ListViewModel }>();
+
+function onClick() {
+  alert(`Export ${props.list.$items.length} items`);
+}
+</script>

--- a/playground/Coalesce.Web.Vue3/src/main.ts
+++ b/playground/Coalesce.Web.Vue3/src/main.ts
@@ -7,7 +7,7 @@ import "@fortawesome/fontawesome-free/css/all.css";
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
 
-import { createApp } from "vue";
+import { createApp, defineAsyncComponent } from "vue";
 import { createVuetify } from "vuetify";
 import { aliases, fa } from "vuetify/iconsets/fa";
 
@@ -122,12 +122,14 @@ const coalesceVuetify = createCoalesceVuetify({
     [
       $metadata.types.Person,
       {
-        tableToolbarActions: PersonTableToolbarActions,
         editorToolbarActions: PersonEditorToolbarActions,
         editorActions: PersonEditorActions,
+        editorPageHeader: defineAsyncComponent(
+          () => import("@/admin-extensions/PersonEditorPageHeader.vue"),
+        ),
+        tableToolbarActions: PersonTableToolbarActions,
         tableRowActions: PersonTableRowActions,
         tablePageHeader: PersonTablePageHeader,
-        editorPageHeader: PersonEditorPageHeader,
       },
     ],
   ],

--- a/playground/Coalesce.Web.Vue3/src/main.ts
+++ b/playground/Coalesce.Web.Vue3/src/main.ts
@@ -34,7 +34,6 @@ import PersonEditorToolbarActions from "@/admin-extensions/PersonEditorToolbarAc
 import PersonEditorActions from "@/admin-extensions/PersonEditorActions.vue";
 import PersonTableRowActions from "@/admin-extensions/PersonTableRowActions.vue";
 import PersonTablePageHeader from "@/admin-extensions/PersonTablePageHeader.vue";
-import PersonEditorPageHeader from "@/admin-extensions/PersonEditorPageHeader.vue";
 
 import testWorker from "./worker.ts?worker";
 import Examples from "./components/Examples.vue";

--- a/playground/Coalesce.Web.Vue3/src/main.ts
+++ b/playground/Coalesce.Web.Vue3/src/main.ts
@@ -29,6 +29,13 @@ import $metadata from "@/metadata.g";
 import CaseStatusInput from "@/admin-overrides/CaseStatusInput.vue";
 import CaseStatusDisplay from "@/admin-overrides/CaseStatusDisplay.vue";
 
+import PersonTableToolbarActions from "@/admin-extensions/PersonTableToolbarActions.vue";
+import PersonEditorToolbarActions from "@/admin-extensions/PersonEditorToolbarActions.vue";
+import PersonEditorActions from "@/admin-extensions/PersonEditorActions.vue";
+import PersonTableRowActions from "@/admin-extensions/PersonTableRowActions.vue";
+import PersonTablePageHeader from "@/admin-extensions/PersonTablePageHeader.vue";
+import PersonEditorPageHeader from "@/admin-extensions/PersonEditorPageHeader.vue";
+
 import testWorker from "./worker.ts?worker";
 import Examples from "./components/Examples.vue";
 new testWorker();
@@ -109,6 +116,19 @@ const coalesceVuetify = createCoalesceVuetify({
     [
       $metadata.types.Case.props.status,
       { input: CaseStatusInput, display: CaseStatusDisplay },
+    ],
+  ],
+  adminExtensions: [
+    [
+      $metadata.types.Person,
+      {
+        tableToolbarActions: PersonTableToolbarActions,
+        editorToolbarActions: PersonEditorToolbarActions,
+        editorActions: PersonEditorActions,
+        tableRowActions: PersonTableRowActions,
+        tablePageHeader: PersonTablePageHeader,
+        editorPageHeader: PersonEditorPageHeader,
+      },
     ],
   ],
 });

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.spec.tsx
@@ -1,0 +1,119 @@
+import { CAdminEditorPage } from "..";
+import "@test-targets/viewmodels.g"; // registers ViewModel.typeLookup
+import $metadata from "@test-targets/metadata.g";
+import { defineComponent, h } from "vue";
+import { mockEndpoint, mountWithCoalesceOptions } from "@test/util";
+
+describe("CAdminEditorPage", () => {
+  beforeEach(() => {
+    mockEndpoint("/Person/get/1", () => ({
+      wasSuccessful: true,
+      object: { personId: 1, firstName: "Alice", lastName: "A" },
+    }));
+  });
+
+  describe("adminExtensions - editorPageHeader", () => {
+    test("renders editorPageHeader extension", () => {
+      const HeaderExtension = defineComponent({
+        name: "EditorPageHeader",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () =>
+            h("div", { class: "editor-page-header-ext" }, "editor header");
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminEditorPage type="Person" id={1} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { editorPageHeader: HeaderExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".editor-page-header-ext").exists()).toBeTruthy();
+      expect(wrapper.find(".editor-page-header-ext").text()).toBe(
+        "editor header",
+      );
+    });
+
+    test("editorPageHeader extension receives model prop", () => {
+      let receivedModel: any = null;
+
+      const HeaderExtension = defineComponent({
+        name: "HeaderPropsInspector",
+        props: { model: { type: Object, required: true } },
+        setup(props) {
+          receivedModel = props.model;
+          return () => h("div", { class: "header-props-ext" });
+        },
+      });
+
+      mountWithCoalesceOptions(
+        () => <CAdminEditorPage type="Person" id={1} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { editorPageHeader: HeaderExtension }],
+          ],
+        },
+      );
+
+      expect(receivedModel).not.toBeNull();
+      expect(receivedModel.$metadata.name).toBe("Person");
+    });
+
+    test("global '*' editorPageHeader renders when no type-specific override", () => {
+      const GlobalHeaderExtension = defineComponent({
+        name: "GlobalEditorPageHeader",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () =>
+            h("div", { class: "global-editor-header-ext" }, "global");
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminEditorPage type="Person" id={1} />,
+        undefined,
+        {
+          adminExtensions: [["*", { editorPageHeader: GlobalHeaderExtension }]],
+        },
+      );
+
+      expect(wrapper.find(".global-editor-header-ext").exists()).toBeTruthy();
+    });
+
+    test("page-header slot replaces extension component", () => {
+      const ExtensionComponent = defineComponent({
+        name: "ShouldNotRender",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "extension-component" });
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => (
+          <CAdminEditorPage type="Person" id={1}>
+            {{
+              "page-header": () =>
+                h("div", { class: "slot-content" }, "Custom Header"),
+            }}
+          </CAdminEditorPage>
+        ),
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { editorPageHeader: ExtensionComponent }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".slot-content").exists()).toBeTruthy();
+      expect(wrapper.find(".extension-component").exists()).toBeFalsy();
+    });
+  });
+});

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.vue
@@ -1,5 +1,13 @@
 <template>
   <v-container class="c-admin-editor-page" :class="'type-' + metadata.name">
+    <slot name="page-header" :model="viewModel">
+      <component
+        :is="editorPageHeaderExtension"
+        v-if="editorPageHeaderExtension"
+        :model="viewModel"
+      />
+    </slot>
+
     <c-admin-editor
       class="c-admin-editor-page--editor"
       tag="section"
@@ -34,6 +42,7 @@ import { computed, watch, getCurrentInstance } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { isPropReadOnly } from "../../util";
 import { copyParamsToNewViewModel } from "./util";
+import { useAdminExtensions } from "../../composables/useAdminExtensions";
 
 defineOptions({
   name: "c-admin-editor-page",
@@ -107,6 +116,11 @@ const metadata = computed((): ModelType => {
   }
   throw `No metadata available.`;
 });
+
+const { resolveEditorPageHeader } = useAdminExtensions();
+const editorPageHeaderExtension = computed(() =>
+  resolveEditorPageHeader(metadata.value),
+);
 
 const isCreate = computed(() => {
   return !viewModel!.$primaryKey;

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor-page.vue
@@ -117,9 +117,9 @@ const metadata = computed((): ModelType => {
   throw `No metadata available.`;
 });
 
-const { resolveEditorPageHeader } = useAdminExtensions();
+const { resolve } = useAdminExtensions();
 const editorPageHeaderExtension = computed(() =>
-  resolveEditorPageHeader(metadata.value),
+  resolve(metadata.value, "editorPageHeader"),
 );
 
 const isCreate = computed(() => {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
@@ -267,7 +267,10 @@ describe("CAdminEditor", () => {
         undefined,
         {
           adminExtensions: [
-            [$metadata.types.Person, { editorToolbarActions: ToolbarExtension }],
+            [
+              $metadata.types.Person,
+              { editorToolbarActions: ToolbarExtension },
+            ],
           ],
         },
       );
@@ -318,9 +321,7 @@ describe("CAdminEditor", () => {
         () => <CAdminEditor model={vm} />,
         undefined,
         {
-          adminExtensions: [
-            ["*", { editorToolbarActions: GlobalExtension }],
-          ],
+          adminExtensions: [["*", { editorToolbarActions: GlobalExtension }]],
         },
       );
 

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
@@ -247,4 +247,84 @@ describe("CAdminEditor", () => {
     expect(row.find(".custom-admin-input").exists()).toBeTruthy();
     expect(row.find(".custom-admin-display").exists()).toBeTruthy();
   });
+
+  describe("adminExtensions", () => {
+    test("renders editorToolbarActions extension", () => {
+      const vm = new PersonViewModel();
+      vm.$loadCleanData({ personId: 1, firstName: "Bob" });
+      vm.$load.wasSuccessful = true;
+
+      const ToolbarExtension = defineComponent({
+        name: "ToolbarExtension",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "editor-toolbar-ext" }, "toolbar ext");
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminEditor model={vm} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { editorToolbarActions: ToolbarExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".editor-toolbar-ext").exists()).toBeTruthy();
+    });
+
+    test("renders editorActions extension in card-actions", () => {
+      const vm = new PersonViewModel();
+      vm.$loadCleanData({ personId: 1, firstName: "Bob" });
+      vm.$load.wasSuccessful = true;
+
+      const ActionsExtension = defineComponent({
+        name: "ActionsExtension",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "editor-actions-ext" }, "actions ext");
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminEditor model={vm} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { editorActions: ActionsExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".editor-actions-ext").exists()).toBeTruthy();
+    });
+
+    test("global '*' extension renders when no type-specific override", () => {
+      const vm = new PersonViewModel();
+      vm.$loadCleanData({ personId: 1, firstName: "Bob" });
+      vm.$load.wasSuccessful = true;
+
+      const GlobalExtension = defineComponent({
+        name: "GlobalToolbar",
+        props: { model: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "global-editor-ext" }, "global");
+        },
+      });
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminEditor model={vm} />,
+        undefined,
+        {
+          adminExtensions: [
+            ["*", { editorToolbarActions: GlobalExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".global-editor-ext").exists()).toBeTruthy();
+    });
+  });
 });

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.spec.tsx
@@ -12,6 +12,17 @@ import { defineComponent, h } from "vue";
 import { mockEndpoint, mount, mountWithCoalesceOptions } from "@test/util";
 
 describe("CAdminEditor", () => {
+  beforeEach(() => {
+    mockEndpoint("/Person/list", () => ({
+      wasSuccessful: true,
+      list: [],
+    }));
+    mockEndpoint("/Company/list", () => ({
+      wasSuccessful: true,
+      list: [],
+    }));
+  });
+
   test("types", () => {
     const model = new Person();
     const vm = new PersonViewModel();
@@ -326,6 +337,68 @@ describe("CAdminEditor", () => {
       );
 
       expect(wrapper.find(".global-editor-ext").exists()).toBeTruthy();
+    });
+
+    test("editorToolbarActions extension receives model and editable props", () => {
+      const vm = new PersonViewModel();
+      vm.$loadCleanData({ personId: 1, firstName: "Bob" });
+      vm.$load.wasSuccessful = true;
+
+      let receivedModel: any = null;
+      let receivedEditable: any = undefined;
+
+      const ToolbarExtension = defineComponent({
+        name: "ToolbarPropsInspector",
+        props: {
+          model: { type: Object, required: true },
+          editable: { type: Boolean, required: true },
+        },
+        setup(props) {
+          receivedModel = props.model;
+          receivedEditable = props.editable;
+          return () => h("div", { class: "toolbar-props-ext" });
+        },
+      });
+
+      mountWithCoalesceOptions(() => <CAdminEditor model={vm} />, undefined, {
+        adminExtensions: [
+          [$metadata.types.Person, { editorToolbarActions: ToolbarExtension }],
+        ],
+      });
+
+      expect(receivedModel).toBe(vm);
+      expect(typeof receivedEditable).toBe("boolean");
+    });
+
+    test("editorActions extension receives model and editable props", () => {
+      const vm = new PersonViewModel();
+      vm.$loadCleanData({ personId: 1, firstName: "Bob" });
+      vm.$load.wasSuccessful = true;
+
+      let receivedModel: any = null;
+      let receivedEditable: any = undefined;
+
+      const ActionsExtension = defineComponent({
+        name: "ActionsPropsInspector",
+        props: {
+          model: { type: Object, required: true },
+          editable: { type: Boolean, required: true },
+        },
+        setup(props) {
+          receivedModel = props.model;
+          receivedEditable = props.editable;
+          return () => h("div", { class: "actions-props-ext" });
+        },
+      });
+
+      mountWithCoalesceOptions(() => <CAdminEditor model={vm} />, undefined, {
+        adminExtensions: [
+          [$metadata.types.Person, { editorActions: ActionsExtension }],
+        ],
+      });
+
+      expect(receivedModel).toBe(vm);
+      expect(typeof receivedEditable).toBe("boolean");
     });
   });
 });

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
@@ -270,8 +270,7 @@ const emit = defineEmits<{
 const form = useTemplateRef("form");
 const { resolveAdminInputComponent, resolveAdminDisplayComponent } =
   useAdminOverrides();
-const { resolveEditorToolbarActions, resolveEditorActions } =
-  useAdminExtensions();
+const { resolve } = useAdminExtensions();
 
 // Validate the form when it is rendered to trigger all validation messages.
 // This will either be immediate for a create scenario, or delayed until load for an edit.
@@ -329,10 +328,10 @@ const metadata = computed((): ModelType => {
 });
 
 const editorToolbarActionsExtension = computed(() =>
-  resolveEditorToolbarActions(metadata.value),
+  resolve(metadata.value, "editorToolbarActions"),
 );
 const editorActionsExtension = computed(() =>
-  resolveEditorActions(metadata.value),
+  resolve(metadata.value, "editorActions"),
 );
 
 const showContent = computed(() => {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
@@ -22,11 +22,12 @@
       </v-toolbar-title>
 
       <v-spacer></v-spacer>
-      <slot name="toolbar-actions" :model="model">
+      <slot name="toolbar-actions" :model="model" :editable="canEdit">
         <component
           :is="editorToolbarActionsExtension"
           v-if="editorToolbarActionsExtension"
           :model="model"
+          :editable="canEdit"
         />
       </slot>
       <v-btn
@@ -180,14 +181,15 @@
     </v-card-text>
 
     <v-card-actions v-if="canEdit && showContent">
-      <slot name="editor-actions" :model="model">
+      <v-spacer></v-spacer>
+      <slot name="editor-actions" :model="model" :editable="canEdit">
         <component
           :is="editorActionsExtension"
           v-if="editorActionsExtension"
           :model="model"
+          :editable="canEdit"
         />
       </slot>
-      <v-spacer></v-spacer>
       <v-btn
         v-if="!model.$isAutoSaveEnabled"
         title="Save"

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
@@ -22,6 +22,13 @@
       </v-toolbar-title>
 
       <v-spacer></v-spacer>
+      <slot name="toolbar-actions" :model="model">
+        <component
+          :is="editorToolbarActionsExtension"
+          v-if="editorToolbarActionsExtension"
+          :model="model"
+        />
+      </slot>
       <v-btn
         v-if="!model.$isAutoSaveEnabled && showContent && canEdit"
         title="Save"
@@ -173,6 +180,13 @@
     </v-card-text>
 
     <v-card-actions v-if="canEdit && showContent">
+      <slot name="editor-actions" :model="model">
+        <component
+          :is="editorActionsExtension"
+          v-if="editorActionsExtension"
+          :model="model"
+        />
+      </slot>
       <v-spacer></v-spacer>
       <v-btn
         v-if="!model.$isAutoSaveEnabled"
@@ -228,6 +242,7 @@ import {
 import { getRefNavRoute } from "./util";
 import { isPropReadOnly } from "../../util";
 import { useAdminOverrides } from "../../composables/useAdminOverrides";
+import { useAdminExtensions } from "../../composables/useAdminExtensions";
 import { watch, computed, useTemplateRef, ref, onUnmounted } from "vue";
 
 defineOptions({
@@ -255,6 +270,8 @@ const emit = defineEmits<{
 const form = useTemplateRef("form");
 const { resolveAdminInputComponent, resolveAdminDisplayComponent } =
   useAdminOverrides();
+const { resolveEditorToolbarActions, resolveEditorActions } =
+  useAdminExtensions();
 
 // Validate the form when it is rendered to trigger all validation messages.
 // This will either be immediate for a create scenario, or delayed until load for an edit.
@@ -310,6 +327,13 @@ const metadata = computed((): ModelType => {
   }
   throw `No metadata available.`;
 });
+
+const editorToolbarActionsExtension = computed(() =>
+  resolveEditorToolbarActions(metadata.value),
+);
+const editorActionsExtension = computed(() =>
+  resolveEditorActions(metadata.value),
+);
 
 const showContent = computed(() => {
   const model = props.model;

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.spec.tsx
@@ -1,0 +1,131 @@
+import { CAdminTablePage } from "..";
+import { PersonListViewModel } from "@test-targets/viewmodels.g";
+import $metadata from "@test-targets/metadata.g";
+import { defineComponent, h } from "vue";
+import { mockEndpoint, mountWithCoalesceOptions } from "@test/util";
+
+describe("CAdminTablePage", () => {
+  beforeEach(() => {
+    mockEndpoint("/Person/list", () => ({
+      wasSuccessful: true,
+      list: [],
+      page: 1,
+      pageCount: 0,
+      pageSize: 10,
+      totalCount: 0,
+    }));
+  });
+
+  describe("adminExtensions - tablePageHeader", () => {
+    test("renders tablePageHeader extension", async () => {
+      const HeaderExtension = defineComponent({
+        name: "TablePageHeader",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () =>
+            h("div", { class: "table-page-header-ext" }, "page header");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTablePage list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tablePageHeader: HeaderExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".table-page-header-ext").exists()).toBeTruthy();
+      expect(wrapper.find(".table-page-header-ext").text()).toBe("page header");
+    });
+
+    test("tablePageHeader extension receives list prop", async () => {
+      let receivedList: any = null;
+
+      const HeaderExtension = defineComponent({
+        name: "HeaderPropsInspector",
+        props: { list: { type: Object, required: true } },
+        setup(props) {
+          receivedList = props.list;
+          return () => h("div", { class: "header-props-ext" });
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      mountWithCoalesceOptions(
+        () => <CAdminTablePage list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tablePageHeader: HeaderExtension }],
+          ],
+        },
+      );
+
+      expect(receivedList).toBe(list);
+    });
+
+    test("global '*' tablePageHeader renders when no type-specific override", async () => {
+      const GlobalHeaderExtension = defineComponent({
+        name: "GlobalTablePageHeader",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "global-table-header-ext" }, "global");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTablePage list={list} />,
+        undefined,
+        {
+          adminExtensions: [["*", { tablePageHeader: GlobalHeaderExtension }]],
+        },
+      );
+
+      expect(wrapper.find(".global-table-header-ext").exists()).toBeTruthy();
+    });
+
+    test("page-header slot replaces extension component", async () => {
+      const ExtensionComponent = defineComponent({
+        name: "ShouldNotRender",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "extension-component" });
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => (
+          <CAdminTablePage list={list}>
+            {{
+              "page-header": () =>
+                h("div", { class: "slot-content" }, "Custom Header"),
+            }}
+          </CAdminTablePage>
+        ),
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tablePageHeader: ExtensionComponent }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".slot-content").exists()).toBeTruthy();
+      expect(wrapper.find(".extension-component").exists()).toBeFalsy();
+    });
+  });
+});

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.vue
@@ -4,6 +4,14 @@
     class="c-admin-table-page"
     :class="'type-' + metadata.name"
   >
+    <slot name="page-header" :list="listVM">
+      <component
+        :is="tablePageHeaderExtension"
+        v-if="tablePageHeaderExtension"
+        :list="listVM"
+      />
+    </slot>
+
     <c-admin-table
       class="c-admin-table-page--table"
       tag="section"
@@ -29,6 +37,7 @@
 <script lang="ts" setup>
 import { computed, PropType, Ref, ref, watch } from "vue";
 import { HiddenAreas, ListViewModel, ModelType } from "coalesce-vue";
+import { useAdminExtensions } from "../../composables/useAdminExtensions";
 
 const props = defineProps({
   type: { required: false, type: String, default: null },
@@ -79,6 +88,11 @@ const metadata = computed((): ModelType => {
 
   throw `No metadata available - no list provided, and couldn't create one.`;
 });
+
+const { resolveTablePageHeader } = useAdminExtensions();
+const tablePageHeaderExtension = computed(() =>
+  resolveTablePageHeader(metadata.value),
+);
 
 /** Support for common convention of exposing 'pageTitle' from router-view hosted components. */
 const pageTitle = computed(() => {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-page.vue
@@ -89,9 +89,9 @@ const metadata = computed((): ModelType => {
   throw `No metadata available - no list provided, and couldn't create one.`;
 });
 
-const { resolveTablePageHeader } = useAdminExtensions();
+const { resolve } = useAdminExtensions();
 const tablePageHeaderExtension = computed(() =>
-  resolveTablePageHeader(metadata.value),
+  resolve(metadata.value, "tablePageHeader"),
 );
 
 /** Support for common convention of exposing 'pageTitle' from router-view hosted components. */

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
@@ -2,11 +2,7 @@ import { CAdminTableToolbar } from "..";
 import { PersonListViewModel } from "@test-targets/viewmodels.g";
 import $metadata from "@test-targets/metadata.g";
 import { defineComponent, h } from "vue";
-import {
-  mockEndpoint,
-  mount,
-  mountWithCoalesceOptions,
-} from "@test/util";
+import { mockEndpoint, mount, mountWithCoalesceOptions } from "@test/util";
 
 describe("CAdminTableToolbar", () => {
   beforeEach(() => {
@@ -39,14 +35,15 @@ describe("CAdminTableToolbar", () => {
         undefined,
         {
           adminExtensions: [
-            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+            [
+              $metadata.types.Person,
+              { tableToolbarActions: ExtensionComponent },
+            ],
           ],
         },
       );
 
-      expect(
-        wrapper.find(".person-toolbar-extension").exists(),
-      ).toBeTruthy();
+      expect(wrapper.find(".person-toolbar-extension").exists()).toBeTruthy();
       expect(wrapper.find(".person-toolbar-extension").text()).toBe(
         "Person Actions",
       );
@@ -69,15 +66,11 @@ describe("CAdminTableToolbar", () => {
         () => <CAdminTableToolbar list={list} />,
         undefined,
         {
-          adminExtensions: [
-            ["*", { tableToolbarActions: GlobalExtension }],
-          ],
+          adminExtensions: [["*", { tableToolbarActions: GlobalExtension }]],
         },
       );
 
-      expect(
-        wrapper.find(".global-toolbar-extension").exists(),
-      ).toBeTruthy();
+      expect(wrapper.find(".global-toolbar-extension").exists()).toBeTruthy();
     });
 
     test("type-specific override takes precedence over global '*'", async () => {
@@ -122,9 +115,7 @@ describe("CAdminTableToolbar", () => {
       const wrapper = mount(() => <CAdminTableToolbar list={list} />);
 
       // Toolbar should still render normally without extensions
-      expect(
-        wrapper.find(".c-admin-table-toolbar").exists(),
-      ).toBeTruthy();
+      expect(wrapper.find(".c-admin-table-toolbar").exists()).toBeTruthy();
     });
 
     test("extension component receives list prop", async () => {
@@ -147,7 +138,10 @@ describe("CAdminTableToolbar", () => {
         undefined,
         {
           adminExtensions: [
-            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+            [
+              $metadata.types.Person,
+              { tableToolbarActions: ExtensionComponent },
+            ],
           ],
         },
       );
@@ -181,7 +175,10 @@ describe("CAdminTableToolbar", () => {
         undefined,
         {
           adminExtensions: [
-            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+            [
+              $metadata.types.Person,
+              { tableToolbarActions: ExtensionComponent },
+            ],
           ],
         },
       );

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
@@ -120,12 +120,17 @@ describe("CAdminTableToolbar", () => {
 
     test("extension component receives list prop", async () => {
       let receivedList: any = null;
+      let receivedEditable: any = undefined;
 
       const ExtensionComponent = defineComponent({
         name: "ListInspector",
-        props: { list: { type: Object, required: true } },
+        props: {
+          list: { type: Object, required: true },
+          editable: { default: null },
+        },
         setup(props) {
           receivedList = props.list;
+          receivedEditable = props.editable;
           return () => h("div", { class: "list-inspector" });
         },
       });
@@ -147,6 +152,7 @@ describe("CAdminTableToolbar", () => {
       );
 
       expect(receivedList).toBe(list);
+      expect(receivedEditable).toBeNull();
     });
   });
 

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
@@ -6,7 +6,6 @@ import {
   mockEndpoint,
   mount,
   mountWithCoalesceOptions,
-  flushPromises,
 } from "@test/util";
 
 describe("CAdminTableToolbar", () => {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
@@ -126,7 +126,7 @@ describe("CAdminTableToolbar", () => {
         name: "ListInspector",
         props: {
           list: { type: Object, required: true },
-          editable: { default: null },
+          editable: { type: Boolean, default: null },
         },
         setup(props) {
           receivedList = props.list;
@@ -211,6 +211,26 @@ describe("CAdminTableToolbar", () => {
       ));
 
       expect(slotList).toBe(list);
+    });
+
+    test("slot receives editable as scoped slot prop", async () => {
+      let slotEditable: any = undefined;
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      mount(() => (
+        <CAdminTableToolbar list={list}>
+          {{
+            "toolbar-actions": (props: any) => {
+              slotEditable = props.editable;
+              return h("div", { class: "slot-content" });
+            },
+          }}
+        </CAdminTableToolbar>
+      ));
+
+      expect(slotEditable).toBeNull();
     });
   });
 });

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.spec.tsx
@@ -1,0 +1,214 @@
+import { CAdminTableToolbar } from "..";
+import { PersonListViewModel } from "@test-targets/viewmodels.g";
+import $metadata from "@test-targets/metadata.g";
+import { defineComponent, h } from "vue";
+import {
+  mockEndpoint,
+  mount,
+  mountWithCoalesceOptions,
+  flushPromises,
+} from "@test/util";
+
+describe("CAdminTableToolbar", () => {
+  beforeEach(() => {
+    mockEndpoint("/Person/list", () => ({
+      wasSuccessful: true,
+      list: [],
+      page: 1,
+      pageCount: 0,
+      pageSize: 10,
+      totalCount: 0,
+    }));
+  });
+
+  describe("adminExtensions - tableToolbarActions", () => {
+    test("renders type-specific extension component", async () => {
+      const ExtensionComponent = defineComponent({
+        name: "PersonToolbarActions",
+        props: { list: { type: Object, required: true } },
+        setup(props) {
+          return () =>
+            h("div", { class: "person-toolbar-extension" }, "Person Actions");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTableToolbar list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+          ],
+        },
+      );
+
+      expect(
+        wrapper.find(".person-toolbar-extension").exists(),
+      ).toBeTruthy();
+      expect(wrapper.find(".person-toolbar-extension").text()).toBe(
+        "Person Actions",
+      );
+    });
+
+    test("renders global '*' extension when no type-specific override exists", async () => {
+      const GlobalExtension = defineComponent({
+        name: "GlobalToolbarActions",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () =>
+            h("div", { class: "global-toolbar-extension" }, "Global Actions");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTableToolbar list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            ["*", { tableToolbarActions: GlobalExtension }],
+          ],
+        },
+      );
+
+      expect(
+        wrapper.find(".global-toolbar-extension").exists(),
+      ).toBeTruthy();
+    });
+
+    test("type-specific override takes precedence over global '*'", async () => {
+      const GlobalExtension = defineComponent({
+        name: "GlobalToolbarActions",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "global-extension" }, "Global");
+        },
+      });
+
+      const TypeExtension = defineComponent({
+        name: "PersonToolbarActions",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "type-extension" }, "Type-specific");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTableToolbar list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            ["*", { tableToolbarActions: GlobalExtension }],
+            [$metadata.types.Person, { tableToolbarActions: TypeExtension }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".type-extension").exists()).toBeTruthy();
+      expect(wrapper.find(".global-extension").exists()).toBeFalsy();
+    });
+
+    test("does not render anything when no extension is configured", async () => {
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mount(() => <CAdminTableToolbar list={list} />);
+
+      // Toolbar should still render normally without extensions
+      expect(
+        wrapper.find(".c-admin-table-toolbar").exists(),
+      ).toBeTruthy();
+    });
+
+    test("extension component receives list prop", async () => {
+      let receivedList: any = null;
+
+      const ExtensionComponent = defineComponent({
+        name: "ListInspector",
+        props: { list: { type: Object, required: true } },
+        setup(props) {
+          receivedList = props.list;
+          return () => h("div", { class: "list-inspector" });
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      mountWithCoalesceOptions(
+        () => <CAdminTableToolbar list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+          ],
+        },
+      );
+
+      expect(receivedList).toBe(list);
+    });
+  });
+
+  describe("toolbar-actions slot", () => {
+    test("slot content replaces extension component", async () => {
+      const ExtensionComponent = defineComponent({
+        name: "ShouldNotRender",
+        props: { list: { type: Object, required: true } },
+        setup() {
+          return () => h("div", { class: "extension-component" });
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => (
+          <CAdminTableToolbar list={list}>
+            {{
+              "toolbar-actions": () =>
+                h("div", { class: "slot-content" }, "Custom Slot"),
+            }}
+          </CAdminTableToolbar>
+        ),
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tableToolbarActions: ExtensionComponent }],
+          ],
+        },
+      );
+
+      expect(wrapper.find(".slot-content").exists()).toBeTruthy();
+      expect(wrapper.find(".extension-component").exists()).toBeFalsy();
+    });
+
+    test("slot receives list as scoped slot prop", async () => {
+      let slotList: any = null;
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      mount(() => (
+        <CAdminTableToolbar list={list}>
+          {{
+            "toolbar-actions": (props: any) => {
+              slotList = props.list;
+              return h("div", { class: "slot-content" });
+            },
+          }}
+        </CAdminTableToolbar>
+      ));
+
+      expect(slotList).toBe(list);
+    });
+  });
+});

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
@@ -45,11 +45,12 @@
       </template>
     </v-btn>
 
-    <slot name="toolbar-actions" :list="list">
+    <slot name="toolbar-actions" :list="list" :editable="editable">
       <component
         :is="toolbarActionsExtension"
         v-if="toolbarActionsExtension"
         :list="list"
+        :editable="editable"
       />
     </slot>
 

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
@@ -116,10 +116,10 @@ const selectedColumns = defineModel<string[] | null>("selectedColumns", {
 });
 
 const { metadata } = useAdminTable(toRef(props, "list"));
-const { resolveTableToolbarActions } = useAdminExtensions();
+const { resolve } = useAdminExtensions();
 
 const toolbarActionsExtension = computed(() =>
-  resolveTableToolbarActions(metadata.value),
+  resolve(metadata.value, "tableToolbarActions"),
 );
 
 const router = useRouter();

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table-toolbar.vue
@@ -45,6 +45,14 @@
       </template>
     </v-btn>
 
+    <slot name="toolbar-actions" :list="list">
+      <component
+        :is="toolbarActionsExtension"
+        v-if="toolbarActionsExtension"
+        :list="list"
+      />
+    </slot>
+
     <v-spacer></v-spacer>
 
     <span v-if="list" class="c-admin-table-toolbar--range hidden-sm-and-down">
@@ -83,9 +91,10 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, toRef } from "vue";
+import { computed, PropType, toRef } from "vue";
 import { ListViewModel, ModelType } from "coalesce-vue";
 import { useAdminTable } from "./useAdminTable";
+import { useAdminExtensions } from "../../composables/useAdminExtensions";
 
 import CAdminCreateBtn from "./c-admin-create-btn.vue";
 import { useRouter } from "vue-router";
@@ -107,6 +116,11 @@ const selectedColumns = defineModel<string[] | null>("selectedColumns", {
 });
 
 const { metadata } = useAdminTable(toRef(props, "list"));
+const { resolveTableToolbarActions } = useAdminExtensions();
+
+const toolbarActionsExtension = computed(() =>
+  resolveTableToolbarActions(metadata.value),
+);
 
 const router = useRouter();
 function addItem(meta: ModelType, route: string) {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.spec.tsx
@@ -1,0 +1,117 @@
+import { CAdminTable } from "..";
+import { PersonListViewModel } from "@test-targets/viewmodels.g";
+import $metadata from "@test-targets/metadata.g";
+import { defineComponent, h } from "vue";
+import { mockEndpoint, mountWithCoalesceOptions } from "@test/util";
+
+describe("CAdminTable", () => {
+  beforeEach(() => {
+    mockEndpoint("/Person/list", () => ({
+      wasSuccessful: true,
+      list: [
+        { personId: 1, firstName: "Alice", lastName: "A" },
+        { personId: 2, firstName: "Bob", lastName: "B" },
+      ],
+      page: 1,
+      pageCount: 1,
+      pageSize: 10,
+      totalCount: 2,
+    }));
+  });
+
+  describe("adminExtensions - tableRowActions", () => {
+    test("renders tableRowActions extension in each row", async () => {
+      const RowExtension = defineComponent({
+        name: "RowExtension",
+        props: {
+          model: { type: Object, required: true },
+          list: { type: Object, required: true },
+          editable: { type: Boolean, required: true },
+        },
+        setup(props) {
+          return () =>
+            h("div", { class: "row-ext" }, `row-${props.model.$primaryKey}`);
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTable list={list} />,
+        undefined,
+        {
+          adminExtensions: [
+            [$metadata.types.Person, { tableRowActions: RowExtension }],
+          ],
+        },
+      );
+
+      const rowExts = wrapper.findAll(".row-ext");
+      expect(rowExts.length).toBe(2);
+      expect(rowExts[0].text()).toBe("row-1");
+      expect(rowExts[1].text()).toBe("row-2");
+    });
+
+    test("tableRowActions extension receives model, list, and editable props", async () => {
+      let receivedModel: any = null;
+      let receivedList: any = null;
+      let receivedEditable: any = undefined;
+
+      const RowExtension = defineComponent({
+        name: "RowPropsInspector",
+        props: {
+          model: { type: Object, required: true },
+          list: { type: Object, required: true },
+          editable: { type: Boolean, required: true },
+        },
+        setup(props) {
+          receivedModel = props.model;
+          receivedList = props.list;
+          receivedEditable = props.editable;
+          return () => h("div", { class: "row-props-ext" });
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      mountWithCoalesceOptions(() => <CAdminTable list={list} />, undefined, {
+        adminExtensions: [
+          [$metadata.types.Person, { tableRowActions: RowExtension }],
+        ],
+      });
+
+      expect(receivedModel).not.toBeNull();
+      expect(receivedList).toBe(list);
+      expect(typeof receivedEditable).toBe("boolean");
+    });
+
+    test("global '*' tableRowActions renders when no type-specific override", async () => {
+      const GlobalRowExtension = defineComponent({
+        name: "GlobalRowExtension",
+        props: {
+          model: { type: Object, required: true },
+          list: { type: Object, required: true },
+          editable: { type: Boolean, required: true },
+        },
+        setup() {
+          return () => h("div", { class: "global-row-ext" }, "global");
+        },
+      });
+
+      const list = new PersonListViewModel();
+      await list.$load();
+
+      const wrapper = mountWithCoalesceOptions(
+        () => <CAdminTable list={list} />,
+        undefined,
+        {
+          adminExtensions: [["*", { tableRowActions: GlobalRowExtension }]],
+        },
+      );
+
+      expect(wrapper.find(".global-row-ext").exists()).toBeTruthy();
+    });
+  });
+});

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
@@ -49,12 +49,18 @@
             class="c-admin-table--actions"
           >
             <div class="d-flex flex-nowrap text-no-wrap ga-1" no-gutters>
-              <slot name="row-actions" :item="item" :list="viewModel">
+              <slot
+                name="row-actions"
+                :item="item"
+                :list="viewModel"
+                :editable="editable"
+              >
                 <component
                   :is="tableRowActionsExtension"
                   v-if="tableRowActionsExtension"
                   :model="item"
                   :list="viewModel"
+                  :editable="editable"
                 />
               </slot>
 

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
@@ -51,7 +51,7 @@
             <div class="d-flex flex-nowrap text-no-wrap ga-1" no-gutters>
               <slot
                 name="row-actions"
-                :item="item"
+                :model="item"
                 :list="viewModel"
                 :editable="editable"
               >

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
@@ -171,12 +171,12 @@ const route = useRoute();
 const instance = getCurrentInstance()!;
 const { metadata, canEdit, canDelete, hasInstanceMethods, getItemRoute } =
   useAdminTable(toRef(props, "list"));
-const { resolveTableRowActions } = useAdminExtensions();
+const { resolve } = useAdminExtensions();
 
 const editable = ref(false);
 
 const tableRowActionsExtension = computed(() =>
-  resolveTableRowActions(metadata.value),
+  resolve(metadata.value, "tableRowActions"),
 );
 
 const viewModel = computed((): ListViewModel => {

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
@@ -49,6 +49,15 @@
             class="c-admin-table--actions"
           >
             <div class="d-flex flex-nowrap text-no-wrap ga-1" no-gutters>
+              <slot name="row-actions" :item="item" :list="viewModel">
+                <component
+                  :is="tableRowActionsExtension"
+                  v-if="tableRowActionsExtension"
+                  :model="item"
+                  :list="viewModel"
+                />
+              </slot>
+
               <v-btn
                 v-if="editable && !effectiveAutoSave"
                 title="Save"
@@ -90,15 +99,6 @@
                   class="v-icon notranslate fa fa-trash-alt"
                 ></i>
               </v-btn>
-
-              <slot name="row-actions" :item="item" :list="viewModel">
-                <component
-                  :is="tableRowActionsExtension"
-                  v-if="tableRowActionsExtension"
-                  :model="item"
-                  :list="viewModel"
-                />
-              </slot>
             </div>
           </td>
         </template>

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-table.vue
@@ -90,6 +90,15 @@
                   class="v-icon notranslate fa fa-trash-alt"
                 ></i>
               </v-btn>
+
+              <slot name="row-actions" :item="item" :list="viewModel">
+                <component
+                  :is="tableRowActionsExtension"
+                  v-if="tableRowActionsExtension"
+                  :model="item"
+                  :list="viewModel"
+                />
+              </slot>
             </div>
           </td>
         </template>
@@ -134,6 +143,7 @@ import {
 } from "vue";
 import { useRoute } from "vue-router";
 import { useAdminTable } from "./useAdminTable";
+import { useAdminExtensions } from "../../composables/useAdminExtensions";
 import { copyParamsToNewViewModel } from "./util";
 
 import CAdminCreateBtn from "./c-admin-create-btn.vue";
@@ -161,8 +171,13 @@ const route = useRoute();
 const instance = getCurrentInstance()!;
 const { metadata, canEdit, canDelete, hasInstanceMethods, getItemRoute } =
   useAdminTable(toRef(props, "list"));
+const { resolveTableRowActions } = useAdminExtensions();
 
 const editable = ref(false);
+
+const tableRowActionsExtension = computed(() =>
+  resolveTableRowActions(metadata.value),
+);
 
 const viewModel = computed((): ListViewModel => {
   if (props.list instanceof ListViewModel) return props.list;

--- a/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
+++ b/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
@@ -1,38 +1,19 @@
 import { inject, type Component } from "vue";
 import type { ModelType, ObjectType } from "coalesce-vue";
-import { coalesceVuetifyKey } from "../install";
+import { coalesceVuetifyKey, type AdminExtension } from "../install";
 
 export function useAdminExtensions() {
   const coalesce = inject(coalesceVuetifyKey, null);
 
-  function resolve(
-    type: ModelType | ObjectType,
-    field: "tableToolbarActions" | "editorToolbarActions" | "editorActions" | "tableRowActions" | "tablePageHeader" | "editorPageHeader",
-  ): Component | undefined {
-    return (
-      coalesce?.adminExtensions.get(type)?.[field] ??
-      coalesce?.adminExtensions.get("*")?.[field]
-    );
-  }
-
   return {
-    resolveTableToolbarActions(type: ModelType | ObjectType) {
-      return resolve(type, "tableToolbarActions");
-    },
-    resolveEditorToolbarActions(type: ModelType | ObjectType) {
-      return resolve(type, "editorToolbarActions");
-    },
-    resolveEditorActions(type: ModelType | ObjectType) {
-      return resolve(type, "editorActions");
-    },
-    resolveTableRowActions(type: ModelType | ObjectType) {
-      return resolve(type, "tableRowActions");
-    },
-    resolveTablePageHeader(type: ModelType | ObjectType) {
-      return resolve(type, "tablePageHeader");
-    },
-    resolveEditorPageHeader(type: ModelType | ObjectType) {
-      return resolve(type, "editorPageHeader");
+    resolve(
+      type: ModelType | ObjectType,
+      field: keyof AdminExtension,
+    ): Component | undefined {
+      return (
+        coalesce?.adminExtensions.get(type)?.[field] ??
+        coalesce?.adminExtensions.get("*")?.[field]
+      );
     },
   };
 }

--- a/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
+++ b/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
@@ -4,14 +4,35 @@ import { coalesceVuetifyKey } from "../install";
 
 export function useAdminExtensions() {
   const coalesce = inject(coalesceVuetifyKey, null);
+
+  function resolve(
+    type: ModelType | ObjectType,
+    field: "tableToolbarActions" | "editorToolbarActions" | "editorActions" | "tableRowActions" | "tablePageHeader" | "editorPageHeader",
+  ): Component | undefined {
+    return (
+      coalesce?.adminExtensions.get(type)?.[field] ??
+      coalesce?.adminExtensions.get("*")?.[field]
+    );
+  }
+
   return {
-    resolveTableToolbarActions(
-      type: ModelType | ObjectType,
-    ): Component | undefined {
-      return (
-        coalesce?.adminExtensions.get(type)?.tableToolbarActions ??
-        coalesce?.adminExtensions.get("*")?.tableToolbarActions
-      );
+    resolveTableToolbarActions(type: ModelType | ObjectType) {
+      return resolve(type, "tableToolbarActions");
+    },
+    resolveEditorToolbarActions(type: ModelType | ObjectType) {
+      return resolve(type, "editorToolbarActions");
+    },
+    resolveEditorActions(type: ModelType | ObjectType) {
+      return resolve(type, "editorActions");
+    },
+    resolveTableRowActions(type: ModelType | ObjectType) {
+      return resolve(type, "tableRowActions");
+    },
+    resolveTablePageHeader(type: ModelType | ObjectType) {
+      return resolve(type, "tablePageHeader");
+    },
+    resolveEditorPageHeader(type: ModelType | ObjectType) {
+      return resolve(type, "editorPageHeader");
     },
   };
 }

--- a/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
+++ b/src/coalesce-vue-vuetify3/src/composables/useAdminExtensions.ts
@@ -1,0 +1,17 @@
+import { inject, type Component } from "vue";
+import type { ModelType, ObjectType } from "coalesce-vue";
+import { coalesceVuetifyKey } from "../install";
+
+export function useAdminExtensions() {
+  const coalesce = inject(coalesceVuetifyKey, null);
+  return {
+    resolveTableToolbarActions(
+      type: ModelType | ObjectType,
+    ): Component | undefined {
+      return (
+        coalesce?.adminExtensions.get(type)?.tableToolbarActions ??
+        coalesce?.adminExtensions.get("*")?.tableToolbarActions
+      );
+    },
+  };
+}

--- a/src/coalesce-vue-vuetify3/src/install.ts
+++ b/src/coalesce-vue-vuetify3/src/install.ts
@@ -14,20 +14,20 @@ export interface AdminOverride {
 
 export interface AdminExtension {
   /** Component rendered after the built-in buttons in c-admin-table-toolbar.
-   * Receives `list: ListViewModel` as a prop. */
+   * Receives `list: ListViewModel` and `editable: boolean | null` as props. */
   tableToolbarActions?: Component;
 
   /** Component rendered in the c-admin-editor toolbar, before the Save/Delete/Reload buttons.
-   * Receives `model: ViewModel` as a prop. */
+   * Receives `model: ViewModel` and `editable: boolean` as props. */
   editorToolbarActions?: Component;
 
   /** Component rendered in the c-admin-editor card-actions area, before the Save button.
-   * Receives `model: ViewModel` as a prop. */
+   * Receives `model: ViewModel` and `editable: boolean` as props. */
   editorActions?: Component;
 
   /** Component rendered in each row's actions column in c-admin-table,
    * alongside the Edit/Delete buttons.
-   * Receives `model: ViewModel` (the row item) and `list: ListViewModel` as props. */
+   * Receives `model: ViewModel`, `list: ListViewModel`, and `editable: boolean` as props. */
   tableRowActions?: Component;
 
   /** Component rendered before the table in c-admin-table-page.

--- a/src/coalesce-vue-vuetify3/src/install.ts
+++ b/src/coalesce-vue-vuetify3/src/install.ts
@@ -1,14 +1,21 @@
 import { App, Component, InjectionKey } from "vue";
-import { Domain, Value } from "coalesce-vue";
+import { Domain, ModelType, ObjectType, Value } from "coalesce-vue";
 import { metadataKey } from "./composables/useMetadata";
 
 type MetadataValue = Value & object;
+type AdminExtensionKey = ModelType | ObjectType | "*";
 
 export interface AdminOverride {
   /** Replaces c-input for this metadata value in admin interfaces. */
   input?: Component;
   /** Replaces c-admin-display for this metadata value in admin interfaces. */
   display?: Component;
+}
+
+export interface AdminExtension {
+  /** Component rendered after the built-in buttons in c-admin-table-toolbar.
+   * Receives `list: ListViewModel` as a prop. */
+  tableToolbarActions?: Component;
 }
 
 export interface CoalesceVuetifyOptions {
@@ -23,6 +30,11 @@ export interface CoalesceVuetifyOptions {
   adminOverrides?:
     | ReadonlyMap<MetadataValue, AdminOverride>
     | ReadonlyArray<readonly [MetadataValue, AdminOverride]>;
+
+  /** Extensions to admin interfaces for specific model types, or "*" for a global default. */
+  adminExtensions?:
+    | ReadonlyMap<AdminExtensionKey, AdminExtension>
+    | ReadonlyArray<readonly [AdminExtensionKey, AdminExtension]>;
 }
 
 export interface CoalesceVuetifyInstance {
@@ -30,6 +42,7 @@ export interface CoalesceVuetifyInstance {
    * as exported from `metadata.g.ts`, e.g. `import metadata from '@/metadata.g'`. */
   readonly metadata: Domain;
   readonly adminOverrides: ReadonlyMap<MetadataValue, AdminOverride>;
+  readonly adminExtensions: ReadonlyMap<AdminExtensionKey, AdminExtension>;
 }
 
 export const coalesceVuetifyKey: InjectionKey<CoalesceVuetifyInstance> =
@@ -44,13 +57,19 @@ declare module "vue" {
 export const createCoalesceVuetify = (options: CoalesceVuetifyOptions) => {
   return {
     install(app: App) {
-      const { metadata, components = {}, adminOverrides } = options;
+      const { metadata, components = {}, adminOverrides, adminExtensions } =
+        options;
       const instance: CoalesceVuetifyInstance = {
         metadata,
         adminOverrides: adminOverrides
           ? adminOverrides instanceof Map
             ? adminOverrides
             : new Map(adminOverrides)
+          : new Map(),
+        adminExtensions: adminExtensions
+          ? adminExtensions instanceof Map
+            ? adminExtensions
+            : new Map(adminExtensions)
           : new Map(),
       };
 

--- a/src/coalesce-vue-vuetify3/src/install.ts
+++ b/src/coalesce-vue-vuetify3/src/install.ts
@@ -78,8 +78,12 @@ declare module "vue" {
 export const createCoalesceVuetify = (options: CoalesceVuetifyOptions) => {
   return {
     install(app: App) {
-      const { metadata, components = {}, adminOverrides, adminExtensions } =
-        options;
+      const {
+        metadata,
+        components = {},
+        adminOverrides,
+        adminExtensions,
+      } = options;
       const instance: CoalesceVuetifyInstance = {
         metadata,
         adminOverrides: adminOverrides

--- a/src/coalesce-vue-vuetify3/src/install.ts
+++ b/src/coalesce-vue-vuetify3/src/install.ts
@@ -16,6 +16,27 @@ export interface AdminExtension {
   /** Component rendered after the built-in buttons in c-admin-table-toolbar.
    * Receives `list: ListViewModel` as a prop. */
   tableToolbarActions?: Component;
+
+  /** Component rendered in the c-admin-editor toolbar, before the Save/Delete/Reload buttons.
+   * Receives `model: ViewModel` as a prop. */
+  editorToolbarActions?: Component;
+
+  /** Component rendered in the c-admin-editor card-actions area, before the Save button.
+   * Receives `model: ViewModel` as a prop. */
+  editorActions?: Component;
+
+  /** Component rendered in each row's actions column in c-admin-table,
+   * alongside the Edit/Delete buttons.
+   * Receives `model: ViewModel` (the row item) and `list: ListViewModel` as props. */
+  tableRowActions?: Component;
+
+  /** Component rendered before the table in c-admin-table-page.
+   * Receives `list: ListViewModel` as a prop. */
+  tablePageHeader?: Component;
+
+  /** Component rendered before the editor in c-admin-editor-page.
+   * Receives `model: ViewModel` as a prop. */
+  editorPageHeader?: Component;
 }
 
 export interface CoalesceVuetifyOptions {


### PR DESCRIPTION
Adds a new `adminExtensions` option to `createCoalesceVuetify()` that allows injecting custom components into admin page surfaces on a per-type basis, with a `"*"` key for a global default fallback.

## Motivation

Users need a way to add custom toolbar actions (e.g. export buttons, bulk operations) to admin table pages without replacing the entire page or toolbar component. The existing `adminOverrides` handles per-value input/display replacement but doesn't cover injecting new content into admin surfaces.

## Approach

Follows the same `[key, override-object]` pattern as `adminOverrides`, but keyed by model type metadata instead of individual property metadata:

```ts
adminExtensions: [
  ["*", { tableToolbarActions: GlobalActions }],
  [$metadata.types.Case, { tableToolbarActions: CaseActions }],
]
```

The `AdminExtension` value object has named fields for different extension kinds, making it easy to add more extension points in the future without changing the API shape.

**Key pieces:**
- `AdminExtension` interface with `tableToolbarActions?: Component` field
- `useAdminExtensions` composable (parallel to `useAdminOverrides`) that resolves type-specific then `"*"` fallback
- `c-admin-table-toolbar` renders the resolved component after the built-in buttons and exposes a `toolbar-actions` scoped slot for conventional per-instance customization
- Extension components receive `{ list: ListViewModel }` as props

## Notes

- The slot takes precedence over the injected extension component (slot content replaces it)
- Resolution order: exact type match > `"*"` global default > nothing rendered
- The `AdminExtensionKey` type accepts both `ModelType` and `ObjectType` for flexibility