### PR TITLE
fix: improve c-app-update-alert detection after tab discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@
 ## Features
 
 - API callers (`ItemApiState`, `ListApiState`) are now awaitable. `await caller` now resolves to `caller.result` after the current or previous operation is completed.
-  - `await vm.$load(1)` - performs a new load call and waits for completion
+  - `await vm.$load(1)` - performs a new load call and waits for completion.
   - `await vm.$load` - waits for completion of the pending load operation, or immediately resolves with the last result if no operation is pending.
 - `useAppUpdateCheck` now also listens for Vite's `vite:preloadError` event, showing the update notification when dynamic imports fail due to stale chunks after a deployment.
 - `useAppUpdateCheck` now persists the observed build in `sessionStorage` (keyed by a fingerprint of loaded script URLs), enabling detection of server updates after a browser discards and restores a tab from cached HTML.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 
-# 6.6.0
 - Added `returnViewModel` prop to `c-select`, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
 - Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - `await vm.$load(1)` - performs a new load call and waits for completion
   - `await vm.$load` - waits for completion of the pending load operation, or immediately resolves with the last result if no operation is pending.
 - `useAppUpdateCheck` now also listens for Vite's `vite:preloadError` event, showing the update notification when dynamic imports fail due to stale chunks after a deployment.
+- `useAppUpdateCheck` now persists the observed build in `sessionStorage` (keyed by a fingerprint of loaded script URLs), enabling detection of server updates after a browser discards and restores a tab from cached HTML.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 
 # 6.6.0

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-app-update-alert.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-app-update-alert.md
@@ -10,6 +10,8 @@ This component monitors the `X-App-Build` response header on API responses (emit
 
 It also listens for Vite's [`vite:preloadError`](https://vite.dev/guide/build.html#load-error-handling) event, which fires when dynamic imports fail (e.g. old chunk files deleted by a new deployment). When this occurs, a HEAD request is made to verify the build header has changed before showing the update notification.
 
+To detect updates after a browser discards and restores a tab from cached HTML (e.g. after the browser "sleeps" an inactive tab), the observed build value is persisted in `sessionStorage` keyed by a fingerprint of the loaded script URLs. This allows the component to detect that the server's build has changed even when the running code was loaded from cached assets.
+
 ## Examples
 
 Place in your root `App.vue`, inside the `<v-app>` element:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "doc": "pnpm -C docs dev",
     "play": "dotnet run --project playground/Coalesce.Web.Vue3",
     "template": "pwsh templates/Coalesce.Vue.Template/TestLocal.ps1",
+    "template:run": "dotnet run --project templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.AppHost",
     "test": "pnpm -r --filter=./src/* run test run"
   },
   "devDependencies": {

--- a/src/coalesce-vue/src/api-client.ts
+++ b/src/coalesce-vue/src/api-client.ts
@@ -630,11 +630,35 @@ AxiosClient.interceptors.request.use((config) => {
 });
 
 const APP_BUILD_HEADER = "x-app-build";
+const APP_BUILD_STORAGE_PREFIX = "coalesce:appBuild:";
+
+/** Compute a fingerprint from the script[src] attributes in the document.
+ * Vite produces content-hashed filenames, so this changes on each new build. */
+function getScriptFingerprint(): string {
+  const scripts = Array.from(document.querySelectorAll("script[src]"))
+    .map((el) => el.getAttribute("src"))
+    .filter(Boolean)
+    .sort()
+    .join("|");
+
+  // Simple DJB2 hash to keep the storage key short
+  let hash = 5381;
+  for (let i = 0; i < scripts.length; i++) {
+    hash = ((hash << 5) + hash + scripts.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
 
 /**
  * Sets up detection of application version changes by monitoring the `X-App-Build`
  * response header on API responses. When the header value changes from the initially
  * observed value, `isUpdateAvailable` becomes true.
+ *
+ * To detect updates after a browser discards and restores a tab from cached HTML,
+ * the previously observed build value is persisted in `sessionStorage`, keyed by a
+ * fingerprint of the loaded script URLs. Since Vite produces content-hashed filenames,
+ * old code will have the same fingerprint (and thus read its stored build from a previous
+ * session), allowing detection when the server reports a newer build.
  *
  * Also listens for Vite's `vite:preloadError` event, which fires when dynamic imports
  * fail due to stale chunks after a new deployment. When this occurs, a HEAD request is
@@ -649,7 +673,22 @@ export function useAppUpdateCheck(axiosInstance = AxiosClient): {
   isUpdateAvailable: Ref<boolean>;
 } {
   const isUpdateAvailable = ref(false);
+
+  // Use the script fingerprint to scope sessionStorage. If we're running the same
+  // code as a previous page load in this tab, we can recover the build value we
+  // previously observed and detect if the server has since been updated.
+  let storageKey: string | null = null;
   let initialBuild: string | null = null;
+  try {
+    const fingerprint = getScriptFingerprint();
+    storageKey = APP_BUILD_STORAGE_PREFIX + fingerprint;
+    const stored = sessionStorage.getItem(storageKey);
+    if (stored) {
+      initialBuild = stored;
+    }
+  } catch {
+    // sessionStorage may be unavailable (e.g. private browsing, storage full).
+  }
 
   const interceptorId = axiosInstance.interceptors.response.use(
     (response) => {
@@ -680,6 +719,15 @@ export function useAppUpdateCheck(axiosInstance = AxiosClient): {
 
   function checkBuild(build: string | undefined) {
     if (!build) return;
+
+    // Persist the observed build so it survives tab discard/restore.
+    if (storageKey) {
+      try {
+        sessionStorage.setItem(storageKey, build);
+      } catch {
+        // Ignore storage errors.
+      }
+    }
 
     if (initialBuild === null) {
       initialBuild = build;

--- a/src/coalesce-vue/test/api-client.spec.ts
+++ b/src/coalesce-vue/test/api-client.spec.ts
@@ -2118,7 +2118,7 @@ describe("useAppUpdateCheck", () => {
 
       // Now simulate a tab restore: same scripts (same fingerprint),
       // but server returns a new build
-      let buildHeader = "build-2";
+      const buildHeader = "build-2";
       const instance2 = axios.create();
       instance2.defaults.adapter = vitest.fn().mockImplementation(() =>
         Promise.resolve(<AxiosResponse>{
@@ -2181,18 +2181,12 @@ describe("useAppUpdateCheck", () => {
       addScriptTag("/assets/index-abc123.js");
 
       // Make sessionStorage throw
-      const originalGetItem = sessionStorage.getItem;
-      const originalSetItem = sessionStorage.setItem;
-      vitest
-        .spyOn(Storage.prototype, "getItem")
-        .mockImplementation(() => {
-          throw new Error("SecurityError");
-        });
-      vitest
-        .spyOn(Storage.prototype, "setItem")
-        .mockImplementation(() => {
-          throw new Error("SecurityError");
-        });
+      vitest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+      vitest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
 
       const instance = makeAxiosWithMockAdapter({
         [APP_BUILD_HEADER]: "build-1",

--- a/src/coalesce-vue/test/api-client.spec.ts
+++ b/src/coalesce-vue/test/api-client.spec.ts
@@ -1843,6 +1843,10 @@ describe("ModelApiClient", () => {
 describe("useAppUpdateCheck", () => {
   const APP_BUILD_HEADER = "x-app-build";
 
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
   function makeAxiosWithMockAdapter(headers: Record<string, string> = {}) {
     const instance = axios.create();
     instance.defaults.adapter = vitest.fn().mockResolvedValue(<AxiosResponse>{
@@ -2056,5 +2060,155 @@ describe("useAppUpdateCheck", () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     vitest.unstubAllGlobals();
+  });
+
+  describe("sessionStorage fingerprint detection", () => {
+    function addScriptTag(src: string) {
+      const script = document.createElement("script");
+      script.src = src;
+      document.head.appendChild(script);
+      return script;
+    }
+
+    function clearScriptTags() {
+      document.querySelectorAll("script[src]").forEach((el) => el.remove());
+    }
+
+    afterEach(() => {
+      sessionStorage.clear();
+      clearScriptTags();
+    });
+
+    test("stores observed build in sessionStorage keyed by script fingerprint", async () => {
+      addScriptTag("/assets/index-abc123.js");
+      const instance = makeAxiosWithMockAdapter({
+        [APP_BUILD_HEADER]: "build-1",
+      });
+
+      const scope = effectScope();
+      scope.run(() => {
+        useAppUpdateCheck(instance);
+      });
+
+      await instance.get("/test");
+
+      // Should have stored the build in sessionStorage
+      const keys = Object.keys(sessionStorage);
+      const buildKey = keys.find((k) => k.startsWith("coalesce:appBuild:"));
+      expect(buildKey).toBeDefined();
+      expect(sessionStorage.getItem(buildKey!)).toBe("build-1");
+
+      scope.stop();
+    });
+
+    test("detects update when sessionStorage has old build for same script fingerprint", async () => {
+      addScriptTag("/assets/index-abc123.js");
+
+      // Simulate a previous page load that stored a build value
+      // First, run useAppUpdateCheck to determine the storage key
+      const instance1 = makeAxiosWithMockAdapter({
+        [APP_BUILD_HEADER]: "build-1",
+      });
+      const scope1 = effectScope();
+      scope1.run(() => {
+        useAppUpdateCheck(instance1);
+      });
+      await instance1.get("/test");
+      scope1.stop();
+
+      // Now simulate a tab restore: same scripts (same fingerprint),
+      // but server returns a new build
+      let buildHeader = "build-2";
+      const instance2 = axios.create();
+      instance2.defaults.adapter = vitest.fn().mockImplementation(() =>
+        Promise.resolve(<AxiosResponse>{
+          data: { wasSuccessful: true },
+          status: 200,
+          statusText: "OK",
+          headers: { [APP_BUILD_HEADER]: buildHeader },
+          config: {} as any,
+        }),
+      );
+
+      const scope2 = effectScope();
+      let result!: ReturnType<typeof useAppUpdateCheck>;
+      scope2.run(() => {
+        result = useAppUpdateCheck(instance2);
+      });
+
+      // Before any API call, the stored build is used as baseline
+      // First API call returns new build → mismatch detected
+      await instance2.get("/test");
+      expect(result.isUpdateAvailable.value).toBe(true);
+
+      scope2.stop();
+    });
+
+    test("does not false-positive when scripts change (new fingerprint after deploy)", async () => {
+      // Old page load stored a build with old script fingerprint
+      addScriptTag("/assets/index-abc123.js");
+      const instance1 = makeAxiosWithMockAdapter({
+        [APP_BUILD_HEADER]: "build-1",
+      });
+      const scope1 = effectScope();
+      scope1.run(() => {
+        useAppUpdateCheck(instance1);
+      });
+      await instance1.get("/test");
+      scope1.stop();
+
+      // After deploy: different scripts (different fingerprint)
+      clearScriptTags();
+      addScriptTag("/assets/index-xyz789.js");
+
+      const instance2 = makeAxiosWithMockAdapter({
+        [APP_BUILD_HEADER]: "build-2",
+      });
+      const scope2 = effectScope();
+      let result!: ReturnType<typeof useAppUpdateCheck>;
+      scope2.run(() => {
+        result = useAppUpdateCheck(instance2);
+      });
+
+      // New fingerprint → no stored build → normal behavior (no false positive)
+      await instance2.get("/test");
+      expect(result.isUpdateAvailable.value).toBe(false);
+
+      scope2.stop();
+    });
+
+    test("handles sessionStorage being unavailable gracefully", async () => {
+      addScriptTag("/assets/index-abc123.js");
+
+      // Make sessionStorage throw
+      const originalGetItem = sessionStorage.getItem;
+      const originalSetItem = sessionStorage.setItem;
+      vitest
+        .spyOn(Storage.prototype, "getItem")
+        .mockImplementation(() => {
+          throw new Error("SecurityError");
+        });
+      vitest
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new Error("SecurityError");
+        });
+
+      const instance = makeAxiosWithMockAdapter({
+        [APP_BUILD_HEADER]: "build-1",
+      });
+      const scope = effectScope();
+      let result!: ReturnType<typeof useAppUpdateCheck>;
+      scope.run(() => {
+        result = useAppUpdateCheck(instance);
+      });
+
+      // Should not throw, just fall back to normal behavior
+      await instance.get("/test");
+      expect(result.isUpdateAvailable.value).toBe(false);
+
+      scope.stop();
+      vitest.restoreAllMocks();
+    });
   });
 });

--- a/templates/Coalesce.Vue.Template/content/Directory.Build.props
+++ b/templates/Coalesce.Vue.Template/content/Directory.Build.props
@@ -7,7 +7,7 @@
 
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 
-    <CoalesceVersion>6.5.0</CoalesceVersion>
+    <CoalesceVersion>6.6.0-beta.20260519.1</CoalesceVersion>
     <!-- Disable Source Link attribute in Debug to avoid hot reload issues.
          In Release, the source revision is included for app update detection. -->
     <IncludeSourceRevisionInInformationalVersion Condition="'$(Configuration)' == 'Debug'">false</IncludeSourceRevisionInInformationalVersion>


### PR DESCRIPTION
When a browser discards a sleeping tab and later restores it from cached HTML, the old JS starts with a fresh heap and captures the server's *current* build version as `initialBuild`. Since the server only ever reports one build value, no mismatch is detected and the update toast never appears -- even though the running code is days old.

## Approach

Derive a "build fingerprint" from the `<script[src]>` attributes in the document (DJB2 hash of sorted src URLs). Since Vite produces content-hashed filenames, this fingerprint is unique per build. The observed `X-App-Build` value is persisted in `sessionStorage` keyed by this fingerprint.

On tab restore with cached HTML:
- Same old scripts -> same fingerprint -> reads stored build ("v1") as baseline
- First API call returns "v2" -> mismatch detected -> toast shown

On normal reload after deploy:
- New scripts -> different fingerprint -> no stored value -> fresh start, no false positive

## Notes

- `sessionStorage` access is wrapped in try/catch for environments where storage is unavailable (private browsing, storage full, etc.)
- The `getScriptFingerprint` function is intentionally not exported; it's an implementation detail
- All 652 existing coalesce-vue tests continue to pass with the new `afterEach(sessionStorage.clear)` guard