### PR TITLE
fix: auto-refresh c-display distance formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added `returnViewModel` prop to `c-select`, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
+- `c-display` now auto-refreshes date distance formatting (`format: { distance: true }`) using an adaptive refresh interval based on the displayed distance.
 - Added `headerComment` generator configuration option to emit custom comments at the start of all generated files. Supports cascading hierarchical configuration—define on a parent generator and child generators automatically inherit the value.
 
 ## Template Changes

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-display.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-display.md
@@ -36,6 +36,12 @@ Displaying a standalone date value without a model or other source of metadata:
 <c-display :value="dateProp" format="M/d/yyyy" />
 ```
 
+Displaying relative time that updates automatically as time passes:
+
+``` vue-html
+<c-display :value="dateProp" :format="{ distance: true, addSuffix: true }" />
+```
+
 For comprehensive information about working with and displaying dates in Coalesce, see [Working with Dates](/topics/working-with-dates.md).
 
 ## Props
@@ -80,4 +86,3 @@ For properties and other values annotated with [DataTypeAttribute], the followin
 * `DataType.PhoneNumber`: Renders as a clickable `tel` link.
 * `DataType.ImageUrl`: Renders as an `img` element.
 * `"Color"`: Renders a colored dot next to the value, interpreting the field value as a 7-character HTML hex color code.
-

--- a/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
+++ b/src/coalesce-vue-vuetify3/src/components/admin/c-admin-editor.vue
@@ -245,7 +245,7 @@ import { getRefNavRoute } from "./util";
 import { isPropReadOnly } from "../../util";
 import { useAdminOverrides } from "../../composables/useAdminOverrides";
 import { useAdminExtensions } from "../../composables/useAdminExtensions";
-import { watch, computed, useTemplateRef, ref, onUnmounted } from "vue";
+import { watch, computed, useTemplateRef, ref } from "vue";
 
 defineOptions({
   name: "c-admin-editor",
@@ -290,16 +290,6 @@ watch(
     }
   },
 );
-
-// Update the display every 10 seconds to keep the "ago" text fresh
-const updateInterval = setInterval(() => {
-  if (lastSavedAt.value) {
-    // Force a re-render by reassigning the same value
-    lastSavedAt.value = new Date(lastSavedAt.value);
-  }
-}, 10000);
-
-onUnmounted(() => clearInterval(updateInterval));
 
 function propInputBinds(p: Property) {
   const readonly = isPropReadOnly(p, props.model);

--- a/src/coalesce-vue-vuetify3/src/components/display/c-display.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/display/c-display.spec.tsx
@@ -109,6 +109,29 @@ describe("CDisplay", () => {
     expect(wrapper.text()).toContain("1990-01-02 03:04:05 AM");
   });
 
+  test(":modelValue date distance format auto-updates", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const value = new Date("2023-12-31T23:59:50.000Z");
+
+      const wrapper = mount(() => (
+        <CDisplay
+          modelValue={value}
+          format={{ distance: true, addSuffix: true, includeSeconds: true }}
+        />
+      ));
+
+      const initialText = wrapper.text();
+      await vi.advanceTimersByTimeAsync(11000);
+      const updatedText = wrapper.text();
+
+      expect(updatedText).not.toEqual(initialText);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("password", async () => {
     const model = new PersonViewModel({ secretPhrase: "Hunter2" });
     const wrapper = mount(() => <CDisplay model={model} for="secretPhrase" />);

--- a/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
+++ b/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
@@ -43,6 +43,99 @@ const passwordWrapper = defineComponent({
   },
 });
 
+type DistanceFormatOption = {
+  distance: true;
+  addSuffix?: boolean;
+  includeSeconds?: boolean;
+};
+
+function isDistanceFormat(
+  formatOption: DisplayOptions["format"] | undefined,
+): formatOption is DistanceFormatOption {
+  return (
+    !!formatOption &&
+    typeof formatOption == "object" &&
+    "distance" in formatOption
+  );
+}
+
+/** Determine how long until the rendered distance string (e.g. "5 minutes ago")
+ * would next change, so we can schedule a refresh exactly when it's needed
+ * rather than on a fixed interval. */
+function getDistanceRefreshDelayMs(
+  parsed: Date,
+  formatOption: DistanceFormatOption,
+): number {
+  const addSuffix = formatOption.addSuffix ?? true;
+  const includeSeconds = formatOption.includeSeconds ?? false;
+  const now = new Date();
+  const currentDistance = formatDistance(parsed, now, {
+    addSuffix,
+    includeSeconds,
+  });
+
+  const candidateDelaysMs = includeSeconds
+    ? [
+        1000, 2000, 5000, 10000, 15000, 30000, 60000, 300000, 900000, 1800000,
+        3600000, 21600000, 43200000, 86400000,
+      ]
+    : [30000, 60000, 300000, 900000, 1800000, 3600000, 21600000, 86400000];
+
+  for (const delayMs of candidateDelaysMs) {
+    const nextDistance = formatDistance(
+      parsed,
+      new Date(now.getTime() + delayMs),
+      {
+        addSuffix,
+        includeSeconds,
+      },
+    );
+    if (nextDistance !== currentDistance) {
+      return delayMs;
+    }
+  }
+
+  return 86400000;
+}
+
+/** Wrapper that re-renders a date distance display on an adaptive schedule so
+ * that relative time text stays current without requiring callers to manually
+ * force re-renders. Only instantiated for date values formatted with
+ * `{ distance: true }`, so non-distance displays incur no timer overhead. */
+const distanceWrapper = defineComponent({
+  name: "CDistanceDisplay",
+  props: {
+    element: { type: String, default: "span" },
+    value: { type: Date, required: true },
+    meta: { type: Object as PropType<DateValue>, required: true },
+    options: { type: Object as PropType<DisplayOptions>, default: undefined },
+  },
+  setup(props, { attrs, slots }) {
+    const refreshTick = ref(0);
+
+    watchEffect((onCleanup) => {
+      // Re-arm the timer whenever a tick fires or the inputs change.
+      void refreshTick.value;
+      const formatOption = props.options?.format;
+      if (!isDistanceFormat(formatOption) || isNaN(props.value.getTime())) {
+        return;
+      }
+
+      const delayMs = getDistanceRefreshDelayMs(props.value, formatOption);
+      const timeout = setTimeout(() => {
+        refreshTick.value += 1;
+      }, delayMs);
+      onCleanup(() => clearTimeout(timeout));
+    });
+
+    return () => {
+      void refreshTick.value;
+      const valueString = valueDisplay(props.value, props.meta, props.options);
+      return h(props.element, attrs, valueString || slots);
+    };
+  },
+});
+
 export type CDisplayProps<TModel extends Model | AnyArgCaller | undefined> = {
   /** An object owning the value to be edited that is specified by the `for` prop. */
   model?: TModel | null;
@@ -85,6 +178,7 @@ import {
 } from "vue";
 import { formatDistance } from "date-fns";
 import { type ForSpec, useMetadataProps } from "../c-metadata-component";
+import type { PropType } from "vue";
 import { valueDisplay } from "coalesce-vue";
 import type {
   DisplayOptions,
@@ -111,7 +205,6 @@ const attrs = useAttrs();
 
 defineSlots(); // Empty defineSlots() prevents TS errors for passthrough slots.
 const slots = useSlots();
-const refreshTick = ref(0);
 
 function resolveDisplayValue() {
   const model = props.model;
@@ -152,66 +245,6 @@ function resolveDisplayValue() {
   return { meta, options, valueProp };
 }
 
-function getRefreshDelayMs(): number | null {
-  const resolved = resolveDisplayValue();
-  if (!resolved || resolved.meta.type !== "date") return null;
-
-  const formatOption = resolved.options?.format;
-  if (
-    !formatOption ||
-    typeof formatOption != "object" ||
-    !("distance" in formatOption)
-  ) {
-    return null;
-  }
-
-  const parsed = resolved.valueProp;
-  if (!(parsed instanceof Date) || isNaN(parsed.getTime())) return null;
-
-  const addSuffix = formatOption.addSuffix ?? true;
-  const includeSeconds = formatOption.includeSeconds ?? false;
-  const now = new Date();
-  const currentDistance = formatDistance(parsed, now, {
-    addSuffix,
-    includeSeconds,
-  });
-
-  const candidateDelaysMs = includeSeconds
-    ? [
-        1000, 2000, 5000, 10000, 15000, 30000, 60000, 300000, 900000, 1800000,
-        3600000, 21600000, 43200000, 86400000,
-      ]
-    : [30000, 60000, 300000, 900000, 1800000, 3600000, 21600000, 86400000];
-
-  for (const delayMs of candidateDelaysMs) {
-    const nextDistance = formatDistance(
-      parsed,
-      new Date(now.getTime() + delayMs),
-      {
-        addSuffix,
-        includeSeconds,
-      },
-    );
-    if (nextDistance !== currentDistance) {
-      return delayMs;
-    }
-  }
-
-  return 86400000;
-}
-
-watchEffect((onCleanup) => {
-  refreshTick.value;
-  const refreshDelayMs = getRefreshDelayMs();
-  if (refreshDelayMs == null) return;
-
-  const timeout = setTimeout(() => {
-    refreshTick.value += 1;
-  }, refreshDelayMs);
-
-  onCleanup(() => clearTimeout(timeout));
-});
-
 function render() {
   const resolved = resolveDisplayValue();
   if (resolved == null) {
@@ -221,8 +254,24 @@ function render() {
     return h(props.element);
   }
 
-  void refreshTick.value;
   const { meta, valueProp, options } = resolved;
+
+  if (
+    meta.type === "date" &&
+    isDistanceFormat(options?.format) &&
+    valueProp instanceof Date &&
+    !isNaN(valueProp.getTime())
+  ) {
+    // Delegate to a wrapper that keeps the relative time text up to date.
+    return h(distanceWrapper, {
+      ...attrs,
+      element: props.element,
+      value: valueProp,
+      meta,
+      options,
+    });
+  }
+
   let valueString = valueDisplay(valueProp, meta, options);
 
   if (meta.type === "string" && valueString) {

--- a/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
+++ b/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
@@ -87,6 +87,7 @@ import { formatDistance } from "date-fns";
 import { type ForSpec, useMetadataProps } from "../c-metadata-component";
 import { valueDisplay } from "coalesce-vue";
 import type {
+  DisplayOptions,
   DateValue,
   Model,
   AnyArgCaller,

--- a/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
+++ b/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
@@ -61,41 +61,47 @@ function isDistanceFormat(
 
 /** Determine how long until the rendered distance string (e.g. "5 minutes ago")
  * would next change, so we can schedule a refresh exactly when it's needed
- * rather than on a fixed interval. */
+ * rather than on a fixed interval.
+ *
+ * Binary-searches the change boundary using `formatDistance` as a black box,
+ * which keeps us decoupled from date-fns' internal thresholds and lands the
+ * refresh exactly on the boundary (down to 1s) instead of overshooting.
+ *
+ * Capped at one hour: in the minutes/hours range, distance buckets change at
+ * most once per hour (e.g. "about 3 hours" -> "about 4 hours" boundaries are
+ * an hour apart), so an hourly cap still catches those right on time. For
+ * day/month/year distances the cap just means a far-off date re-renders hourly
+ * and usually produces the same string - a negligible cost that's well worth
+ * the much smaller search range. */
 function getDistanceRefreshDelayMs(
   parsed: Date,
   formatOption: DistanceFormatOption,
 ): number {
-  const addSuffix = formatOption.addSuffix ?? true;
-  const includeSeconds = formatOption.includeSeconds ?? false;
-  const now = new Date();
-  const currentDistance = formatDistance(parsed, now, {
-    addSuffix,
-    includeSeconds,
-  });
+  const opts = {
+    addSuffix: formatOption.addSuffix ?? true,
+    includeSeconds: formatOption.includeSeconds ?? false,
+  };
 
-  const candidateDelaysMs = includeSeconds
-    ? [
-        1000, 2000, 5000, 10000, 15000, 30000, 60000, 300000, 900000, 1800000,
-        3600000, 21600000, 43200000, 86400000,
-      ]
-    : [30000, 60000, 300000, 900000, 1800000, 3600000, 21600000, 86400000];
+  const now = Date.now();
+  const current = formatDistance(parsed, new Date(now), opts);
 
-  for (const delayMs of candidateDelaysMs) {
-    const nextDistance = formatDistance(
-      parsed,
-      new Date(now.getTime() + delayMs),
-      {
-        addSuffix,
-        includeSeconds,
-      },
-    );
-    if (nextDistance !== currentDistance) {
-      return delayMs;
-    }
+  const maxMs = 3_600_000; // 1 hour
+  if (formatDistance(parsed, new Date(now + maxMs), opts) === current) {
+    return maxMs;
   }
 
-  return 86400000;
+  // Smallest delay (>= 1s) at which the formatted string changes.
+  let lo = 1000;
+  let hi = maxMs;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (formatDistance(parsed, new Date(now + mid), opts) !== current) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return lo;
 }
 
 /** Wrapper that re-renders a date distance display on an adaptive schedule so

--- a/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
+++ b/src/coalesce-vue-vuetify3/src/components/display/c-display.vue
@@ -74,17 +74,23 @@ export type CDisplayProps<TModel extends Model | AnyArgCaller | undefined> = {
   setup
   generic="TModel extends Model | AnyArgCaller | undefined"
 >
-import { defineComponent, h, mergeProps } from "vue";
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  useAttrs,
+  useSlots,
+  ref,
+  watchEffect,
+} from "vue";
+import { formatDistance } from "date-fns";
 import { type ForSpec, useMetadataProps } from "../c-metadata-component";
 import { valueDisplay } from "coalesce-vue";
 import type {
-  DisplayOptions,
   DateValue,
   Model,
   AnyArgCaller,
 } from "coalesce-vue";
-import { useAttrs } from "vue";
-import { useSlots } from "vue";
 
 const props = withDefaults(defineProps<CDisplayProps<TModel>>(), {
   element: "span",
@@ -104,16 +110,14 @@ const attrs = useAttrs();
 
 defineSlots(); // Empty defineSlots() prevents TS errors for passthrough slots.
 const slots = useSlots();
+const refreshTick = ref(0);
 
-function render() {
+function resolveDisplayValue() {
   const model = props.model;
   let valueProp = props.modelValue ?? props.value;
 
   if (model == null && valueProp == null) {
-    // If no model and no value were provided, just display nothing.
-    // This isn't an error case - it just means the thing we're trying to display
-    // is `null`-ish, and should be treated the same way that vue would treat {{null}}
-    return h(props.element);
+    return null;
   }
 
   const modelMeta = modelMetaRef.value;
@@ -143,6 +147,81 @@ function render() {
   }
 
   valueProp ??= (valueOwner.value as any)[meta.name];
+
+  return { meta, options, valueProp };
+}
+
+function getRefreshDelayMs(): number | null {
+  const resolved = resolveDisplayValue();
+  if (!resolved || resolved.meta.type !== "date") return null;
+
+  const formatOption = resolved.options?.format;
+  if (
+    !formatOption ||
+    typeof formatOption != "object" ||
+    !("distance" in formatOption)
+  ) {
+    return null;
+  }
+
+  const parsed = resolved.valueProp;
+  if (!(parsed instanceof Date) || isNaN(parsed.getTime())) return null;
+
+  const addSuffix = formatOption.addSuffix ?? true;
+  const includeSeconds = formatOption.includeSeconds ?? false;
+  const now = new Date();
+  const currentDistance = formatDistance(parsed, now, {
+    addSuffix,
+    includeSeconds,
+  });
+
+  const candidateDelaysMs = includeSeconds
+    ? [
+        1000, 2000, 5000, 10000, 15000, 30000, 60000, 300000, 900000, 1800000,
+        3600000, 21600000, 43200000, 86400000,
+      ]
+    : [30000, 60000, 300000, 900000, 1800000, 3600000, 21600000, 86400000];
+
+  for (const delayMs of candidateDelaysMs) {
+    const nextDistance = formatDistance(
+      parsed,
+      new Date(now.getTime() + delayMs),
+      {
+        addSuffix,
+        includeSeconds,
+      },
+    );
+    if (nextDistance !== currentDistance) {
+      return delayMs;
+    }
+  }
+
+  return 86400000;
+}
+
+watchEffect((onCleanup) => {
+  refreshTick.value;
+  const refreshDelayMs = getRefreshDelayMs();
+  if (refreshDelayMs == null) return;
+
+  const timeout = setTimeout(() => {
+    refreshTick.value += 1;
+  }, refreshDelayMs);
+
+  onCleanup(() => clearTimeout(timeout));
+});
+
+function render() {
+  const resolved = resolveDisplayValue();
+  if (resolved == null) {
+    // If no model and no value were provided, just display nothing.
+    // This isn't an error case - it just means the thing we're trying to display
+    // is `null`-ish, and should be treated the same way that vue would treat {{null}}
+    return h(props.element);
+  }
+
+  void refreshTick.value;
+  const { meta, valueProp, options } = resolved;
   let valueString = valueDisplay(valueProp, meta, options);
 
   if (meta.type === "string" && valueString) {


### PR DESCRIPTION
`c-display` supported distance formatting (for example `:format="{ distance: true }"`) but did not update itself over time, so relative text like "less than a minute ago" became stale unless parent components manually forced rerenders. This change makes distance displays self-updating in `c-display` so consumers do not need component-specific timer workarounds.

## What changed
- Added adaptive refresh scheduling in `c-display` for date distance formatting by checking when the rendered `formatDistance(...)` string would next change, then scheduling a one-shot update at that boundary.
- Scoped this behavior to values that are already valid `Date` instances; if the value is not a `Date`, adaptive refresh is skipped.
- Removed the manual `setInterval` rerender logic from `c-admin-editor` autosave UI because the shared `c-display` behavior now covers it.
- Added/updated docs and changelog entries for the new `c-display` behavior.
- Added a component test that verifies distance-formatted output updates over time.

## Notes for reviewers
- Refresh cadence is intentionally adaptive (seconds when needed, then progressively less frequent) to keep relative text accurate while avoiding unnecessary frequent updates for older timestamps.