### PR TITLE
feat: add orderBy option to BulkSaveOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Features
 
+- Added `orderBy` option to `BulkSaveOptions`, allowing customization of the order in which items are sent to the server during a bulk save. The server respects client ordering when possible, but may reorder items to satisfy foreign key dependencies.
+
 - Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library to reduce boilerplate duplication in projects.
 - Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type or global extension components to be injected into admin pages. Supported extension points: `tableToolbarActions`, `editorToolbarActions`, `editorActions`, `tableRowActions`, `tablePageHeader`, and `editorPageHeader`. Each corresponding component also exposes a slot for conventional per-instance customization.
 - Open generic data sources whose single type parameter is constrained to a base class are now automatically available as data sources for that base class and all derived entity types.

--- a/docs/stacks/vue/layers/viewmodels.md
+++ b/docs/stacks/vue/layers/viewmodels.md
@@ -266,13 +266,14 @@ Bulk saves save all changes to an object graph in one API call and one database 
 
 To use bulk saves, you can work with your ViewModel instances on the client much in the same way you would on the server with Entity Framework. Assign objects to reference navigation properties and modify scalar values to perform creates and updates. To perform deletions, you must call `model.$remove()` on the ViewModel you want to remove, similar how you would call `DbSet<>.Remove(model)` on the server.
 
-When `$bulkSave()` is called, Coalesce will recursively traverse through all reachable navigation properties (and all models that were `$remove()`d) to determine which models will be saved. You can filter this by providing a `predicate` to the `options` parameter.
+When `$bulkSave()` is called, Coalesce will recursively traverse through all reachable navigation properties (and all models that were `$remove()`d) to determine which models will be saved. You can filter this by providing a `predicate` to the `options` parameter, and control the order of operations with `orderBy`.
 
 If the client-side [Rules/Validation](/stacks/vue/layers/viewmodels.md#rules-validation) report any errors for any of the models being saved in the operation, an error will be thrown.
 
 On the server, each affected entity is handled through the same standard mechanisms as are used by individual saves or deletes ([Behaviors](/modeling/model-components/behaviors.md), [Data Sources](/modeling/model-components/data-sources.md), and [Security Attributes](/modeling/model-components/attributes/security-attribute.md)), but with a bit of sugar on top:
 * All operations are wrapped in a single database transaction that is rolled back if any individual operation fails.
 * Foreign keys will be fixed up as new items are created, allowing a parent and child record to be created at the same time even when the client has no foreign key to link the two together.
+* The server will respect client-specified ordering when possible, but may reorder items when necessary to satisfy foreign key dependencies (e.g. a parent entity must be created before its children).
 
 For the response to a bulk save, the server will load and return the root ViewModel that `$bulkSave` was called upon, using the instance's `$params` object for the [Standard Parameters](/modeling/model-components/data-sources.md#standard-parameters).
 

--- a/src/coalesce-vue/src/viewmodel.ts
+++ b/src/coalesce-vue/src/viewmodel.ts
@@ -884,6 +884,19 @@ export abstract class ViewModel<
       });
     }
 
+    if (options?.orderBy) {
+      // Sort items by the user-provided comparator.
+      // Build paired tuples so both arrays stay in sync.
+      const paired = dataToSend.map(
+        (raw, i) => [raw, itemsToSend[i]] as const,
+      );
+      paired.sort((a, b) => options.orderBy!(a[0], b[0]));
+      for (let i = 0; i < paired.length; i++) {
+        dataToSend[i] = paired[i][0];
+        itemsToSend[i] = paired[i][1];
+      }
+    }
+
     return {
       /** True if there are any models with a pending save or delete. */
       isDirty,
@@ -2187,6 +2200,20 @@ export interface BulkSaveOptions {
    * but are still desired to be saved during the same operation.
    */
   additionalRoots?: ViewModel[];
+
+  /** A comparator function that controls the order in which items are sent
+   * to the server. Works like `Array.prototype.sort` - return a negative number
+   * to sort `a` before `b`, a positive number to sort `b` before `a`, or zero
+   * to preserve their relative order.
+   *
+   * The server will respect client ordering when possible, but may reorder items
+   * when necessary to satisfy foreign key dependencies (e.g. a parent entity
+   * must be created before its children).
+   */
+  orderBy?: (
+    a: BulkSaveRequestRawItem,
+    b: BulkSaveRequestRawItem,
+  ) => number;
 }
 
 /**

--- a/src/coalesce-vue/src/viewmodel.ts
+++ b/src/coalesce-vue/src/viewmodel.ts
@@ -887,9 +887,7 @@ export abstract class ViewModel<
     if (options?.orderBy) {
       // Sort items by the user-provided comparator.
       // Build paired tuples so both arrays stay in sync.
-      const paired = dataToSend.map(
-        (raw, i) => [raw, itemsToSend[i]] as const,
-      );
+      const paired = dataToSend.map((raw, i) => [raw, itemsToSend[i]] as const);
       paired.sort((a, b) => options.orderBy!(a[0], b[0]));
       for (let i = 0; i < paired.length; i++) {
         dataToSend[i] = paired[i][0];
@@ -2210,10 +2208,7 @@ export interface BulkSaveOptions {
    * when necessary to satisfy foreign key dependencies (e.g. a parent entity
    * must be created before its children).
    */
-  orderBy?: (
-    a: BulkSaveRequestRawItem,
-    b: BulkSaveRequestRawItem,
-  ) => number;
+  orderBy?: (a: BulkSaveRequestRawItem, b: BulkSaveRequestRawItem) => number;
 }
 
 /**

--- a/src/coalesce-vue/test/viewmodel.spec.ts
+++ b/src/coalesce-vue/test/viewmodel.spec.ts
@@ -1561,9 +1561,7 @@ describe("ViewModel", () => {
       });
 
       const parsed = JSON.parse(endpoint.mock.calls[0][0].data);
-      const names = parsed.items.map(
-        (i: any) => i.data.firstName ?? "(root)",
-      );
+      const names = parsed.items.map((i: any) => i.data.firstName ?? "(root)");
       // Root company first (stable sort preserves position),
       // then employees sorted reverse alphabetically
       expect(names).toEqual(["(root)", "charlie", "bob", "alice"]);

--- a/src/coalesce-vue/test/viewmodel.spec.ts
+++ b/src/coalesce-vue/test/viewmodel.spec.ts
@@ -1590,8 +1590,8 @@ describe("ViewModel", () => {
       });
 
       // rawItems and items should have matching order
-      expect(preview.rawItems.map((r) => r.model)).toEqual(
-        preview.items.map((_, i) => preview.rawItems[i].model),
+      expect(preview.rawItems.map((r) => [r.metadata.name, r.action])).toEqual(
+        preview.items.map((i) => [i.type, i.action]),
       );
 
       const models = preview.rawItems.map((r) => r.model);

--- a/src/coalesce-vue/test/viewmodel.spec.ts
+++ b/src/coalesce-vue/test/viewmodel.spec.ts
@@ -1531,6 +1531,76 @@ describe("ViewModel", () => {
 
       bulkSaveEndpoint.destroy();
     });
+
+    test("options.orderBy sorts items in the payload", async () => {
+      const endpoint = mockEndpoint(
+        "/Company/bulkSave",
+        vitest.fn((req) => ({
+          wasSuccessful: true,
+        })),
+      );
+
+      const company = new CompanyViewModel();
+      company.$loadCleanData({ companyId: 1, name: "existing company" });
+
+      const alice = new PersonViewModel({ firstName: "alice" });
+      const bob = new PersonViewModel({ firstName: "bob" });
+      const charlie = new PersonViewModel({ firstName: "charlie" });
+      company.employees?.push(alice, bob, charlie);
+
+      await company.$bulkSave({
+        orderBy(a, b) {
+          // Sort employees in reverse alphabetical order by firstName.
+          // Non-Person items (the root Company) come first.
+          if (a.metadata.name !== "Person" || b.metadata.name !== "Person")
+            return 0;
+          const aName = (a.model as PersonViewModel).firstName ?? "";
+          const bName = (b.model as PersonViewModel).firstName ?? "";
+          return bName.localeCompare(aName);
+        },
+      });
+
+      const parsed = JSON.parse(endpoint.mock.calls[0][0].data);
+      const names = parsed.items.map(
+        (i: any) => i.data.firstName ?? "(root)",
+      );
+      // Root company first (stable sort preserves position),
+      // then employees sorted reverse alphabetically
+      expect(names).toEqual(["(root)", "charlie", "bob", "alice"]);
+
+      endpoint.destroy();
+    });
+
+    test("options.orderBy is reflected in $bulkSavePreview", () => {
+      const company = new CompanyViewModel();
+      company.$loadCleanData({ companyId: 1, name: "existing company" });
+
+      const alice = new PersonViewModel({ firstName: "alice" });
+      const bob = new PersonViewModel({ firstName: "bob" });
+      company.employees?.push(alice, bob);
+
+      const preview = company.$bulkSavePreview({
+        orderBy(a, b) {
+          // Sort Person items by firstName descending.
+          // Non-Person items keep original position.
+          if (a.metadata.name !== "Person" || b.metadata.name !== "Person")
+            return 0;
+          const aName = (a.model as PersonViewModel).firstName ?? "";
+          const bName = (b.model as PersonViewModel).firstName ?? "";
+          return bName.localeCompare(aName);
+        },
+      });
+
+      // rawItems and items should have matching order
+      expect(preview.rawItems.map((r) => r.model)).toEqual(
+        preview.items.map((_, i) => preview.rawItems[i].model),
+      );
+
+      const models = preview.rawItems.map((r) => r.model);
+      expect(models[0]).toBe(company);
+      expect(models[1]).toBe(bob);
+      expect(models[2]).toBe(alice);
+    });
   });
 
   describe("autoSave", () => {


### PR DESCRIPTION
Bulk saves currently send items in breadth-first traversal order with no way to customize it. This means scenarios that require a specific operation order -- like promoting one user before demoting another to avoid permission errors -- cannot use bulk saves and must fall back to sequential individual saves.

This adds an `orderBy` comparator to `BulkSaveOptions` that controls the order items appear in the payload sent to the server. The server's existing save loop already naturally preserves client ordering for items at the same FK dependency level, only reordering when necessary to resolve foreign key references. So no server-side changes are needed.

### Changes

- **`BulkSaveOptions.orderBy`**: New comparator function receiving `BulkSaveRequestRawItem` pairs (which expose `.model`, `.action`, `.metadata`, etc.). Works like `Array.prototype.sort`.
- **`$bulkSavePreview`**: Applies the sort after items are collected, keeping the `rawItems` and `items` arrays in sync.
- **Tests**: Two new tests verifying ordering in both `$bulkSave` payloads and `$bulkSavePreview` results.
- **Docs**: Updated bulk save section noting the `orderBy` option and the server's FK-aware reordering behavior.
- **Changelog**: Added feature entry.