### PR TITLE
feat: support [DefaultOrderBy(Suppress = true)] on collection properties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ The required tools and dependencies are automatically installed via the GitHub A
 
 - YOU MUST Format PR titles with Semantic Commits. The work item number should follow the colon after the commit type like `feat: #12345 added ...` (don't insert a work item number if you don't have one)
 - YOU MUST update the documentation when making changes or adding features that will affect developers who use Coalesce.
-- YOU MUST add an entry to CHANGELOG.md when adding new features or fixing non-trivial bugs. Be concise and factual. The changelog is not a marketing document - you don't have to convince users of the value of the feature, or explain how to use it or configure it.
+- YOU MUST add an entry to CHANGELOG.md when adding new features or fixing non-trivial bugs. Be concise and factual. The changelog is not a marketing document - you don't have to convince users of the value of the feature, or explain how to use it or configure it. Insert new entries at a position appropriate for their significance—major features go near the top of the section, minor enhancements near the bottom. Do not prepend to the top by default.
 - YOU MUST Avoid making breaking changes if not necessary. A less obvious example of a breaking change would be changing an existing CSS class name.
 - Consider adding or updating example files in `playground\Coalesce.Web.Vue3\src\examples` when making changes to coalesce-vue-vuetify.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `adminOverrides` option to `createCoalesceVuetify()`, allowing custom Vue components to replace the default input and/or display components used in admin pages (`c-admin-editor`, `c-admin-method`, `c-table`) for specific model properties, method parameters, or method return values.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 - Added `headerComment` generator configuration option to emit custom comments at the start of all generated files. Supports cascading hierarchical configuration—define on a parent generator and child generators automatically inherit the value.
+- `[DefaultOrderBy(Suppress = true)]` can now be placed on a collection navigation property to suppress the default sorting of that collection in the generated response DTO.
 
 ## Template Changes
 - Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project that doesn't diverge significantly from the previous out-of-the-box Coalesce template tenancy behavior:

--- a/docs/modeling/model-components/attributes/default-order-by.md
+++ b/docs/modeling/model-components/attributes/default-order-by.md
@@ -62,9 +62,9 @@ When using the `DefaultOrderByAttribute` on an object property, specifies the fi
 
 <Prop def="public bool Suppress { get; set; } = false;" />
 
-When set to `true`, prevents this property from being used as a fallback ordering.
+When placed on a scalar property and set to `true`, prevents that property from being used as a fallback ordering. If no properties are decorated with `[DefaultOrderBy]`, Coalesce will automatically sort by a property named `Name` if one exists, otherwise by the primary key. Setting `Suppress = true` on the `Name` or primary key property prevents them from being used for this fallback behavior.
 
-If no properties are decorated with `[DefaultOrderBy]`, Coalesce will automatically sort by a property named `Name` if one exists, otherwise by the primary key. Setting `Suppress = true` on the `Name` or primary key property prevents them from being used for this fallback behavior.
+When placed on a collection navigation property and set to `true`, suppresses the default ordering of that collection in the generated response DTO. Normally, child collections are sorted by the child type's `[DefaultOrderBy]` rules (or by `Name`/primary key as a fallback). This allows you to preserve the original database ordering or the order produced by custom data sources.
 
 ``` cs
 public class RandomOrder
@@ -73,5 +73,17 @@ public class RandomOrder
     
     [DefaultOrderBy(Suppress = true)]
     public string Name { get; set; }
+}
+```
+
+``` cs
+public class Parent
+{
+    public int Id { get; set; }
+
+    // Children will not be re-sorted in the response DTO,
+    // preserving their original order from the database or data source.
+    [DefaultOrderBy(Suppress = true)]
+    public ICollection<Child> Children { get; set; }
 }
 ```

--- a/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ClassDto.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Api/Generators/ClassDto.cs
@@ -535,7 +535,9 @@ public class ClassDto : StringBuilderCSharpGenerator<ClassViewModel>
                 {
                     sb.Line($"{dtoVar}.{name} = propVal{name}");
 
-                    var defaultOrderBy = property.Object.DefaultOrderBy;
+                    var defaultOrderBy = property.IsDefaultOrderBySuppressed
+                        ? []
+                        : property.Object.DefaultOrderBy;
                     if (defaultOrderBy.Count > 0)
                     {
                         var orderByStatements = defaultOrderBy

--- a/src/IntelliTect.Coalesce.Testing/TargetClasses/Ordering.cs
+++ b/src/IntelliTect.Coalesce.Testing/TargetClasses/Ordering.cs
@@ -1,4 +1,5 @@
 using IntelliTect.Coalesce.DataAnnotations;
+using System.Collections.Generic;
 
 namespace IntelliTect.Coalesce.Testing.TargetClasses;
 
@@ -54,4 +55,14 @@ public class SuppressedDefaultOrdering
 
     [DefaultOrderBy(Suppress = true)]
     public string Name { get; set; }
+}
+
+public class SuppressedCollectionOrdering
+{
+    public int Id { get; set; }
+
+    [DefaultOrderBy(Suppress = true)]
+    public ICollection<OrderingChild> Children { get; set; }
+
+    public ICollection<OrderingChild> UnsuppressedChildren { get; set; }
 }

--- a/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
+++ b/src/IntelliTect.Coalesce.Tests/Tests/TypeDefinition/ClassViewModelTests.cs
@@ -81,6 +81,19 @@ public class ClassViewModelTests
     }
 
     [Test]
+    [ClassViewModelData(typeof(Testing.TargetClasses.SuppressedCollectionOrdering))]
+    public async Task DefaultOrderBy_SuppressOnCollectionProperty(ClassViewModelData data)
+    {
+        var vm = data.ClassViewModel;
+
+        var suppressedProp = vm.PropertyByName("Children")!;
+        await Assert.That(suppressedProp.IsDefaultOrderBySuppressed).IsTrue();
+
+        var unsuppressedProp = vm.PropertyByName("UnsuppressedChildren")!;
+        await Assert.That(unsuppressedProp.IsDefaultOrderBySuppressed).IsFalse();
+    }
+
+    [Test]
     public async Task ClientDataSources_ExcludesAbstractNestedDataSources()
     {
         var repo = ReflectionRepositoryFactory.Reflection;

--- a/src/IntelliTect.Coalesce/DataAnnotations/DefaultOrderByAttribute.cs
+++ b/src/IntelliTect.Coalesce/DataAnnotations/DefaultOrderByAttribute.cs
@@ -29,8 +29,10 @@ public class DefaultOrderByAttribute : System.Attribute
     public string? FieldName { get; set; }
 
     /// <summary>
-    /// When true, suppresses using this property as a fallback ordering.
+    /// When placed on a scalar property, suppresses using this property as a fallback ordering.
     /// Useful for preventing automatic ordering by Name or primary key properties.
+    /// When placed on a collection navigation property, suppresses the default ordering
+    /// of that collection in the generated response DTO.
     /// </summary>
     public bool Suppress { get; set; }
 

--- a/src/IntelliTect.Coalesce/TypeDefinition/PropertyViewModel.cs
+++ b/src/IntelliTect.Coalesce/TypeDefinition/PropertyViewModel.cs
@@ -698,6 +698,14 @@ public abstract class PropertyViewModel : ValueViewModel
     }
 
 
+    /// <summary>
+    /// Returns true if this property has [DefaultOrderBy(Suppress = true)].
+    /// When on a collection navigation property, this suppresses the default ordering
+    /// of that collection in the generated response DTO.
+    /// </summary>
+    public bool IsDefaultOrderBySuppressed =>
+        this.GetAttributeValue<DefaultOrderByAttribute, bool>(a => a.Suppress) == true;
+
     public OrderByInformation? DefaultOrderBy
     {
         get
@@ -705,10 +713,9 @@ public abstract class PropertyViewModel : ValueViewModel
             var order = this.GetAttributeValue<DefaultOrderByAttribute, int>(a => a.FieldOrder);
             var direction = this.GetAttributeValue<DefaultOrderByAttribute, DefaultOrderByAttribute.OrderByDirections>(nameof(DefaultOrderByAttribute.OrderByDirection));
             var fieldName = this.GetAttributeValue<DefaultOrderByAttribute>(a => a.FieldName);
-            var suppress = this.GetAttributeValue<DefaultOrderByAttribute, bool>(a => a.Suppress);
 
             // If Suppress is true, this property should not be used for ordering at all
-            if (suppress == true)
+            if (IsDefaultOrderBySuppressed)
             {
                 return null;
             }


### PR DESCRIPTION
When a collection navigation property has its own `[DefaultOrderBy]` rules (defined on the child type), Coalesce automatically applies `.OrderBy(...)` in the generated response DTO mapping. Sometimes this is undesirable -- for example when the collection order is deliberately controlled by a custom data source or the database itself.

This adds support for placing `[DefaultOrderBy(Suppress = true)]` on a collection navigation property to skip that automatic sorting in the generated DTO, preserving the original order from the database or data source.

**Approach:**
- Added `IsDefaultOrderBySuppressed` property on `PropertyViewModel` to expose the suppress flag cleanly.
- In the `ClassDto` generator, the collection ordering logic now checks this flag before emitting `.OrderBy(...)` chains.
- Updated xmldoc, documentation, changelog, and added a unit test with a new test target class.