### PR TITLE
chore: suppress NuGet audit for GHSA-2m69-gcr7-jv3q

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -61,4 +61,9 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- SQLite is only used for unit tests -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The NuGet audit flags [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) for the SQLite dependency. Since SQLite is only used for unit tests and never in production, this advisory does not pose a real risk.

This adds a `NuGetAuditSuppress` entry in `src/Directory.Build.props` to silence the warning.