### PR TITLE
fix: parseJSONDate incorrectly adding 1900 to years 0-99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
      ```
   3. Delete the `ConfigureTenancy` method, the `TenantInterceptor` class, and the `TenantIdValueGenerator` class from your `AppDbContext`. The `ITenanted` interface and `TenantedBase` class remain in your project — they are not provided by the library.
 
+## Fixes
+- Fixed `parseJSONDate` incorrectly adding 1900 to years 0-99 due to JavaScript's `Date` constructor behavior (e.g. "0001-01-01" was parsed as year 1901).
+
 
 # 6.5.2
 - Fix `c-input` using numeric enum values instead of string values for string-serialized enums (`[JsonStringEnumConverter]`), causing the selected item to not be found in the dropdown.

--- a/src/coalesce-vue/src/util.ts
+++ b/src/coalesce-vue/src/util.ts
@@ -90,11 +90,19 @@ export function parseJSONDate(argument: string, kind: DateKind = "datetime") {
 
   const partTzOffset = parts[8] == "Z" ? 0 : parts[10]; // TZ offset
 
+  // The JS Date constructor (and Date.UTC) interpret a year in the range 0-99
+  // as 1900+year. We detect that case and shift the result back by exactly 1900
+  // years. A relative shift (rather than setting an absolute year) is required so
+  // that any normalization from the constructor - e.g. a timezone offset that
+  // pushes the instant across a year boundary - is preserved.
+  const year = +parts[1];
+  const needsYearFixup = year >= 0 && year < 100;
+
   if (partTzOffset !== undefined) {
     // Date+Time, with offset specifier
-    return new Date(
+    const d = new Date(
       Date.UTC(
-        +parts[1],
+        year,
         +parts[2] - 1,
         +parts[3],
         +parts[4] - (+partTzOffset || 0) * (parts[9] == "-" ? -1 : 1),
@@ -103,10 +111,12 @@ export function parseJSONDate(argument: string, kind: DateKind = "datetime") {
         +((parts[7] || "0") + "00").substring(0, 3),
       ),
     );
+    if (needsYearFixup) d.setUTCFullYear(d.getUTCFullYear() - 1900);
+    return d;
   } else if (parts[4] !== undefined) {
     // Date+Time, without offset specifier
-    return new Date(
-      +parts[1],
+    const d = new Date(
+      year,
       +parts[2] - 1,
       +parts[3],
       +parts[4],
@@ -114,9 +124,13 @@ export function parseJSONDate(argument: string, kind: DateKind = "datetime") {
       +parts[6],
       +((parts[7] || "0") + "00").substring(0, 3),
     );
+    if (needsYearFixup) d.setFullYear(d.getFullYear() - 1900);
+    return d;
   } else {
     // Date only, without a time portion:
-    return new Date(+parts[1], +parts[2] - 1, +parts[3]);
+    const d = new Date(year, +parts[2] - 1, +parts[3]);
+    if (needsYearFixup) d.setFullYear(d.getFullYear() - 1900);
+    return d;
   }
 }
 

--- a/src/coalesce-vue/test/model.toModel.spec.ts
+++ b/src/coalesce-vue/test/model.toModel.spec.ts
@@ -33,6 +33,21 @@ function unparsable(meta: Value, ...values: any[]) {
   });
 }
 
+/** Build a Date with a year between 0-99 without the JS Date ctor's
+ * legacy behavior of adding 1900 to two-digit years. */
+function dateWithYear(year: number, ...rest: any[]) {
+  const d = new Date(year, ...(rest as [any]));
+  d.setFullYear(year);
+  return d;
+}
+
+/** Build a UTC Date with a year between 0-99 without the legacy 1900 offset. */
+function utcDateWithYear(year: number, ...rest: any[]) {
+  const d = new Date(Date.UTC(year, ...(rest as [any])));
+  d.setUTCFullYear(year);
+  return d;
+}
+
 /** Set of data to run simple mapping tests on.
  * Will be ran against both mapToModel and convertToModel variants.
  */
@@ -106,6 +121,57 @@ const dtoToModelMappings = <MappingData[]>[
     meta: { ...cmProps.dateTimeOffset, dateKind: "date" },
     dto: "2020-06-10T14:00:00Z",
     model: new Date(1591797600000),
+  },
+  {
+    // Years 0-99 must not have 1900 added to them (JS Date ctor legacy behavior).
+    meta: { ...cmProps.dateTimeOffset, dateKind: "date" },
+    dto: "0001-01-01",
+    model: dateWithYear(1, 0, 1),
+  },
+  {
+    meta: { ...cmProps.dateTimeOffset, dateKind: "date" },
+    dto: "0099-06-15",
+    model: dateWithYear(99, 5, 15),
+  },
+  {
+    // Datetime without offset, year < 100.
+    meta: cmProps.dateTimeOffset,
+    dto: "0001-01-01T14:00:00",
+    model: dateWithYear(1, 0, 1, 14, 0, 0, 0),
+  },
+  {
+    // Year < 100 with an explicit offset.
+    meta: cmProps.dateTimeOffset,
+    dto: "0001-06-15T12:00:00Z",
+    model: utcDateWithYear(1, 5, 15, 12, 0, 0, 0),
+  },
+  {
+    // Leap day in a year < 100 (year 4 is a leap year) must be preserved.
+    meta: { ...cmProps.dateTimeOffset, dateKind: "date" },
+    dto: "0004-02-29",
+    model: dateWithYear(4, 1, 29),
+  },
+  {
+    // A positive offset that pushes the UTC instant back into the previous year
+    // must NOT have its year clobbered by the small-year fixup.
+    meta: cmProps.dateTimeOffset,
+    dto: "2020-01-01T00:30:00+01:00",
+    model: new Date(Date.UTC(2019, 11, 31, 23, 30, 0, 0)),
+  },
+  {
+    // Small year (< 100) where the offset pushes the UTC instant into the prior
+    // year. The fixup must be a relative -1900 shift (yielding year 0 here), not
+    // an absolute set of the parsed year.
+    meta: cmProps.dateTimeOffset,
+    dto: "0001-01-01T00:30:00+01:00",
+    model: utcDateWithYear(0, 11, 31, 23, 30, 0, 0),
+  },
+  {
+    // Boundary: year 100 is the first year the JS ctor does NOT offset, so it
+    // must be left untouched by the fixup.
+    meta: { ...cmProps.dateTimeOffset, dateKind: "date" },
+    dto: "0100-01-01",
+    model: dateWithYear(100, 0, 1),
   },
   {
     meta: { ...cmProps.dateTimeOffset, dateKind: "time" },


### PR DESCRIPTION
## Why

`parseJSONDate` was returning the wrong year for dates with a year in the range 0-99. For example, `parseJSONDate("0001-01-01", "date")` produced `Tue Jan 01 1901` instead of year 1. This is because JavaScript's `Date` constructor (and `Date.UTC`) interpret a year of 0-99 as `1900 + year`.

## Approach

After constructing the `Date`, we now shift the result back by exactly 1900 years, but only when the parsed year falls in the 0-99 range. The shift is **relative** (`getFullYear() - 1900`) rather than an absolute `setFullYear(parsedYear)`. This matters because the constructor may normalize the date across a year boundary (e.g. a timezone offset that pushes the UTC instant into the previous year); a relative shift preserves that normalization, whereas an absolute set would clobber it and produce an off-by-one-year result.

The fix is applied consistently across all three relevant branches: date-only, datetime without offset, and datetime with a `Z`/explicit offset. The time-only branch is unaffected (it already uses the current year by design).

## Testing

Coverage was added through the existing `convertToModel`/`mapToModel` date-mapping table in `model.toModel.spec.ts` (runs against both mapping variants), covering:

- Small years across all three branches (`0001-01-01`, `0099-06-15`, `0001-01-01T14:00:00`, `0001-06-15T12:00:00Z`)
- Leap day in a small year (`0004-02-29`)
- A normal year whose offset crosses back into the prior year, which must NOT be clobbered (`2020-01-01T00:30:00+01:00`)
- A small year whose offset crosses back into year 0, validating the relative shift (`0001-01-01T00:30:00+01:00`)
- The `year < 100` boundary (`0100-01-01`), which must be left untouched

All 668 coalesce-vue tests pass and `tsc` is clean.