### PR TITLE
chore: use built-in reader from Microsoft.OpenApi on net10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,8 +28,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.3.9" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.24" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Tests/IntelliTect.Coalesce.CodeGeneration.Tests.csproj
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Tests/IntelliTect.Coalesce.CodeGeneration.Tests.csproj
@@ -18,9 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net10.0'">
+    <PackageReference Include="Microsoft.OpenApi.Readers" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelliTect.Coalesce.CodeGeneration.Tests/OpenApi/OpenApiFixture.cs
+++ b/src/IntelliTect.Coalesce.CodeGeneration.Tests/OpenApi/OpenApiFixture.cs
@@ -12,8 +12,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
 #else
 using Microsoft.OpenApi.Models;
-#endif
 using Microsoft.OpenApi.Readers;
+#endif
 using System.Net;
 using System.Reflection;
 

--- a/src/IntelliTect.Coalesce.Swashbuckle.Tests/IntelliTect.Coalesce.Swashbuckle.Tests.csproj
+++ b/src/IntelliTect.Coalesce.Swashbuckle.Tests/IntelliTect.Coalesce.Swashbuckle.Tests.csproj
@@ -15,9 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net10.0'">
+    <PackageReference Include="Microsoft.OpenApi.Readers" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelliTect.Coalesce.Swashbuckle.Tests/OpenApiFixture.cs
+++ b/src/IntelliTect.Coalesce.Swashbuckle.Tests/OpenApiFixture.cs
@@ -9,8 +9,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
 #else
 using Microsoft.OpenApi.Models;
-#endif
 using Microsoft.OpenApi.Readers;
+#endif
 using System.Net;
 using System.Reflection;
 

--- a/src/IntelliTect.Coalesce.Testing/IntelliTect.Coalesce.Testing.csproj
+++ b/src/IntelliTect.Coalesce.Testing/IntelliTect.Coalesce.Testing.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" />
     <PackageReference Include="TUnit.Core" />
     <PackageReference Include="TUnit.Assertions" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump `Microsoft.OpenApi` to `2.7.5` for the `net10.0` target.
- Drop the legacy `Microsoft.OpenApi.Readers` (1.6.24) package on `net10.0`, where the OpenAPI reader API is now built directly into `Microsoft.OpenApi`.
- Gate the `Microsoft.OpenApi.Readers` `PackageReference` (and its `using` directive in the test fixtures) behind non-`net10.0` target frameworks so older targets keep building.

## Details
`Microsoft.OpenApi` 2.x folds the document-reading API into the main package, so the separate `Microsoft.OpenApi.Readers` dependency (which was pinned to an older 1.6.x line) is no longer needed on `net10.0`. This removes a version-mismatched transitive dependency for that target while leaving other target frameworks unchanged.

Affected projects: `IntelliTect.Coalesce.Testing`, `IntelliTect.Coalesce.CodeGeneration.Tests`, `IntelliTect.Coalesce.Swashbuckle.Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)