### PR TITLE
Fixes nullability of GetDisplayName return type

### DIFF
--- a/src/IntelliTect.Coalesce/Helpers/EnumExtensions.cs
+++ b/src/IntelliTect.Coalesce/Helpers/EnumExtensions.cs
@@ -1,13 +1,11 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Reflection;
 
 namespace IntelliTect.Coalesce.Helpers;
 
 public static class EnumExtensions
 {
-    public static string? GetDisplayName(this Enum value)
+    public static string GetDisplayName(this Enum value)
     {
         return value.GetType()
             .GetMember(value.ToString())


### PR DESCRIPTION
## Description

Corrects the return type of the enum display name helper to reflect that it always returns a non-nullable string. This aligns the method signature with its actual behavior and cleans up unnecessary using directives.

Fixes #Issue_Number (if available)

### Ensure that your pull request has followed all the steps below:
- [ ] Code compilation
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary