### PR TITLE
fix: c-datetime-picker menu only opens when clicking the field

### DIFF
--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
@@ -1,4 +1,4 @@
-import { delay, mount, mountApp, openMenu } from "@test/util";
+import { delay, mount, mountApp, openMenu, flushPromises } from "@test/util";
 import { CDatetimePicker } from "..";
 import { Case, ComplexModel } from "@test-targets/models.g";
 import { ComplexModelViewModel } from "@test-targets/viewmodels.g";
@@ -143,6 +143,24 @@ describe("CDatetimePicker", () => {
     expect(overlay.text()).contains("1970");
     expect(overlay.text()).contains("Sun, Aug 2");
     expect(overlay.find(".c-time-picker-header").text()).equals("1:51 PM PDT");
+  });
+
+  test("clicking hint text does not open picker menu", async () => {
+    const date = new Date(18478289085);
+    const wrapper = mountApp(() => (
+      <CDatetimePicker
+        modelValue={date}
+        timeZone="America/Los_Angeles"
+        hint="Some hint text"
+        persistent-hint
+      />
+    )).findComponent(CDatetimePicker);
+
+    await flushPromises();
+    await wrapper.find(".v-input__details").trigger("click");
+    await flushPromises();
+
+    expect(document.querySelector(".v-overlay__content")).toBeNull();
   });
 
   test("caller model - date value", async () => {

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
@@ -633,7 +633,12 @@ function setToday() {
   dateChanged(new Date());
 }
 
-function onInputClick() {
+function onInputClick(e: MouseEvent) {
+  // Only trigger the menu when clicking the field itself, not the hint/error
+  // text or other parts of the v-input (e.g. `.v-input__details`).
+  if (!(e.target as HTMLElement)?.closest?.(".v-field")) {
+    return;
+  }
   if (menu.value) {
     // Menu already open - switch to text editing mode (shows keyboard on mobile)
     isEditingInput.value = true;


### PR DESCRIPTION
Clicking anywhere in the `c-datetime-picker`'s `v-input` used to open the picker menu, including the hint/error text area below the field. That felt weird and annoying since clicking non-interactive hint text shouldn't trigger the popup.

The click activator is now scoped to only fire when the click lands inside the `.v-field` element. Clicking the field, input, or icon still opens the menu; clicking the hint or error message text in `.v-input__details` no longer does.

Added a test covering the hint-click case.