### PR TITLE
feat: add onStart/onStop/onSaved/onError callbacks to autosave options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `useAppUpdateCheck` now persists the observed build in `sessionStorage` (keyed by a fingerprint of loaded script URLs), enabling detection of server updates after a browser discards and restores a tab from cached HTML.
 - Added `limit` option to `useResponseCaching` to cap the number (`maxEntries`) or total size (`maxBytes`) of cached responses per endpoint group. Oldest entries are evicted first when limits are exceeded.
 - `c-select`: Added `returnViewModel` prop, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
+- Added `onStart`, `onStop`, `onSaved`, and `onError` callbacks to `AutoSaveOptions` (`$startAutoSave`/`$useAutoSave`). Each callback receives the affected view model, making it practical to observe the save lifecycle of individual entities when using deep auto-saves.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 - `c-display`: now auto-refreshes date distance formatting (`format: { distance: true }`) using an adaptive refresh interval based on the displayed distance.
 - Fixed `parseJSONDate` incorrectly adding 1900 to years 0-99 due to JavaScript's `Date` constructor behavior (e.g. "0001-01-01" was parsed as year 1901).

--- a/docs/stacks/vue/layers/viewmodels.md
+++ b/docs/stacks/vue/layers/viewmodels.md
@@ -244,8 +244,30 @@ type AutoSaveOptions<TThis> =
         Only allowed if not using deep auto-saves.
     */
     predicate?: (viewModel: TThis) => boolean;
+
+    /** Called when auto-save is started on a view model. With `deep` auto-saves,
+        this is invoked for each entity as auto-save is attached to it, including
+        entities attached to the graph after auto-save was started. */
+    onStart?: (viewModel: TThis) => void;
+
+    /** Called when auto-save is stopped on a view model, either explicitly via
+        `$stopAutoSave()` or automatically when the owning Vue component is unmounted.
+        Since `$stopAutoSave()` is not recursive, calling it on a `deep` root only
+        invokes this for the root; it is invoked for every entity on unmount. */
+    onStop?: (viewModel: TThis) => void;
+
+    /** Called after an auto-save `$save` completes successfully. With `deep`
+        auto-saves, receives whichever entity in the graph was saved. */
+    onSaved?: (viewModel: TThis) => void;
+
+    /** Called if an auto-save `$save` fails. With `deep` auto-saves, receives
+        whichever entity in the graph failed to save. Not invoked for saves that
+        were skipped due to client validation errors or a `predicate`. */
+    onError?: (viewModel: TThis, error: unknown) => void;
 }
 ```
+
+The `onStart`, `onStop`, `onSaved`, and `onError` callbacks are especially useful with `deep` auto-saves, where entities are attached to the object graph dynamically and there is otherwise no central place to observe the save lifecycle of each individual entity.
 
 <Prop def="$stopAutoSave(): void" lang="ts" />
     

--- a/src/coalesce-vue/src/viewmodel.ts
+++ b/src/coalesce-vue/src/viewmodel.ts
@@ -1167,12 +1167,19 @@ export abstract class ViewModel<
           // Everything should be good to go. Go forth and save!
           ranOnce = true;
           this.$save()
-            // After the save finishes, attempt another autosave.
-            // If the model has become dirty since the last save,
-            // we need to save again.
-            // This will happen if the state of the model changes while the save
-            // is in-flight.
-            .then(enqueueSave)
+            .then(
+              () => {
+                options.onSaved?.(this);
+                // After the save finishes, attempt another autosave.
+                // If the model has become dirty since the last save,
+                // we need to save again.
+                // This will happen if the state of the model changes while the save
+                // is in-flight.
+                enqueueSave();
+              },
+              // Report the failure to the caller-provided callback.
+              (error) => options.onError?.(this, error),
+            )
             // We need a catch block so all of this is testable.
             // Otherwise, jest will fail tests as soon as it sees an unhandled promise rejection.
             .catch(() => {});
@@ -1195,6 +1202,17 @@ export abstract class ViewModel<
     };
 
     startAutoCall(state, vue, undefined, enqueueSave);
+
+    // Wrap the cleanup installed by startAutoCall so that `onStop` is invoked
+    // when auto-save is actually deactivated (either explicitly or on unmount).
+    const innerCleanup = state.cleanup;
+    state.cleanup = () => {
+      const wasActive = state.active;
+      innerCleanup?.();
+      if (wasActive) options.onStop?.(this);
+    };
+
+    options.onStart?.(this);
     state.trigger();
 
     if (options.deep) {
@@ -2152,24 +2170,56 @@ type AutoLoadOptions<TThis> = DebounceOptions & {
   immediate?: boolean;
 };
 
+type AutoSaveCallbacks<TVm> = {
+  /** A function that is called when auto-save is started on a view model.
+   *
+   * With `deep` auto-saves, this is invoked for each entity in the object graph
+   * as auto-save is attached to it - including entities that get attached to the
+   * graph (via navigation properties or collections) after auto-save was started. */
+  onStart?: (viewModel: TVm) => void;
+
+  /** A function that is called when auto-save is stopped on a view model,
+   * either explicitly via `$stopAutoSave()` or automatically when the Vue
+   * component that owns the auto-save is unmounted.
+   *
+   * Note that `$stopAutoSave()` is not recursive, so when using `deep` auto-saves,
+   * calling `$stopAutoSave()` on a root model will only invoke this for that root.
+   * The callback will still be invoked for every entity when the owning component unmounts. */
+  onStop?: (viewModel: TVm) => void;
+
+  /** A function that is called after an auto-save `$save` completes successfully.
+   *
+   * With `deep` auto-saves, this is invoked for whichever entity in the object
+   * graph was saved. */
+  onSaved?: (viewModel: TVm) => void;
+
+  /** A function that is called if an auto-save `$save` fails with an error.
+   *
+   * With `deep` auto-saves, this is invoked for whichever entity in the object
+   * graph failed to save. This is only invoked for failures of the save request
+   * itself - saves that are skipped due to client-side validation errors
+   * (observable via `$hasError`) or a `predicate` do not invoke this callback. */
+  onError?: (viewModel: TVm, error: unknown) => void;
+};
+
 type AutoSaveOptions<TThis> = DebounceOptions &
   (
-    | {
+    | ({
         /** A function that will be called before autosaving that can return false to prevent a save. */
         predicate?: (viewModel: TThis) => boolean;
 
         /** If true, auto-saving will also be enabled for all view models that are
          * reachable from the navigation properties & collections of the current view model. */
         deep?: false;
-      }
-    | {
+      } & AutoSaveCallbacks<TThis>)
+    | ({
         /** A function that will be called before autosaving that can return false to prevent a save. */
         predicate?: (viewModel: ViewModel) => boolean;
 
         /** If true, auto-saving will also be enabled for all view models that are
          * reachable from the navigation properties & collections of the current view model. */
         deep: true;
-      }
+      } & AutoSaveCallbacks<ViewModel>)
   );
 
 export interface BulkSaveOptions {

--- a/src/coalesce-vue/test/viewmodel.spec.ts
+++ b/src/coalesce-vue/test/viewmodel.spec.ts
@@ -2183,6 +2183,166 @@ describe("ViewModel", () => {
         expect(parent.currentCourse?.name).toBe("Math");
       });
     });
+
+    describe("callbacks", () => {
+      test("onStart is called on start, onStop on stop", async () => {
+        const student = new StudentViewModel({ studentId: 1, name: "bob" });
+        student.$isDirty = false;
+        const vue = mountData({ student });
+
+        const onStart = vitest.fn();
+        const onStop = vitest.fn();
+        student.$startAutoSave(vue, { wait: 0, onStart, onStop });
+
+        expect(onStart).toBeCalledTimes(1);
+        expect(onStart).toBeCalledWith(student);
+        expect(onStop).toBeCalledTimes(0);
+
+        student.$stopAutoSave();
+        expect(onStop).toBeCalledTimes(1);
+        expect(onStop).toBeCalledWith(student);
+
+        // Stopping again should not re-invoke onStop.
+        student.$stopAutoSave();
+        expect(onStop).toBeCalledTimes(1);
+      });
+
+      test("onSaved is called after a successful save", async () => {
+        const student = new StudentViewModel({ studentId: 1, name: "bob" });
+        student.$isDirty = false;
+        student.$apiClient.save = vitest.fn().mockResolvedValue(<
+          AxiosItemResult<any>
+        >{
+          data: { wasSuccessful: true },
+        });
+        const vue = mountData({ student });
+
+        const onSaved = vitest.fn();
+        const onError = vitest.fn();
+        student.$startAutoSave(vue, { wait: 0, onSaved, onError });
+
+        student.name = "changed";
+        await delay(10);
+
+        expect(onSaved).toBeCalledTimes(1);
+        expect(onSaved).toBeCalledWith(student);
+        expect(onError).toBeCalledTimes(0);
+      });
+
+      test("onError is called when a save fails", async () => {
+        const student = new StudentViewModel({ studentId: 1, name: "bob" });
+        student.$isDirty = false;
+        const error = new Error("save failed");
+        student.$apiClient.save = vitest.fn().mockRejectedValue(error);
+        const vue = mountData({ student });
+
+        const onSaved = vitest.fn();
+        const onError = vitest.fn();
+        student.$startAutoSave(vue, { wait: 0, onSaved, onError });
+
+        student.name = "changed";
+        await delay(100);
+
+        expect(onError).toBeCalledTimes(1);
+        expect(onError).toBeCalledWith(student, error);
+        expect(onSaved).toBeCalledTimes(0);
+      });
+
+      test("deep: onStart is called for each entity, including newly attached", async () => {
+        const student = new StudentViewModel(
+          new Student({
+            studentId: 1,
+            studentAdvisorId: 3,
+            advisor: { advisorId: 3, name: "Bob" },
+          }),
+        );
+        student.$isDirty = false;
+        const vue = mountData({ student });
+
+        const started: ViewModel[] = [];
+        student.$startAutoSave(vue, {
+          wait: 0,
+          deep: true,
+          onStart: (vm) => started.push(vm),
+        });
+
+        // Root + existing advisor should have been reported.
+        expect(started).toContain(student);
+        expect(started).toContain(student.advisor);
+        const countAfterStart = started.length;
+
+        // Attaching a new entity to the graph reports it too.
+        const newCourse = student.$addChild("courses") as CourseViewModel;
+        expect(started).toContain(newCourse);
+        expect(started.length).toBe(countAfterStart + 1);
+      });
+
+      test("deep: onSaved reports the specific entity that was saved", async () => {
+        const student = new StudentViewModel(
+          new Student({
+            studentId: 1,
+            studentAdvisorId: 3,
+            advisor: { advisorId: 3, name: "Bob" },
+          }),
+        );
+        student.$isDirty = false;
+        student.advisor!.$isDirty = false;
+        student.advisor!.$apiClient.save = vitest
+          .fn()
+          .mockResolvedValue(<AxiosItemResult<any>>{
+            data: { wasSuccessful: true },
+          });
+        student.$apiClient.save = vitest
+          .fn()
+          .mockResolvedValue(<AxiosItemResult<any>>{
+            data: { wasSuccessful: true },
+          });
+        const vue = mountData({ student });
+
+        const saved: ViewModel[] = [];
+        student.$startAutoSave(vue, {
+          wait: 0,
+          deep: true,
+          onSaved: (vm) => saved.push(vm),
+        });
+
+        student.advisor!.name = "changed";
+        await delay(10);
+
+        expect(saved).toContain(student.advisor);
+        expect(saved).not.toContain(student);
+      });
+
+      test("deep: onStop is called for each entity on unmount", async () => {
+        const student = new StudentViewModel(
+          new Student({
+            studentId: 1,
+            studentAdvisorId: 3,
+            advisor: { advisorId: 3, name: "Bob" },
+          }),
+        );
+        student.$isDirty = false;
+
+        const stopped: ViewModel[] = [];
+        const wrapper = mount(
+          defineComponent({
+            setup() {
+              student.$startAutoSave(getCurrentInstance()!.proxy!, {
+                wait: 0,
+                deep: true,
+                onStop: (vm) => stopped.push(vm),
+              });
+            },
+            template: "<div></div>",
+          }),
+        );
+
+        destroy(wrapper);
+
+        expect(stopped).toContain(student);
+        expect(stopped).toContain(student.advisor);
+      });
+    });
   });
 
   describe("$addChild", () => {


### PR DESCRIPTION
## Why

Deep auto-saves attach and detach auto-save from entities as they enter and leave the object graph (new navigation properties, loaded collections, `$addChild`). Today there's no central place to observe the save lifecycle of each individual entity, so reacting to a successful/failed save or knowing when auto-save was attached to a nested entity requires wiring `$save.onFulfilled`/`onRejected` on every entity by hand.

## What

Adds four optional callbacks to `AutoSaveOptions` (usable from both `$startAutoSave` and `$useAutoSave`, on item and list view models):

- `onStart(vm)` - invoked per entity as auto-save attaches, including entities attached to the graph *after* start.
- `onStop(vm)` - invoked when auto-save deactivates (explicit `$stopAutoSave()` or component unmount).
- `onSaved(vm)` - invoked after a successful auto-save `$save`.
- `onError(vm, error)` - invoked when an auto-save `$save` fails.

Each callback receives the affected view model, which is essential under `deep` since a single options object is shared across the whole graph.

## Notes for reviewers

- `onError` fires only on actual `$save` rejections. Saves skipped due to client validation errors (already observable via `$hasError`) or a `predicate` do not invoke it, since no save is attempted.
- Consistent with existing behavior, `$stopAutoSave()` is not recursive: stopping a deep root only fires `onStop` for the root. On component unmount, `onStop` fires for every entity. This is documented in the callback doc comments and the ViewModels docs.
- Callbacks fire on actual entities, not on the `ListViewModel` container (a list never saves; its items each fire their own).

Includes 6 new unit tests covering start/stop/saved/error for both shallow and deep cases, plus CHANGELOG and documentation updates. Full coalesce-vue suite passes (683 tests).