### PR TITLE
Change default color of `c-datetime-picker` to `primary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking Changes
 - The generated ViewModel stubs for abstract model types have been replaced by static objects with a static `.load(id)` method that returns a standard `ItemApiState` caller. They are no longer exposed as instantiable proxy objects that mutate themselves into the correct implementation type after `$load`ing from the server - this approach did not fully satisfy the TypeScript contract of the derived types at runtime and otherwise attempted (and failed) to provide a concrete instance of a type that should not actually be instantiable.
 - Removed the `coalesce_generate` MCP tool, which was created back when agents didn't support terminal auto-approvals. Update your projects' agent guidance to instead run `dotnet coalesce` in your `.Web` project.
+- The default `color` of `c-datetime-picker` is now `primary` instead of `secondary`. Pass `color="secondary"` to restore the previous appearance.
 
 ## Frontend
 - Added `adminExtensions` option to `createCoalesceVuetify()`, allowing per-type or global extension components to be injected into admin pages. Supported extension points: `tableToolbarActions`, `editorToolbarActions`, `editorActions`, `tableRowActions`, `tablePageHeader`, and `editorPageHeader`. Each corresponding component also exposes a slot for conventional per-instance customization.

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-datetime-picker.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-datetime-picker.md
@@ -88,6 +88,10 @@ Does not impact time selection.
 The [IANA Time Zone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) name that the user will pick the date/time value in.
 Defaults to the value configured with [`setDefaultTimeZone`](/stacks/vue/layers/models.md#setdefaulttimezone) if the value bound to with `model`/`for` is a `DateTimeOffset`.
 
+<Prop def="color?: string = 'primary'" lang="ts" />
+
+The Vuetify theme color used by the date and time pickers in the popup menu.
+
 <Prop def="native?: boolean" lang="ts" />
 
 True if a native HTML5 input should be used instead of a popup menu with date/time pickers inside of it.

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
@@ -263,7 +263,7 @@ const props = withDefaults(
       showTodayButton?: boolean;
     } & /* @vue-ignore */ InheritedProps
   >(),
-  { closeOnDatePicked: null, color: "secondary" },
+  { closeOnDatePicked: null, color: "primary" },
 );
 
 defineSlots<InheritedSlots>();

--- a/src/coalesce-vue-vuetify3/src/components/input/c-time-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-time-picker.vue
@@ -100,7 +100,7 @@ const props = withDefaults(
     max?: Date | null;
     color?: string | null;
   }>(),
-  { step: 1, color: "secondary" },
+  { step: 1, color: "primary" },
 );
 
 const emit = defineEmits<{


### PR DESCRIPTION
## What

Breaking change: the default `color` of `c-datetime-picker` is now `primary` instead of `secondary`.

## Why

The color prop feeds the `v-date-picker`, the "Today" button, the popup close button, and the nested time picker. `secondary` renders those in a theme color unrelated to the selection/active color used by the rest of the input components, so the popup looked disconnected from the app's palette.

## Changes

- `c-datetime-picker.vue` — `withDefaults` default for `color` changed from `"secondary"` to `"primary"`.
- `c-time-picker.vue` — matched its own fallback default. This component isn't exported from the package and is only consumed by `c-datetime-picker`, which always passes `color` explicitly; the change just keeps the internal default from diverging.
- `CHANGELOG.md` — entry under 7.0.0 **Breaking Changes**.
- `docs/.../c-datetime-picker.md` — the `color` prop was undocumented; added it to the Props section with the new default.

## Migration

Pass `color="secondary"` to any `c-datetime-picker` that should keep the previous appearance.

## Notes for reviewers

No tests assert on the color value, so nothing in the spec files needed updating.
