### PR TITLE
fix: name the data protection application in the Vue template

### DIFF
--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Program.cs
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/Program.cs
@@ -88,7 +88,9 @@ services.AddCoalesce<AppDbContext>(
 #else
 services.AddCoalesce<AppDbContext>();
 #endif
-services.AddDataProtection().PersistKeysToDbContext<AppDbContext>();
+services.AddDataProtection()
+    .SetApplicationName("Coalesce.Starter.Vue")
+    .PersistKeysToDbContext<AppDbContext>();
 services.AddMvc();
 
 #if BlobStorage


### PR DESCRIPTION
Running a generated solution from two directories at once — two worktrees, or a copy alongside the original —
makes the two instances evict each other's login. Signing in to one signs you out of the other, and signing
back in there returns the favour.

## Why

Data protection derives a per-application subkey from an *application discriminator*, and the default
discriminator is `IHostEnvironment.ContentRootPath` — the directory the app runs out of.

`PersistKeysToDbContext<AppDbContext>` puts the master key ring in the database, which both instances share.
The master keys are therefore already common; the discriminators are not, so the derived subkeys differ and
neither instance can unprotect what the other protected.

The auth cookie is such a payload. Cookies are scoped by host and ignore the port
([RFC 6265 §8.5](https://www.rfc-editor.org/rfc/rfc6265#section-8.5)), so both instances on `localhost` write
to one cookie slot named `.AspNetCore.Identity.Application`. Put together:

1. Sign in on instance A. Its cookie lands in the shared slot.
2. Instance B receives any request. It cannot unprotect the cookie, so it treats the request as anonymous
   **and deletes the cookie**.
3. A is signed out. Signing in on A again evicts B.

It stays latent while only one instance serves a given cookie jar, and bites as soon as two do — which the
Aspire host makes easy, since it gives each instance its own port but not its own host.

## The change

`SetApplicationName` makes the discriminator explicit, so it no longer depends on where the app happens to
be running from. `sourceName` substitution turns the literal into the generated project's name, so every
generated solution still gets a discriminator distinct from every other one — just a stable one.

The alternative would be to give each instance its own cookie name so that nothing can touch anything
else's session, but that costs a separate sign-in per directory where this keeps one.
