### PR TITLE
fix: keep `c-select`'s input on the same line as a wrapping selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `c-display`: now auto-refreshes date distance formatting (`format: { distance: true }`) using an adaptive refresh interval based on the displayed distance.
 - Fixed `parseJSONDate` incorrectly adding 1900 to years 0-99 due to JavaScript's `Date` constructor behavior (e.g. "0001-01-01" was parsed as year 1901).
 - Fixed `$save` invocations downgrading type discriminators to their base types on nested polymorphic objects.
+- Fixed `c-select` in single-select mode placing its text input on a line of its own when the selected item is too wide to fit on one line, adding an empty line to the bottom of the field.
 
 ## Backend
 - Added `IntelliTect.Coalesce.MultiTenancy` package, extracting the template's multi-tenancy database mechanics into a reusable library to reduce boilerplate duplication in projects.

--- a/playground/Coalesce.Web.Vue3/src/examples/c-select/wrapping-content.vue
+++ b/playground/Coalesce.Web.Vue3/src/examples/c-select/wrapping-content.vue
@@ -1,0 +1,58 @@
+<template>
+  <h1>Narrow field, long selection</h1>
+  <v-row>
+    <v-col cols="3">
+      <v-card class="pa-3" title="Default display">
+        <c-select v-model:object-value="person1" for="Person" clearable />
+      </v-card>
+    </v-col>
+    <v-col cols="3">
+      <v-card class="pa-3" title="#item slot">
+        <c-select v-model:object-value="person2" for="Person" clearable>
+          <template #item="{ item }">
+            {{ item.name }}
+            <v-chip size="small" color="green" class="ml-2">Active</v-chip>
+          </template>
+        </c-select>
+      </v-card>
+    </v-col>
+    <v-col cols="3">
+      <v-card class="pa-3" title="Outlined + label">
+        <c-select
+          v-model:object-value="person3"
+          for="Person"
+          label="Primary Contact"
+          variant="outlined"
+          clearable
+        >
+          <template #item="{ item }">
+            {{ item.name }}
+            <v-chip size="small" color="green" class="ml-2">Active</v-chip>
+          </template>
+        </c-select>
+      </v-card>
+    </v-col>
+    <v-col cols="3">
+      <v-card class="pa-3" title="Multiple (still wraps)">
+        <c-select v-model="people" for="Person" multiple clearable />
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { Person } from "@/models.g";
+import { ref } from "vue";
+
+function person(name: string, id: number) {
+  return new Person({ personId: id, name });
+}
+
+const person1 = ref<Person>(person("Anastasia Wojciechowska-Lindqvist", 1));
+const person2 = ref<Person>(person("Bartholomew Fitzgerald-Montgomery", 2));
+const person3 = ref<Person>(person("Alexandria Featherstonehaugh-Whitmore", 3));
+const people = ref<Person[]>([
+  person("Maximilian Van Der Bergstrom", 4),
+  person("Christopher Papadopoulos-Rasmussen", 5),
+]);
+</script>

--- a/src/coalesce-vue-vuetify3/src/components/input/c-select.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-select.vue
@@ -1551,7 +1551,6 @@ defineExpose({
   .v-field__field {
     align-items: center;
     .v-field__input {
-      // flex-wrap: nowrap;
       input {
         min-width: 0;
         flex: 1 1;
@@ -1560,6 +1559,26 @@ defineExpose({
           outline: none;
         }
       }
+    }
+  }
+
+  &:not(.c-select--multiple) {
+    .v-field__field .v-field__input {
+      // Flex line breaking uses each item's max-content size, so a selection
+      // that's wider than the field would otherwise push the (always empty) input
+      // onto a line of its own.
+      flex-wrap: nowrap;
+
+      input {
+        // Reserve room for the caret, since the selection will otherwise
+        // consume every available pixel.
+        min-width: 2px;
+      }
+    }
+    .v-select__selection {
+      // Vuetify only constrains max-width, which leaves the selection unable to
+      // shrink past its min-content size.
+      min-width: 0;
     }
   }
   .v-input__details {


### PR DESCRIPTION
A single-select `c-select` whose selected item is too wide for one line pushed the text field's `<input>` onto a line of its own, leaving an empty line with just a caret at the bottom of the field. Flex line breaking on `.v-field__input` uses each item's max-content size, so the selection claimed an entire flex line regardless of how narrow the input was; `flex-wrap: nowrap` in single-select mode fixes it, and the input needs no width of its own because it is always empty and only captures typeahead keystrokes.

Multiple-select is untouched, since chips wrapping onto additional lines is intended there.