### PR TITLE
feat: menu positioning and activation options for c-datetime-picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `c-select`: Added `returnViewModel` prop, enabling ViewModel instances to be returned directly when bound with `for="TypeName"`.
 - `c-datetime-picker`: Assorted UI and UX improvements and fixes.
 - `c-datetime-picker`: Added `lazy` prop (also usable as the `lazy` modifier on `v-model`) that defers updates to the bound value until the input is committed, rather than publishing every keystroke.
+- `c-datetime-picker`: Added `openOn` prop selecting what opens the popup: `field` (default), `icon`, `focus`, `picker-only` (the text field can't be typed into), or `none`. Arrow up/down also opens it in every mode but `none`.
+- `c-datetime-picker`: Added `menuProps` for passing props to the popup's `v-menu` (e.g. `location`), and `v-model:menu` for opening and closing it from outside the component.
 - `c-display`: now auto-refreshes date distance formatting (`format: { distance: true }`) using an adaptive refresh interval based on the displayed distance.
 - Fixed `parseJSONDate` incorrectly adding 1900 to years 0-99 due to JavaScript's `Date` constructor behavior (e.g. "0001-01-01" was parsed as year 1901).
 - Fixed `$save` invocations downgrading type discriminators to their base types on nested polymorphic objects.
@@ -29,6 +31,7 @@
 - Fixed generated DTO `MapToModelOrNew` mapping a polymorphic property onto an existing instance of the wrong concrete type. It now constructs a new instance of the correct type when the incoming type differs from the existing one, while continuing to update in place when the types match.
 
 ## Template Changes
+- `VDatePicker` now defaults to `controlVariant: "modal"`.
 - Multi-tenancy database configuration is now provided by the `IntelliTect.Coalesce.MultiTenancy` package instead of inline code in `AppDbContext`. To migrate an existing project that doesn't diverge significantly from the previous out-of-the-box Coalesce template tenancy behavior:
   1. Add the package `IntelliTect.Coalesce.MultiTenancy`
   2. In `OnConfiguring`, replace `.AddInterceptors(new TenantInterceptor())` with:

--- a/docs/stacks/vue/coalesce-vue-vuetify/components/c-datetime-picker.md
+++ b/docs/stacks/vue/coalesce-vue-vuetify/components/c-datetime-picker.md
@@ -92,6 +92,37 @@ Defaults to the value configured with [`setDefaultTimeZone`](/stacks/vue/layers/
 
 The Vuetify theme color used by the date and time pickers in the popup menu.
 
+<Prop def="openOn?: 'field' | 'icon' | 'focus' | 'picker-only' | 'none' = 'field'" lang="ts" />
+
+Determines how the popup containing the date and time pickers is opened:
+
+| | |
+|---|---|
+| `field` | Clicking anywhere in the text field. |
+| `icon` | Clicking the calendar/clock icon. The text field is left free for typing. |
+| `focus` | Focusing the text field, including by clicking it. |
+| `picker-only` | Clicking the text field, which cannot be typed into. The value can only be set with the pickers. |
+| `none` | Not by any interaction with the component, leaving a text field that parses typed dates. The popup can still be opened with `v-model:menu`. |
+
+Pressing `ArrowUp` or `ArrowDown` in the text field also opens the popup in every mode except `none`. `native` inputs use the browser's own picker, so this prop has no effect on them.
+
+<Prop def="v-model:menu?: boolean" lang="ts" />
+
+The open state of the popup, for opening or closing it from outside the component.
+
+``` vue-html
+<c-datetime-picker :model="person" for="birthDate" open-on="none" v-model:menu="menu" />
+<v-btn @click="menu = !menu"> Pick a date </v-btn>
+```
+
+<Prop def="menuProps?: VMenu['$props']" lang="ts" />
+
+Props to pass to the [v-menu](https://vuetifyjs.com/en/api/v-menu/) that contains the date and time pickers. For example, `:menu-props="{ location: 'end center' }"` opens the popup to the right of the input instead of below it.
+
+<Prop def="datePickerProps?: VDatePicker['$props']" lang="ts" />
+
+Props to pass to the [v-date-picker](https://vuetifyjs.com/en/api/v-date-picker/) inside the popup menu.
+
 <Prop def="native?: boolean" lang="ts" />
 
 True if a native HTML5 input should be used instead of a popup menu with date/time pickers inside of it.

--- a/playground/Coalesce.Web.Vue3/src/examples/c-datetime-picker/open-on.vue
+++ b/playground/Coalesce.Web.Vue3/src/examples/c-datetime-picker/open-on.vue
@@ -1,0 +1,49 @@
+<template>
+  <h1>openOn</h1>
+  <v-row v-for="mode in modes" :key="mode" class="align-center">
+    <v-col>
+      <c-datetime-picker
+        v-model="values[mode]"
+        :label="mode"
+        :open-on="mode"
+        date-kind="date"
+        clearable
+      ></c-datetime-picker>
+    </v-col>
+    <v-col :id="'value-' + mode"> {{ values[mode] }} </v-col>
+  </v-row>
+
+  <h1>v-model:menu</h1>
+  <v-row class="align-center">
+    <v-col>
+      <c-datetime-picker
+        v-model="externalDate"
+        v-model:menu="menu"
+        label="open-on=none"
+        open-on="none"
+        clearable
+      ></c-datetime-picker>
+    </v-col>
+    <v-col>
+      <v-btn id="toggle-menu" @click="menu = !menu">Toggle menu</v-btn>
+    </v-col>
+    <v-col id="menu-state"> menu: {{ menu }} </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+const modes = ["field", "icon", "focus", "picker-only", "none"] as const;
+
+const values = ref<Record<(typeof modes)[number], Date | null>>({
+  field: new Date(2026, 5, 6),
+  icon: new Date(2026, 5, 6),
+  focus: new Date(2026, 5, 6),
+  "picker-only": new Date(2026, 5, 6),
+  none: new Date(2026, 5, 6),
+});
+
+const externalDate = ref<Date | null>(new Date(2026, 5, 6));
+const menu = ref(false);
+</script>

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
@@ -877,6 +877,11 @@ describe("CDatetimePicker", () => {
       await flushPromises();
       expect(menuState()).toBe("absent");
 
+      // Nothing the user can expand, so the combobox attributes are dropped.
+      expect(input.attributes("role")).toBeUndefined();
+      expect(input.attributes("aria-expanded")).toBeUndefined();
+      expect(input.attributes("aria-controls")).toBeUndefined();
+
       // Text entry still works.
       await input.setValue("1/3/2017");
       await delay(1);

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
@@ -1,4 +1,11 @@
-import { delay, mount, mountApp, openMenu, flushPromises } from "@test/util";
+import {
+  delay,
+  mount,
+  mountApp,
+  openMenu,
+  getWrapper,
+  flushPromises,
+} from "@test/util";
 import { CDatetimePicker } from "..";
 import { Case, ComplexModel } from "@test-targets/models.g";
 import { ComplexModelViewModel } from "@test-targets/viewmodels.g";
@@ -54,6 +61,17 @@ describe("CDatetimePicker", () => {
     () => <CDatetimePicker modelValue={selectedDate} />;
     //@ts-expect-error wrong value type
     () => <CDatetimePicker modelValue={selectedDate as string} />;
+
+    () => <CDatetimePicker modelValue={selectedDate} openOn="picker-only" />;
+    //@ts-expect-error not an activation mode
+    () => <CDatetimePicker modelValue={selectedDate} openOn="whenever" />;
+    () => (
+      <CDatetimePicker
+        modelValue={selectedDate}
+        menu={true}
+        onUpdate:menu={(v: boolean) => {}}
+      />
+    );
 
     // *****
     // API caller args
@@ -725,6 +743,246 @@ describe("CDatetimePicker", () => {
       await delay(1);
 
       expect(model.systemDateOnly?.getFullYear()).toBe(2017);
+    });
+  });
+
+  describe("openOn", () => {
+    /** The overlay element persists after closing, so its visibility is what tells them apart. */
+    function menuState() {
+      const el = document.querySelector(".v-overlay__content") as HTMLElement;
+      if (!el) return "absent";
+      return el.style.display == "none" ? "closed" : "open";
+    }
+
+    test("field: clicking the field opens the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="field" />
+      )).findComponent(CDatetimePicker);
+
+      await openMenu(wrapper);
+      expect(menuState()).toBe("open");
+    });
+
+    test("field: the icon is not a tab stop", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      expect(
+        wrapper.find(".v-field__append-inner .v-icon").attributes("tabindex"),
+      ).toBeUndefined();
+    });
+
+    test("icon: clicking the field does not open the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="icon" />
+      )).findComponent(CDatetimePicker);
+
+      await openMenu(wrapper);
+      expect(menuState()).toBe("absent");
+      expect(wrapper.find("input").element.readOnly).toBe(false);
+    });
+
+    test("icon: clicking the icon toggles the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="icon" />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      const icon = wrapper.find(".v-field__append-inner .v-icon");
+      // The click handler also makes the icon reachable by keyboard.
+      expect(icon.attributes("tabindex")).toBe("0");
+
+      await icon.trigger("click");
+      await flushPromises();
+      expect(menuState()).toBe("open");
+
+      await icon.trigger("click");
+      await flushPromises();
+      expect(menuState()).toBe("closed");
+    });
+
+    test("focus: focusing the field opens the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="focus" />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      await wrapper.find("input").trigger("focus");
+      await flushPromises();
+      expect(menuState()).toBe("open");
+    });
+
+    test("focus: closing the menu does not reopen it", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="focus" />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      const input = wrapper.find("input");
+      await input.trigger("focus");
+      await flushPromises();
+
+      // Simulate the menu having taken focus, as it does when opened.
+      await input.trigger("blur");
+      await flushPromises();
+
+      // Closing returns focus to the field, which must not open it again.
+      await getWrapper(".c-datetime-picker__close-btn").trigger("click");
+      await flushPromises();
+      expect(menuState()).toBe("closed");
+    });
+
+    test("picker-only: the field cannot be typed into", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker
+          model={model}
+          for="systemDateOnly"
+          openOn="picker-only"
+        />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      expect(wrapper.find("input").element.readOnly).toBe(true);
+    });
+
+    test("picker-only: clicking the field toggles the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker
+          model={model}
+          for="systemDateOnly"
+          openOn="picker-only"
+        />
+      )).findComponent(CDatetimePicker);
+
+      await openMenu(wrapper);
+      expect(menuState()).toBe("open");
+
+      await wrapper.find(".v-field").trigger("click");
+      await flushPromises();
+      expect(menuState()).toBe("closed");
+    });
+
+    test("none: nothing in the component opens the menu", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" openOn="none" />
+      )).findComponent(CDatetimePicker);
+
+      await openMenu(wrapper);
+      expect(menuState()).toBe("absent");
+
+      const input = wrapper.find("input");
+      await input.trigger("keydown.down");
+      await flushPromises();
+      expect(menuState()).toBe("absent");
+
+      // Text entry still works.
+      await input.setValue("1/3/2017");
+      await delay(1);
+      expect(model.systemDateOnly?.getFullYear()).toBe(2017);
+    });
+
+    test("none: v-model:menu still opens the menu", async () => {
+      const menu = ref(false);
+      mountApp(() => (
+        <CDatetimePicker
+          model={model}
+          for="systemDateOnly"
+          openOn="none"
+          menu={menu.value}
+          onUpdate:menu={(v: boolean) => (menu.value = v)}
+        />
+      ));
+      await flushPromises();
+
+      menu.value = true;
+      await flushPromises();
+      expect(menuState()).toBe("open");
+    });
+
+    test("readonly fields have no menu to advertise", async () => {
+      const wrapper = mountApp(() => (
+        <CDatetimePicker model={model} for="systemDateOnly" readonly />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      const input = wrapper.find("input");
+      expect(input.attributes("role")).toBeUndefined();
+      expect(input.attributes("aria-expanded")).toBeUndefined();
+      expect(input.attributes("aria-controls")).toBeUndefined();
+    });
+
+    describe.each(["field", "icon", "focus", "picker-only"] as const)(
+      "%s",
+      (openOn) => {
+        test("arrow down opens the menu, escape closes it", async () => {
+          const wrapper = mountApp(() => (
+            <CDatetimePicker
+              model={model}
+              for="systemDateOnly"
+              openOn={openOn}
+            />
+          )).findComponent(CDatetimePicker);
+          await flushPromises();
+
+          const input = wrapper.find("input");
+          expect(input.attributes("aria-expanded")).toBe("false");
+
+          await input.trigger("keydown.down");
+          await flushPromises();
+          expect(menuState()).toBe("open");
+          expect(input.attributes("aria-expanded")).toBe("true");
+
+          await input.trigger("keydown", { key: "Escape" });
+          await flushPromises();
+          expect(menuState()).toBe("closed");
+        });
+
+        test("arrow up opens the menu", async () => {
+          const wrapper = mountApp(() => (
+            <CDatetimePicker
+              model={model}
+              for="systemDateOnly"
+              openOn={openOn}
+            />
+          )).findComponent(CDatetimePicker);
+          await flushPromises();
+
+          await wrapper.find("input").trigger("keydown.up");
+          await flushPromises();
+          expect(menuState()).toBe("open");
+        });
+      },
+    );
+
+    test("v-model:menu reflects and controls the menu", async () => {
+      const menu = ref(false);
+      const wrapper = mountApp(() => (
+        <CDatetimePicker
+          model={model}
+          for="systemDateOnly"
+          menu={menu.value}
+          onUpdate:menu={(v: boolean) => (menu.value = v)}
+        />
+      )).findComponent(CDatetimePicker);
+      await flushPromises();
+
+      // Opened by the consumer
+      menu.value = true;
+      await flushPromises();
+      expect(menuState()).toBe("open");
+
+      // Closed by the component
+      await getWrapper(".c-datetime-picker__close-btn").trigger("click");
+      await flushPromises();
+      expect(menu.value).toBe(false);
+      expect(menuState()).toBe("closed");
+
+      // Opened by the component
+      await wrapper.find(".v-field").trigger("click");
+      await flushPromises();
+      expect(menu.value).toBe(true);
     });
   });
 });

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.spec.tsx
@@ -944,6 +944,51 @@ describe("CDatetimePicker", () => {
           expect(menuState()).toBe("closed");
         });
 
+        test("arrow down hands the popup focus", async () => {
+          const wrapper = mountApp(() => (
+            <CDatetimePicker
+              model={model}
+              for="systemDateOnly"
+              openOn={openOn}
+            />
+          )).findComponent(CDatetimePicker);
+          await flushPromises();
+
+          await wrapper.find("input").trigger("keydown.down");
+          await delay(100);
+
+          expect(
+            document.activeElement?.closest(".v-date-picker"),
+          ).toBeTruthy();
+
+          // And back out again, with focus returned to the field.
+          await getWrapper(".v-overlay__content").trigger("keydown", {
+            key: "Escape",
+          });
+          await flushPromises();
+          expect(menuState()).toBe("closed");
+          expect(document.activeElement).toBe(wrapper.find("input").element);
+        });
+
+        test("arrow down hands a time-only popup focus", async () => {
+          const wrapper = mountApp(() => (
+            <CDatetimePicker
+              model={model}
+              for="systemDateOnly"
+              dateKind="time"
+              openOn={openOn}
+            />
+          )).findComponent(CDatetimePicker);
+          await flushPromises();
+
+          await wrapper.find("input").trigger("keydown.down");
+          await delay(100);
+
+          expect(document.activeElement?.className).toContain(
+            "c-time-picker__column-hour",
+          );
+        });
+
         test("arrow up opens the menu", async () => {
           const wrapper = mountApp(() => (
             <CDatetimePicker

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
@@ -31,9 +31,9 @@
     v-bind="textFieldAttrs"
     v-model:focused="focused"
     class="c-datetime-picker"
-    :role="isInteractive ? 'combobox' : undefined"
-    :aria-expanded="isInteractive ? menu : undefined"
-    :aria-controls="isInteractive ? popupId : undefined"
+    :role="canUserOpenMenu ? 'combobox' : undefined"
+    :aria-expanded="canUserOpenMenu ? menu : undefined"
+    :aria-controls="canUserOpenMenu ? popupId : undefined"
     :class="{ 'has-today-btn': showTodayButton }"
     :placeholder="internalFormat"
     :append-inner-icon="appendInnerIcon"
@@ -320,7 +320,8 @@ let ignoreNextFocus = false;
 const { isDisabled, isReadonly, isInteractive } = useCustomInput(props);
 
 // The popup itself exists whenever the field is interactive, even under
-// `openOn: none`, so that `v-model:menu` can still open it.
+// `openOn: none`, so that `v-model:menu` can still open it. The field only
+// carries combobox semantics when the user can expand it from the field.
 const canUserOpenMenu = computed(
   () => isInteractive.value && props.openOn != "none",
 );

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
@@ -28,32 +28,30 @@
   <v-text-field
     v-else
     ref="rootRef"
-    v-bind="inputBindAttrs"
+    v-bind="textFieldAttrs"
     v-model:focused="focused"
     class="c-datetime-picker"
-    role="combobox"
-    :aria-expanded="menu"
-    :aria-controls="popupId"
+    :role="isInteractive ? 'combobox' : undefined"
+    :aria-expanded="isInteractive ? menu : undefined"
+    :aria-controls="isInteractive ? popupId : undefined"
     :class="{ 'has-today-btn': showTodayButton }"
     :placeholder="internalFormat"
-    :append-inner-icon="
-      internalDateKind == 'time'
-        ? 'fa fa-clock cursor-pointer'
-        : 'fa fa-calendar-alt cursor-pointer'
-    "
+    :append-inner-icon="appendInnerIcon"
     :rules="effectiveRules"
     :modelValue="internalTextValue == null ? displayedValue : internalTextValue"
     :validation-value="internalValue"
     :error-messages="error"
     :inputmode="inputmode"
-    :readonly="isReadonly"
+    :readonly="isTextReadonly"
     :disabled="isDisabled"
     autocomplete="off"
     @keydown.enter="acceptInput()"
     @keydown.escape="acceptInput()"
+    @keydown.capture.down="onArrowKeydown"
+    @keydown.capture.up="onArrowKeydown"
     @keydown.tab="
       acceptInput();
-      closeMenu();
+      closeMenu(false);
     "
     @update:model-value="textInputChanged($event, false)"
     @click:clear="acceptInput()"
@@ -74,6 +72,7 @@
         stick-to-target
         :scroll-strategy="$vuetify.display.xs ? 'block' : undefined"
         min-width="1px"
+        v-bind="menuProps"
         @update:model-value="!$event ? closeMenu() : openMenu()"
       >
         <v-card :id="popupId" class="d-flex" @keydown.enter="closeMenu()">
@@ -138,7 +137,7 @@
 </template>
 
 <script lang="ts">
-import { VTextField, VDatePicker } from "vuetify/components";
+import { VTextField, VDatePicker, VMenu } from "vuetify/components";
 import { TypedValidationRule } from "../../util";
 
 type InheritedProps = Omit<
@@ -267,12 +266,25 @@ const props = withDefaults(
       allowedDates?: null | Date[] | ((date: Date) => boolean);
       // Object containing extra props to pass through to `v-date-picker`.
       datePickerProps?: DatePickerProps;
+      /** Props to pass to the underlying v-menu component */
+      menuProps?: VMenu["$props"] & { [s: string]: any };
+      /** How the date/time picker popup is opened:
+       * * `field` (default) - clicking anywhere in the text field.
+       * * `icon` - clicking the calendar/clock icon. The text field is left
+       *   free for typing.
+       * * `focus` - focusing the text field, including by clicking it.
+       * * `picker-only` - clicking the text field, which cannot be typed into.
+       * * `none` - by nothing in the component. `v-model:menu` still works.
+       *
+       * Arrow up/down also opens the popup, except when `none`.
+       * Has no effect when `native`. */
+      openOn?: "field" | "icon" | "focus" | "picker-only" | "none";
       /** Determines whether the 'Today' button is displayed in the date picker actions.
        * When enabled, the 'Today' button allows users to quickly select the current date. */
       showTodayButton?: boolean;
     } & /* @vue-ignore */ InheritedProps
   >(),
-  { closeOnDatePicked: null, color: "primary" },
+  { closeOnDatePicked: null, color: "primary", openOn: "field" },
 );
 
 defineSlots<InheritedSlots>();
@@ -288,7 +300,8 @@ const { inputBindAttrs, valueMeta, valueOwner } = useMetadataProps(props);
 
 const focused = ref(false);
 const error = ref<string[]>([]);
-const menu = ref(false);
+/** The open state of the popup. */
+const menu = defineModel<boolean>("menu", { default: false });
 const internalTextValue = ref<string>();
 
 const { mobile } = useDisplay();
@@ -300,7 +313,33 @@ const inputmode = computed(() =>
   mobile.value && !isEditingInput.value ? "none" : undefined,
 );
 
+// Set while closing the menu returns focus to the field, so that `openOn: focus`
+// doesn't reopen it.
+let ignoreNextFocus = false;
+
 const { isDisabled, isReadonly, isInteractive } = useCustomInput(props);
+
+// The popup itself exists whenever the field is interactive, even under
+// `openOn: none`, so that `v-model:menu` can still open it.
+const canUserOpenMenu = computed(
+  () => isInteractive.value && props.openOn != "none",
+);
+
+// `picker-only` takes its value exclusively from the popup. This deliberately
+// doesn't go through `props.readonly`, which would also disable the popup.
+const isTextReadonly = computed(
+  () => isReadonly.value || props.openOn == "picker-only",
+);
+
+const textFieldAttrs = computed(() => {
+  const attrs = { ...inputBindAttrs.value };
+  // A focusable icon is only wanted when it is the sole way to open the popup;
+  // v-text-field makes the icon a tab stop as soon as it has a click handler.
+  if (props.openOn == "icon") {
+    attrs["onClick:appendInner"] = onIconClick;
+  }
+  return attrs;
+});
 
 // A native input's change event is only raised once a whole date has been entered,
 // so `lazy` has nothing to defer there.
@@ -385,6 +424,12 @@ const internalDateKind = computed((): DateKind => {
   if (props.dateKind) return props.dateKind;
   if (dateMeta.value) return dateMeta.value.dateKind;
   return "datetime";
+});
+
+const appendInnerIcon = computed(() => {
+  const icon =
+    internalDateKind.value == "time" ? "fa fa-clock" : "fa fa-calendar-alt";
+  return canUserOpenMenu.value ? icon + " cursor-pointer" : icon;
 });
 
 const nativeInternalFormat = computed(() => {
@@ -655,22 +700,59 @@ function onInputClick(e: MouseEvent) {
   if (!(e.target as HTMLElement)?.closest?.(".v-field")) {
     return;
   }
-  if (menu.value) {
+  // The icon is inside the field, so it is the icon's handler that acts here.
+  if (props.openOn == "icon") {
+    return;
+  }
+  if (!menu.value) {
+    openMenu();
+  } else if (props.openOn == "picker-only") {
+    // There's nothing to type into, so the field toggles the menu instead.
+    closeMenu();
+  } else {
     // Menu already open - switch to text editing mode (shows keyboard on mobile)
     isEditingInput.value = true;
+  }
+}
+
+function onIconClick() {
+  if (menu.value) {
+    closeMenu();
   } else {
     openMenu();
   }
 }
 
+/** Bound in the capture phase: v-menu's own activator handler swallows arrow keys
+ * with `stopImmediatePropagation`, so a bubbling listener would never see them. */
+function onArrowKeydown(e: KeyboardEvent) {
+  if (!canUserOpenMenu.value) {
+    // v-menu opens itself from the activator's arrow keys, which `none` must not.
+    e.stopPropagation();
+    return;
+  }
+  if (menu.value) return;
+  // Arrow keys open the popup, per the ARIA combobox pattern.
+  e.preventDefault();
+  openMenu();
+}
+
 function openMenu() {
+  if (!canUserOpenMenu.value) return;
   menu.value = true;
 }
 
-function closeMenu() {
+/** @param refocus Whether to return focus to the text field. Tabbing out of the
+ * field must not, or focus lands back where it started - trapping the user when
+ * the icon is a tab stop of its own. */
+function closeMenu(refocus = true) {
   menu.value = false;
   isEditingInput.value = false;
-  rootRef.value?.focus();
+  if (refocus) {
+    // Refocusing would immediately reopen the menu when `openOn: focus`.
+    ignoreNextFocus = props.openOn == "focus";
+    rootRef.value?.focus();
+  }
 }
 
 function acceptInput() {
@@ -819,12 +901,19 @@ function handleDateKeydown(event: KeyboardEvent) {
 }
 
 watch(focused, (focused) => {
-  // When the user is no longer typing into the text field,
-  // clear the temporary value that stores exactly what they typed
-  // so that the text field can fall back to the nicely formatted date.
   if (!focused) {
+    // When the user is no longer typing into the text field,
+    // clear the temporary value that stores exactly what they typed
+    // so that the text field can fall back to the nicely formatted date.
+    ignoreNextFocus = false;
     acceptInput();
+    return;
   }
+
+  if (props.openOn == "focus" && !ignoreNextFocus) {
+    openMenu();
+  }
+  ignoreNextFocus = false;
 });
 </script>
 

--- a/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
+++ b/src/coalesce-vue-vuetify3/src/components/input/c-datetime-picker.vue
@@ -317,6 +317,9 @@ const inputmode = computed(() =>
 // doesn't reopen it.
 let ignoreNextFocus = false;
 
+// Set while the popup is being opened by keyboard, which hands it focus.
+let openedByKeyboard = false;
+
 const { isDisabled, isReadonly, isInteractive } = useCustomInput(props);
 
 // The popup itself exists whenever the field is interactive, even under
@@ -735,8 +738,42 @@ function onArrowKeydown(e: KeyboardEvent) {
   if (menu.value) return;
   // Arrow keys open the popup, per the ARIA combobox pattern.
   e.preventDefault();
+  openedByKeyboard = true;
   openMenu();
 }
+
+/** Hands the popup focus, so that the pickers' own arrow key navigation can take
+ * over. Only wanted for a keyboard open: a mouse user arrives by clicking. */
+async function focusPopup() {
+  // v-menu's transition holds the popup's contents at `visibility: hidden` for
+  // its first couple of frames, and an invisible element can't take focus, so
+  // keep trying until it does. Timers rather than frames, so that this also
+  // works where frames aren't painted, e.g. jsdom.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (!menu.value) return;
+
+    const target = showDate.value
+      ? (datePickerRef.value?.$el as HTMLElement | undefined)
+      : (
+          timePickerRef.value?.$el as HTMLElement | undefined
+        )?.querySelector<HTMLElement>(".c-time-picker__column-hour");
+
+    if (target?.contains(document.activeElement)) return;
+    target?.focus();
+    if (target && document.activeElement == target) return;
+
+    await new Promise((resolve) => setTimeout(resolve, 16));
+  }
+}
+
+watch(
+  menu,
+  (open) => {
+    if (open && openedByKeyboard) focusPopup();
+    openedByKeyboard = false;
+  },
+  { flush: "post" },
+);
 
 function openMenu() {
   if (!canUserOpenMenu.value) return;
@@ -749,6 +786,7 @@ function openMenu() {
 function closeMenu(refocus = true) {
   menu.value = false;
   isEditingInput.value = false;
+  openedByKeyboard = false;
   if (refocus) {
     // Refocusing would immediately reopen the menu when `openOn: focus`.
     ignoreNextFocus = props.openOn == "focus";

--- a/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/src/main.ts
+++ b/templates/Coalesce.Vue.Template/content/Coalesce.Starter.Vue.Web/src/main.ts
@@ -44,6 +44,9 @@ const vuetify = createVuetify({
     VField: inputDefaults,
     VInput: inputDefaults,
     VSwitch: { color: "primary" },
+    VDatePicker: {
+      controlVariant: "modal",
+    },
   },
   theme: {
     themes: {


### PR DESCRIPTION
Adds `menuProps` for passing props through to the popup's `v-menu` (matching `c-select`), an `openOn` prop that selects what opens the popup — the field, the icon, focus, picker-only, or nothing — and `v-model:menu` for driving it from outside the component. The Vue template now also defaults `VDatePicker` to `controlVariant: "modal"`.

`openOn: none` suppresses the component's own activation but keeps the popup mounted, so `v-model:menu` still works. Arrow keys open the popup in every other mode; focus stays on the text field rather than moving into the pickers, as it did before.